### PR TITLE
Refactor signer to work for Reader

### DIFF
--- a/aws/core.go
+++ b/aws/core.go
@@ -75,7 +75,7 @@ type Request struct {
 	Operation    *Operation
 	HTTPRequest  *http.Request
 	HTTPResponse *http.Response
-	Body         io.ReadSeeker
+	Body         io.Reader
 	Params       interface{}
 	Error        error
 	Data         interface{}
@@ -160,8 +160,12 @@ func (r *Request) SetBufferBody(buf []byte) {
 	r.SetReaderBody(bytes.NewReader(buf))
 }
 
-func (r *Request) SetReaderBody(reader io.ReadSeeker) {
-	r.HTTPRequest.Body = ioutil.NopCloser(reader)
+func (r *Request) SetReaderBody(reader io.Reader) {
+	if closer, ok := reader.(io.ReadCloser); ok {
+		r.HTTPRequest.Body = closer
+	} else {
+		r.HTTPRequest.Body = ioutil.NopCloser(reader)
+	}
 	r.Body = reader
 }
 

--- a/aws/protocol/rest/build.go
+++ b/aws/protocol/rest/build.go
@@ -42,7 +42,7 @@ func buildHeaders(r *aws.Request, v reflect.Value) {
 func buildBody(r *aws.Request, v reflect.Value) {
 	payload := v.FieldByName(r.Operation.InPayload)
 	if payload.IsValid() && payload.Type().Kind() == reflect.Interface {
-		reader := payload.Interface().(io.ReadSeeker)
+		reader := payload.Interface().(io.Reader)
 		r.SetReaderBody(reader)
 	}
 }

--- a/aws/signer/v4/v4.go
+++ b/aws/signer/v4/v4.go
@@ -1,11 +1,13 @@
 package v4
 
 import (
+	"bytes"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"sort"
@@ -39,7 +41,6 @@ type signer struct {
 	SecretAccessKey string
 	SessionToken    string
 	Query           url.Values
-	Body            io.ReadSeeker
 	Debug           uint
 
 	formattedTime      string
@@ -63,7 +64,6 @@ func Sign(req *aws.Request) {
 		Time:            req.Time,
 		ExpireTime:      300 * time.Second,
 		Query:           req.HTTPRequest.URL.Query(),
-		Body:            req.Body,
 		ServiceName:     req.Service.ServiceName,
 		Region:          req.Service.Config.Region,
 		AccessKeyID:     creds.AccessKeyID,
@@ -213,14 +213,14 @@ func (v4 *signer) buildSignature() {
 func (v4 *signer) bodyDigest() string {
 	hash := v4.Request.Header.Get("X-Amz-Content-Sha256")
 	if hash == "" {
-		if v4.Body == nil {
+		if v4.Request.Body == nil {
 			if v4.ServiceName == "s3" {
 				hash = "UNSIGNED-PAYLOAD"
 			} else {
 				hash = hex.EncodeToString(makeSha256([]byte{}))
 			}
 		} else {
-			hash = hex.EncodeToString(makeSha256Reader(v4.Body))
+			hash = hex.EncodeToString(makeSha256Reader(v4.Request))
 		}
 		v4.Request.Header.Add("X-Amz-Content-Sha256", hash)
 	}
@@ -239,21 +239,42 @@ func makeSha256(data []byte) []byte {
 	return hash.Sum(nil)
 }
 
-func makeSha256Reader(reader io.ReadSeeker) []byte {
-	packet := make([]byte, 4096)
+// makeSha256Reader reads the Body from an http.Request and constructs a sha256
+// hashsum of it.  If the body is seekable, such as one created from os.Open,
+// it will be memory efficient, otherwise it will read the body contents into
+// memory to reset the reader
+func makeSha256Reader(request *http.Request) []byte {
+	// Note, to be able to re-assign in the non-seeker case, we can't take a
+	// naked io.Reader. Taking a 'signable' interface with get/set body could
+	// make sense
+	reader := request.Body
 	hash := sha256.New()
 
-	reader.Seek(0, 0)
-	for {
-		n, err := reader.Read(packet)
-		if n > 0 {
-			hash.Write(packet[0:n])
-		}
-		if err == io.EOF || n == 0 {
-			break
+	writeHash := func(r io.Reader) {
+		packet := make([]byte, 4096)
+		for {
+			n, err := r.Read(packet)
+			if n > 0 {
+				hash.Write(packet[0:n])
+			}
+			if err == io.EOF || n == 0 {
+				break
+			}
 		}
 	}
-	reader.Seek(0, 0)
+
+	if seeker, ok := reader.(io.ReadSeeker); ok {
+		// If we have a seeker, use it
+		seeker.Seek(0, 0)
+		writeHash(seeker)
+		seeker.Seek(0, 0)
+	} else {
+		// If we don't have a seeker, read the body into memory to allow it to be re-read
+		var readerClone bytes.Buffer
+		tee := io.TeeReader(reader, &readerClone)
+		writeHash(tee)
+		request.Body = ioutil.NopCloser(&readerClone)
+	}
 
 	return hash.Sum(nil)
 }

--- a/aws/signer/v4/v4_test.go
+++ b/aws/signer/v4/v4_test.go
@@ -1,6 +1,10 @@
 package v4
 
 import (
+	"bytes"
+	"crypto/sha256"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
@@ -22,7 +26,6 @@ func buildSigner(serviceName string, region string, signTime time.Time, body str
 		Time:            signTime,
 		ExpireTime:      300 * time.Second,
 		Query:           req.URL.Query(),
-		Body:            reader,
 		ServiceName:     serviceName,
 		Region:          region,
 		AccessKeyID:     "AKID",
@@ -64,5 +67,62 @@ func BenchmarkSignRequest(b *testing.B) {
 	signer := buildSigner("dynamodb", "us-east-1", time.Now(), "{}")
 	for i := 0; i < b.N; i++ {
 		signer.sign()
+	}
+}
+
+type readSeekCloser struct {
+	*bytes.Reader
+}
+
+func (r readSeekCloser) Close() error {
+	return nil
+}
+
+func TestMakeShaReaderReadSeeker(t *testing.T) {
+	var seeker io.ReadSeeker
+	testData := []byte(`I am a read seeker`)
+	seeker = &readSeekCloser{bytes.NewReader(testData)}
+	mockRequest, _ := http.NewRequest("GET", "http://example.com", seeker)
+
+	checksum := makeSha256Reader(mockRequest)
+	expectedCheckum := sha256.Sum256(testData)
+
+	if !bytes.Equal(checksum, expectedCheckum[:]) {
+		t.Errorf("Checksum did not match expected; was %v instead of %v", checksum, sha256.Sum256(testData))
+	}
+
+	// Verify it was rewound
+	data, err := ioutil.ReadAll(mockRequest.Body)
+	if err != nil {
+		t.Errorf("Unable to read seeker: %v", err)
+	}
+	if !bytes.Equal(data, testData) {
+		t.Errorf("Re-reading reader got different result: %v != %v", string(data), string(testData))
+	}
+}
+
+func TestMakeShaReaderNotSeeker(t *testing.T) {
+	var reader io.Reader
+	testData := []byte(`I am not a read seeker`)
+	reader = bytes.NewBuffer(testData)
+	if _, ok := reader.(io.ReadSeeker); ok {
+		t.Fatal("We're trying to test something that's not a readseeker here. Fix the test or downgrade Go :)")
+	}
+	mockRequest, _ := http.NewRequest("GET", "http://example.com", reader)
+
+	checksum := makeSha256Reader(mockRequest)
+	expectedCheckum := sha256.Sum256(testData)
+
+	if !bytes.Equal(checksum, expectedCheckum[:]) {
+		t.Errorf("Checksum did not match expected; was %v instead of %v", checksum, sha256.Sum256(testData))
+	}
+
+	// Verify it was rewound
+	data, err := ioutil.ReadAll(mockRequest.Body)
+	if err != nil {
+		t.Errorf("Unable to read seeker: %v", err)
+	}
+	if !bytes.Equal(data, testData) {
+		t.Errorf("Re-reading reader got different result: %v != %v", string(data), string(testData))
 	}
 }


### PR DESCRIPTION
This was inspired by reading issue #81.

The following test program works after these changes (before it paniced):
```go
func main() {
	bucket := "MY_BUCKET"
	file, _ := os.Open("/tmp/large_file")
	fi, _ := file.Stat()
	length := fi.Size()
	largeKey := "/test/golang/large_file"
	largeFile := s3.PutObjectInput{
		Bucket:        &bucket,
		Key:           &largeKey,
		Body:          file,
		ContentLength: &length,
	}

	simpleKey := "/test/golang/simple_key"
	simpleLen := int64(len([]byte("Simple test")))
	simpleUpload := s3.PutObjectInput{
		Bucket:        &bucket,
		Key:           &simpleKey,
		Body:          ioutil.NopCloser(bytes.NewReader([]byte("Simple test"))),
		ContentLength: &simpleLen,
	}

	client := s3.New(&s3.S3Config{aws.DefaultConfig})

	_, err := client.PutObject(&simpleUpload)
	if err != nil {
		log.Fatal(err)
	}

	_, err = client.PutObject(&largeFile)
	if err != nil {
		log.Fatal(err)
	}
}
```

I manually verified that the case of using a the file from os.Open it does go through the Seek codepath (also, it was a 1.5G file and my ram usage did not noticeably increase).

Note: running `go test ./...` passed, but `make` gives me an error both before and after this change (missing package: protocol/ec2).