### PR TITLE
fix: ListDistributions would always return the zero ListDistributionsRes...

### DIFF
--- a/gen/cloudfront/cloudfront.go
+++ b/gen/cloudfront/cloudfront.go
@@ -831,8 +831,8 @@ func (c *CloudFront) ListCloudFrontOriginAccessIdentities(req *ListCloudFrontOri
 }
 
 // ListDistributions is undocumented.
-func (c *CloudFront) ListDistributions(req *ListDistributionsRequest) (resp *ListDistributionsResult, err error) {
-	resp = &ListDistributionsResult{}
+func (c *CloudFront) ListDistributions(req *ListDistributionsRequest) (resp *DistributionList, err error) {
+	resp = &DistributionList{}
 
 	var body io.Reader
 	var contentType string
@@ -1915,17 +1915,6 @@ type ListDistributionsRequest struct {
 }
 
 func (v *ListDistributionsRequest) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
-	return aws.MarshalXML(v, e, start)
-}
-
-// ListDistributionsResult is undocumented.
-type ListDistributionsResult struct {
-	XMLName xml.Name
-
-	DistributionList *DistributionList `xml:"DistributionList,omitempty"`
-}
-
-func (v *ListDistributionsResult) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	return aws.MarshalXML(v, e, start)
 }
 


### PR DESCRIPTION
...ponse

The API is actually returning a DistributionList.  Changing the signature of
ListDistributions fixes this.  I'm not sure this is The Right Way to fix this,
but it's an improvement over it not working at all.