### PR TITLE
Properly print enum name in comments

### DIFF
--- a/gen/autoscaling/autoscaling.go
+++ b/gen/autoscaling/autoscaling.go
@@ -960,7 +960,7 @@ type LifecycleHook struct {
 	RoleARN               aws.StringValue  `query:"RoleARN" xml:"RoleARN"`
 }
 
-// Possible values for AutoScaling.
+// Possible values for LifecycleState.
 const (
 	LifecycleStateDetached           = "Detached"
 	LifecycleStateDetaching          = "Detaching"
@@ -1072,7 +1072,7 @@ type RecordLifecycleActionHeartbeatType struct {
 	LifecycleHookName    aws.StringValue `query:"LifecycleHookName" xml:"LifecycleHookName"`
 }
 
-// Possible values for AutoScaling.
+// Possible values for ScalingActivityStatusCode.
 const (
 	ScalingActivityStatusCodeCancelled                       = "Cancelled"
 	ScalingActivityStatusCodeFailed                          = "Failed"

--- a/gen/cloudformation/cloudformation.go
+++ b/gen/cloudformation/cloudformation.go
@@ -230,7 +230,7 @@ type CancelUpdateStackInput struct {
 	StackName aws.StringValue `query:"StackName" xml:"StackName"`
 }
 
-// Possible values for CloudFormation.
+// Possible values for Capability.
 const (
 	CapabilityCapabilityIAM = "CAPABILITY_IAM"
 )
@@ -380,7 +380,7 @@ type ListStacksOutput struct {
 	StackSummaries []StackSummary  `query:"StackSummaries.member" xml:"ListStacksResult>StackSummaries>member"`
 }
 
-// Possible values for CloudFormation.
+// Possible values for OnFailure.
 const (
 	OnFailureDelete    = "DELETE"
 	OnFailureDoNothing = "DO_NOTHING"
@@ -410,13 +410,13 @@ type ParameterDeclaration struct {
 	ParameterType aws.StringValue  `query:"ParameterType" xml:"ParameterType"`
 }
 
-// Possible values for CloudFormation.
+// Possible values for ResourceSignalStatus.
 const (
 	ResourceSignalStatusFailure = "FAILURE"
 	ResourceSignalStatusSuccess = "SUCCESS"
 )
 
-// Possible values for CloudFormation.
+// Possible values for ResourceStatus.
 const (
 	ResourceStatusCreateComplete   = "CREATE_COMPLETE"
 	ResourceStatusCreateFailed     = "CREATE_FAILED"
@@ -514,7 +514,7 @@ type StackResourceSummary struct {
 	ResourceType         aws.StringValue `query:"ResourceType" xml:"ResourceType"`
 }
 
-// Possible values for CloudFormation.
+// Possible values for StackStatus.
 const (
 	StackStatusCreateComplete                          = "CREATE_COMPLETE"
 	StackStatusCreateFailed                            = "CREATE_FAILED"

--- a/gen/cloudfront/cloudfront.go
+++ b/gen/cloudfront/cloudfront.go
@@ -1629,7 +1629,7 @@ func (v *GeoRestriction) MarshalXML(e *xml.Encoder, start xml.StartElement) erro
 	return aws.MarshalXML(v, e, start)
 }
 
-// Possible values for CloudFront.
+// Possible values for GeoRestrictionType.
 const (
 	GeoRestrictionTypeBlacklist = "blacklist"
 	GeoRestrictionTypeNone      = "none"
@@ -1864,7 +1864,7 @@ func (v *InvalidationSummary) MarshalXML(e *xml.Encoder, start xml.StartElement)
 	return aws.MarshalXML(v, e, start)
 }
 
-// Possible values for CloudFront.
+// Possible values for ItemSelection.
 const (
 	ItemSelectionAll       = "all"
 	ItemSelectionNone      = "none"
@@ -1990,7 +1990,7 @@ func (v *LoggingConfig) MarshalXML(e *xml.Encoder, start xml.StartElement) error
 	return aws.MarshalXML(v, e, start)
 }
 
-// Possible values for CloudFront.
+// Possible values for Method.
 const (
 	MethodDelete  = "DELETE"
 	MethodGet     = "GET"
@@ -2001,7 +2001,7 @@ const (
 	MethodPut     = "PUT"
 )
 
-// Possible values for CloudFront.
+// Possible values for MinimumProtocolVersion.
 const (
 	MinimumProtocolVersionSSLv3 = "SSLv3"
 	MinimumProtocolVersionTLSv1 = "TLSv1"
@@ -2021,7 +2021,7 @@ func (v *Origin) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	return aws.MarshalXML(v, e, start)
 }
 
-// Possible values for CloudFront.
+// Possible values for OriginProtocolPolicy.
 const (
 	OriginProtocolPolicyHTTPOnly    = "http-only"
 	OriginProtocolPolicyMatchViewer = "match-viewer"
@@ -2051,7 +2051,7 @@ func (v *Paths) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	return aws.MarshalXML(v, e, start)
 }
 
-// Possible values for CloudFront.
+// Possible values for PriceClass.
 const (
 	PriceClassPriceClass100 = "PriceClass_100"
 	PriceClassPriceClass200 = "PriceClass_200"
@@ -2092,7 +2092,7 @@ func (v *S3OriginConfig) MarshalXML(e *xml.Encoder, start xml.StartElement) erro
 	return aws.MarshalXML(v, e, start)
 }
 
-// Possible values for CloudFront.
+// Possible values for SSLSupportMethod.
 const (
 	SSLSupportMethodSNIOnly = "sni-only"
 	SSLSupportMethodVIP     = "vip"
@@ -2295,7 +2295,7 @@ func (v *ViewerCertificate) MarshalXML(e *xml.Encoder, start xml.StartElement) e
 	return aws.MarshalXML(v, e, start)
 }
 
-// Possible values for CloudFront.
+// Possible values for ViewerProtocolPolicy.
 const (
 	ViewerProtocolPolicyAllowAll        = "allow-all"
 	ViewerProtocolPolicyHTTPSOnly       = "https-only"

--- a/gen/cloudhsm/cloudhsm.go
+++ b/gen/cloudhsm/cloudhsm.go
@@ -180,13 +180,13 @@ func (c *CloudHSM) ModifyLunaClient(req *ModifyLunaClientRequest) (resp *ModifyL
 	return
 }
 
-// Possible values for CloudHSM.
+// Possible values for ClientVersion.
 const (
 	ClientVersion51 = "5.1"
 	ClientVersion53 = "5.3"
 )
 
-// Possible values for CloudHSM.
+// Possible values for CloudHsmObjectState.
 const (
 	CloudHSMObjectStateDegraded = "DEGRADED"
 	CloudHSMObjectStateReady    = "READY"
@@ -339,7 +339,7 @@ type GetConfigResponse struct {
 	ConfigType aws.StringValue `json:"ConfigType,omitempty"`
 }
 
-// Possible values for CloudHSM.
+// Possible values for HsmStatus.
 const (
 	HSMStatusDegraded    = "DEGRADED"
 	HSMStatusPending     = "PENDING"
@@ -430,7 +430,7 @@ type ModifyLunaClientResponse struct {
 	ClientARN aws.StringValue `json:"ClientArn,omitempty"`
 }
 
-// Possible values for CloudHSM.
+// Possible values for SubscriptionType.
 const (
 	SubscriptionTypeProduction = "PRODUCTION"
 )

--- a/gen/cloudsearch/cloudsearch.go
+++ b/gen/cloudsearch/cloudsearch.go
@@ -306,7 +306,7 @@ type AccessPoliciesStatus struct {
 	Status  *OptionStatus   `query:"Status" xml:"Status"`
 }
 
-// Possible values for CloudSearch.
+// Possible values for AlgorithmicStemming.
 const (
 	AlgorithmicStemmingFull    = "full"
 	AlgorithmicStemmingLight   = "light"
@@ -330,7 +330,7 @@ type AnalysisScheme struct {
 	AnalysisSchemeName     aws.StringValue  `query:"AnalysisSchemeName" xml:"AnalysisSchemeName"`
 }
 
-// Possible values for CloudSearch.
+// Possible values for AnalysisSchemeLanguage.
 const (
 	AnalysisSchemeLanguageAr     = "ar"
 	AnalysisSchemeLanguageBg     = "bg"
@@ -720,7 +720,7 @@ type IndexFieldStatus struct {
 	Status  *OptionStatus `query:"Status" xml:"Status"`
 }
 
-// Possible values for CloudSearch.
+// Possible values for IndexFieldType.
 const (
 	IndexFieldTypeDate         = "date"
 	IndexFieldTypeDateArray    = "date-array"
@@ -794,7 +794,7 @@ type LiteralOptions struct {
 	SourceField   aws.StringValue  `query:"SourceField" xml:"SourceField"`
 }
 
-// Possible values for CloudSearch.
+// Possible values for OptionState.
 const (
 	OptionStateActive                 = "Active"
 	OptionStateFailedToValidate       = "FailedToValidate"
@@ -811,7 +811,7 @@ type OptionStatus struct {
 	UpdateVersion   aws.IntegerValue `query:"UpdateVersion" xml:"UpdateVersion"`
 }
 
-// Possible values for CloudSearch.
+// Possible values for PartitionInstanceType.
 const (
 	PartitionInstanceTypeSearchM1Large   = "search.m1.large"
 	PartitionInstanceTypeSearchM1Small   = "search.m1.small"
@@ -843,7 +843,7 @@ type Suggester struct {
 	SuggesterName            aws.StringValue           `query:"SuggesterName" xml:"SuggesterName"`
 }
 
-// Possible values for CloudSearch.
+// Possible values for SuggesterFuzzyMatching.
 const (
 	SuggesterFuzzyMatchingHigh = "high"
 	SuggesterFuzzyMatchingLow  = "low"

--- a/gen/cloudsearchdomain/cloudsearchdomain.go
+++ b/gen/cloudsearchdomain/cloudsearchdomain.go
@@ -300,7 +300,7 @@ type BucketInfo struct {
 	Buckets []Bucket `json:"buckets,omitempty"`
 }
 
-// Possible values for CloudSearchDomain.
+// Possible values for ContentType.
 const (
 	ContentTypeApplicationJSON = "application/json"
 	ContentTypeApplicationXML  = "application/xml"
@@ -326,7 +326,7 @@ type Hits struct {
 	Start  aws.LongValue   `json:"start,omitempty"`
 }
 
-// Possible values for CloudSearchDomain.
+// Possible values for QueryParser.
 const (
 	QueryParserDismax     = "dismax"
 	QueryParserLucene     = "lucene"

--- a/gen/cloudwatch/cloudwatch.go
+++ b/gen/cloudwatch/cloudwatch.go
@@ -183,7 +183,7 @@ type AlarmHistoryItem struct {
 	Timestamp       time.Time       `query:"Timestamp" xml:"Timestamp"`
 }
 
-// Possible values for CloudWatch.
+// Possible values for ComparisonOperator.
 const (
 	ComparisonOperatorGreaterThanOrEqualToThreshold = "GreaterThanOrEqualToThreshold"
 	ComparisonOperatorGreaterThanThreshold          = "GreaterThanThreshold"
@@ -294,7 +294,7 @@ type GetMetricStatisticsOutput struct {
 	Label      aws.StringValue `query:"Label" xml:"GetMetricStatisticsResult>Label"`
 }
 
-// Possible values for CloudWatch.
+// Possible values for HistoryItemType.
 const (
 	HistoryItemTypeAction              = "Action"
 	HistoryItemTypeConfigurationUpdate = "ConfigurationUpdate"
@@ -390,7 +390,7 @@ type SetAlarmStateInput struct {
 	StateValue      aws.StringValue `query:"StateValue" xml:"StateValue"`
 }
 
-// Possible values for CloudWatch.
+// Possible values for StandardUnit.
 const (
 	StandardUnitBits            = "Bits"
 	StandardUnitBitsSecond      = "Bits/Second"
@@ -421,14 +421,14 @@ const (
 	StandardUnitTerabytesSecond = "Terabytes/Second"
 )
 
-// Possible values for CloudWatch.
+// Possible values for StateValue.
 const (
 	StateValueAlarm            = "ALARM"
 	StateValueInsufficientData = "INSUFFICIENT_DATA"
 	StateValueOK               = "OK"
 )
 
-// Possible values for CloudWatch.
+// Possible values for Statistic.
 const (
 	StatisticAverage     = "Average"
 	StatisticMaximum     = "Maximum"

--- a/gen/codedeploy/codedeploy.go
+++ b/gen/codedeploy/codedeploy.go
@@ -234,7 +234,7 @@ type ApplicationInfo struct {
 	LinkedToGitHub  aws.BooleanValue   `json:"linkedToGitHub,omitempty"`
 }
 
-// Possible values for CodeDeploy.
+// Possible values for ApplicationRevisionSortBy.
 const (
 	ApplicationRevisionSortByFirstUsedTime = "firstUsedTime"
 	ApplicationRevisionSortByLastUsedTime  = "lastUsedTime"
@@ -267,7 +267,7 @@ type BatchGetDeploymentsOutput struct {
 	DeploymentsInfo []DeploymentInfo `json:"deploymentsInfo,omitempty"`
 }
 
-// Possible values for CodeDeploy.
+// Possible values for BundleType.
 const (
 	BundleTypeTAR = "tar"
 	BundleTypeTGZ = "tgz"
@@ -354,7 +354,7 @@ type DeploymentConfigInfo struct {
 	MinimumHealthyHosts  *MinimumHealthyHosts `json:"minimumHealthyHosts,omitempty"`
 }
 
-// Possible values for CodeDeploy.
+// Possible values for DeploymentCreator.
 const (
 	DeploymentCreatorAutoscaling = "autoscaling"
 	DeploymentCreatorUser        = "user"
@@ -399,7 +399,7 @@ type DeploymentOverview struct {
 	Succeeded  aws.LongValue `json:"Succeeded,omitempty"`
 }
 
-// Possible values for CodeDeploy.
+// Possible values for DeploymentStatus.
 const (
 	DeploymentStatusCreated    = "Created"
 	DeploymentStatusFailed     = "Failed"
@@ -424,14 +424,14 @@ type EC2TagFilter struct {
 	Value aws.StringValue `json:"Value,omitempty"`
 }
 
-// Possible values for CodeDeploy.
+// Possible values for EC2TagFilterType.
 const (
 	EC2TagFilterTypeKeyAndValue = "KEY_AND_VALUE"
 	EC2TagFilterTypeKeyOnly     = "KEY_ONLY"
 	EC2TagFilterTypeValueOnly   = "VALUE_ONLY"
 )
 
-// Possible values for CodeDeploy.
+// Possible values for ErrorCode.
 const (
 	ErrorCodeApplicationMissing       = "APPLICATION_MISSING"
 	ErrorCodeDeploymentGroupMissing   = "DEPLOYMENT_GROUP_MISSING"
@@ -532,7 +532,7 @@ type GitHubLocation struct {
 	Repository aws.StringValue `json:"repository,omitempty"`
 }
 
-// Possible values for CodeDeploy.
+// Possible values for InstanceStatus.
 const (
 	InstanceStatusFailed     = "Failed"
 	InstanceStatusInProgress = "InProgress"
@@ -551,7 +551,7 @@ type InstanceSummary struct {
 	Status          aws.StringValue    `json:"status,omitempty"`
 }
 
-// Possible values for CodeDeploy.
+// Possible values for LifecycleErrorCode.
 const (
 	LifecycleErrorCodeScriptFailed        = "ScriptFailed"
 	LifecycleErrorCodeScriptMissing       = "ScriptMissing"
@@ -570,7 +570,7 @@ type LifecycleEvent struct {
 	Status             aws.StringValue    `json:"status,omitempty"`
 }
 
-// Possible values for CodeDeploy.
+// Possible values for LifecycleEventStatus.
 const (
 	LifecycleEventStatusFailed     = "Failed"
 	LifecycleEventStatusInProgress = "InProgress"
@@ -660,7 +660,7 @@ type ListDeploymentsOutput struct {
 	NextToken   aws.StringValue `json:"nextToken,omitempty"`
 }
 
-// Possible values for CodeDeploy.
+// Possible values for ListStateFilterAction.
 const (
 	ListStateFilterActionExclude = "exclude"
 	ListStateFilterActionIgnore  = "ignore"
@@ -673,7 +673,7 @@ type MinimumHealthyHosts struct {
 	Value aws.IntegerValue `json:"value,omitempty"`
 }
 
-// Possible values for CodeDeploy.
+// Possible values for MinimumHealthyHostsType.
 const (
 	MinimumHealthyHostsTypeFleetPercent = "FLEET_PERCENT"
 	MinimumHealthyHostsTypeHostCount    = "HOST_COUNT"
@@ -693,7 +693,7 @@ type RevisionLocation struct {
 	S3Location     *S3Location     `json:"s3Location,omitempty"`
 }
 
-// Possible values for CodeDeploy.
+// Possible values for RevisionLocationType.
 const (
 	RevisionLocationTypeGitHub = "GitHub"
 	RevisionLocationTypeS3     = "S3"
@@ -708,7 +708,7 @@ type S3Location struct {
 	Version    aws.StringValue `json:"version,omitempty"`
 }
 
-// Possible values for CodeDeploy.
+// Possible values for SortOrder.
 const (
 	SortOrderAscending  = "ascending"
 	SortOrderDescending = "descending"
@@ -725,7 +725,7 @@ type StopDeploymentOutput struct {
 	StatusMessage aws.StringValue `json:"statusMessage,omitempty"`
 }
 
-// Possible values for CodeDeploy.
+// Possible values for StopStatus.
 const (
 	StopStatusPending   = "Pending"
 	StopStatusSucceeded = "Succeeded"

--- a/gen/cognito/sync/sync.go
+++ b/gen/cognito/sync/sync.go
@@ -901,13 +901,13 @@ type ListRecordsResponse struct {
 	SyncSessionToken                      aws.StringValue  `json:"SyncSessionToken,omitempty"`
 }
 
-// Possible values for CognitoSync.
+// Possible values for Operation.
 const (
 	OperationRemove  = "remove"
 	OperationReplace = "replace"
 )
 
-// Possible values for CognitoSync.
+// Possible values for Platform.
 const (
 	PlatformADM         = "ADM"
 	PlatformAPNS        = "APNS"

--- a/gen/config/config.go
+++ b/gen/config/config.go
@@ -154,7 +154,7 @@ func (c *Config) StopConfigurationRecorder(req *StopConfigurationRecorderRequest
 	return
 }
 
-// Possible values for Config.
+// Possible values for ChronologicalOrder.
 const (
 	ChronologicalOrderForward = "Forward"
 	ChronologicalOrderReverse = "Reverse"
@@ -196,7 +196,7 @@ type ConfigurationItem struct {
 	Version                      aws.StringValue    `json:"version,omitempty"`
 }
 
-// Possible values for Config.
+// Possible values for ConfigurationItemStatus.
 const (
 	ConfigurationItemStatusDeleted    = "Deleted"
 	ConfigurationItemStatusDiscovered = "Discovered"
@@ -253,7 +253,7 @@ type DeliveryChannelStatus struct {
 	Name                       aws.StringValue           `json:"name,omitempty"`
 }
 
-// Possible values for Config.
+// Possible values for DeliveryStatus.
 const (
 	DeliveryStatusFailure = "Failure"
 	DeliveryStatusSuccess = "Success"
@@ -326,7 +326,7 @@ type PutDeliveryChannelRequest struct {
 	DeliveryChannel *DeliveryChannel `json:"DeliveryChannel"`
 }
 
-// Possible values for Config.
+// Possible values for RecorderStatus.
 const (
 	RecorderStatusFailure = "Failure"
 	RecorderStatusPending = "Pending"
@@ -340,7 +340,7 @@ type Relationship struct {
 	ResourceType     aws.StringValue `json:"resourceType,omitempty"`
 }
 
-// Possible values for Config.
+// Possible values for ResourceType.
 const (
 	ResourceTypeAWSCloudTrailTrail     = "AWS::CloudTrail::Trail"
 	ResourceTypeAWSEC2CustomerGateway  = "AWS::EC2::CustomerGateway"

--- a/gen/datapipeline/datapipeline.go
+++ b/gen/datapipeline/datapipeline.go
@@ -343,7 +343,7 @@ type Operator struct {
 	Values []string        `json:"values,omitempty"`
 }
 
-// Possible values for DataPipeline.
+// Possible values for OperatorType.
 const (
 	OperatorTypeBetween = "BETWEEN"
 	OperatorTypeEq      = "EQ"
@@ -496,7 +496,7 @@ type TaskObject struct {
 	TaskID     aws.StringValue           `json:"taskId,omitempty"`
 }
 
-// Possible values for DataPipeline.
+// Possible values for TaskStatus.
 const (
 	TaskStatusFailed   = "FAILED"
 	TaskStatusFalse    = "FALSE"

--- a/gen/directconnect/directconnect.go
+++ b/gen/directconnect/directconnect.go
@@ -317,7 +317,7 @@ type Connection struct {
 	VLAN            aws.IntegerValue `json:"vlan,omitempty"`
 }
 
-// Possible values for DirectConnect.
+// Possible values for ConnectionState.
 const (
 	ConnectionStateAvailable = "available"
 	ConnectionStateDeleted   = "deleted"
@@ -416,7 +416,7 @@ type Interconnect struct {
 	Region            aws.StringValue `json:"region,omitempty"`
 }
 
-// Possible values for DirectConnect.
+// Possible values for InterconnectState.
 const (
 	InterconnectStateAvailable = "available"
 	InterconnectStateDeleted   = "deleted"
@@ -520,7 +520,7 @@ type VirtualInterface struct {
 	VLAN                  aws.IntegerValue    `json:"vlan,omitempty"`
 }
 
-// Possible values for DirectConnect.
+// Possible values for VirtualInterfaceState.
 const (
 	VirtualInterfaceStateAvailable  = "available"
 	VirtualInterfaceStateConfirming = "confirming"

--- a/gen/dynamodb/dynamodb.go
+++ b/gen/dynamodb/dynamodb.go
@@ -317,7 +317,7 @@ func (c *DynamoDB) UpdateTable(req *UpdateTableInput) (resp *UpdateTableOutput, 
 	return
 }
 
-// Possible values for DynamoDB.
+// Possible values for AttributeAction.
 const (
 	AttributeActionAdd    = "ADD"
 	AttributeActionDelete = "DELETE"
@@ -382,7 +382,7 @@ type Capacity struct {
 	CapacityUnits aws.DoubleValue `json:"CapacityUnits,omitempty"`
 }
 
-// Possible values for DynamoDB.
+// Possible values for ComparisonOperator.
 const (
 	ComparisonOperatorBeginsWith  = "BEGINS_WITH"
 	ComparisonOperatorBetween     = "BETWEEN"
@@ -405,7 +405,7 @@ type Condition struct {
 	ComparisonOperator aws.StringValue  `json:"ComparisonOperator"`
 }
 
-// Possible values for DynamoDB.
+// Possible values for ConditionalOperator.
 const (
 	ConditionalOperatorAnd = "AND"
 	ConditionalOperatorOr  = "OR"
@@ -530,7 +530,7 @@ type GlobalSecondaryIndexUpdate struct {
 	Update *UpdateGlobalSecondaryIndexAction `json:"Update,omitempty"`
 }
 
-// Possible values for DynamoDB.
+// Possible values for IndexStatus.
 const (
 	IndexStatusActive   = "ACTIVE"
 	IndexStatusCreating = "CREATING"
@@ -550,7 +550,7 @@ type KeySchemaElement struct {
 	KeyType       aws.StringValue `json:"KeyType"`
 }
 
-// Possible values for DynamoDB.
+// Possible values for KeyType.
 const (
 	KeyTypeHash  = "HASH"
 	KeyTypeRange = "RANGE"
@@ -599,7 +599,7 @@ type Projection struct {
 	ProjectionType   aws.StringValue `json:"ProjectionType,omitempty"`
 }
 
-// Possible values for DynamoDB.
+// Possible values for ProjectionType.
 const (
 	ProjectionTypeAll      = "ALL"
 	ProjectionTypeInclude  = "INCLUDE"
@@ -676,20 +676,20 @@ type QueryOutput struct {
 	ScannedCount     aws.IntegerValue            `json:"ScannedCount,omitempty"`
 }
 
-// Possible values for DynamoDB.
+// Possible values for ReturnConsumedCapacity.
 const (
 	ReturnConsumedCapacityIndexes = "INDEXES"
 	ReturnConsumedCapacityNone    = "NONE"
 	ReturnConsumedCapacityTotal   = "TOTAL"
 )
 
-// Possible values for DynamoDB.
+// Possible values for ReturnItemCollectionMetrics.
 const (
 	ReturnItemCollectionMetricsNone = "NONE"
 	ReturnItemCollectionMetricsSize = "SIZE"
 )
 
-// Possible values for DynamoDB.
+// Possible values for ReturnValue.
 const (
 	ReturnValueAllNew     = "ALL_NEW"
 	ReturnValueAllOld     = "ALL_OLD"
@@ -698,7 +698,7 @@ const (
 	ReturnValueUpdatedOld = "UPDATED_OLD"
 )
 
-// Possible values for DynamoDB.
+// Possible values for ScalarAttributeType.
 const (
 	ScalarAttributeTypeB = "B"
 	ScalarAttributeTypeN = "N"
@@ -732,7 +732,7 @@ type ScanOutput struct {
 	ScannedCount     aws.IntegerValue            `json:"ScannedCount,omitempty"`
 }
 
-// Possible values for DynamoDB.
+// Possible values for Select.
 const (
 	SelectAllAttributes          = "ALL_ATTRIBUTES"
 	SelectAllProjectedAttributes = "ALL_PROJECTED_ATTRIBUTES"
@@ -754,7 +754,7 @@ type TableDescription struct {
 	TableStatus            aws.StringValue                   `json:"TableStatus,omitempty"`
 }
 
-// Possible values for DynamoDB.
+// Possible values for TableStatus.
 const (
 	TableStatusActive   = "ACTIVE"
 	TableStatusCreating = "CREATING"

--- a/gen/ec2/ec2.go
+++ b/gen/ec2/ec2.go
@@ -2161,7 +2161,7 @@ type AccountAttribute struct {
 	AttributeValues []AccountAttributeValue `ec2:"AttributeValues" xml:"attributeValueSet>item"`
 }
 
-// Possible values for EC2.
+// Possible values for AccountAttributeName.
 const (
 	AccountAttributeNameDefaultVPC         = "default-vpc"
 	AccountAttributeNameSupportedPlatforms = "supported-platforms"
@@ -2197,7 +2197,7 @@ type AllocateAddressResult struct {
 	PublicIP     aws.StringValue `ec2:"PublicIp" xml:"publicIp"`
 }
 
-// Possible values for EC2.
+// Possible values for ArchitectureValues.
 const (
 	ArchitectureValuesI386  = "i386"
 	ArchitectureValuesX8664 = "x86_64"
@@ -2299,7 +2299,7 @@ type AttachVPNGatewayResult struct {
 	VPCAttachment *VPCAttachment `ec2:"VpcAttachment" xml:"attachment"`
 }
 
-// Possible values for EC2.
+// Possible values for AttachmentStatus.
 const (
 	AttachmentStatusAttached  = "attached"
 	AttachmentStatusAttaching = "attaching"
@@ -2357,7 +2357,7 @@ type AvailabilityZoneMessage struct {
 	Message aws.StringValue `ec2:"Message" xml:"message"`
 }
 
-// Possible values for EC2.
+// Possible values for AvailabilityZoneState.
 const (
 	AvailabilityZoneStateAvailable = "available"
 )
@@ -2405,7 +2405,7 @@ type BundleTaskError struct {
 	Message aws.StringValue `ec2:"Message" xml:"message"`
 }
 
-// Possible values for EC2.
+// Possible values for BundleTaskState.
 const (
 	BundleTaskStateBundling           = "bundling"
 	BundleTaskStateCancelling         = "cancelling"
@@ -2449,7 +2449,7 @@ type CancelReservedInstancesListingResult struct {
 	ReservedInstancesListings []ReservedInstancesListing `ec2:"ReservedInstancesListings" xml:"reservedInstancesListingsSet>item"`
 }
 
-// Possible values for EC2.
+// Possible values for CancelSpotInstanceRequestState.
 const (
 	CancelSpotInstanceRequestStateActive    = "active"
 	CancelSpotInstanceRequestStateCancelled = "cancelled"
@@ -2495,7 +2495,7 @@ type ConfirmProductInstanceResult struct {
 	OwnerID aws.StringValue `ec2:"OwnerId" xml:"ownerId"`
 }
 
-// Possible values for EC2.
+// Possible values for ContainerFormat.
 const (
 	ContainerFormatOva = "ova"
 )
@@ -2511,7 +2511,7 @@ type ConversionTask struct {
 	Tags             []Tag                      `ec2:"Tags" xml:"tagSet>item"`
 }
 
-// Possible values for EC2.
+// Possible values for ConversionTaskState.
 const (
 	ConversionTaskStateActive     = "active"
 	ConversionTaskStateCancelled  = "cancelled"
@@ -2832,7 +2832,7 @@ type CreateVPNGatewayResult struct {
 	VPNGateway *VPNGateway `ec2:"VpnGateway" xml:"vpnGateway"`
 }
 
-// Possible values for EC2.
+// Possible values for CurrencyCodeValues.
 const (
 	CurrencyCodeValuesUsd = "USD"
 )
@@ -2847,7 +2847,7 @@ type CustomerGateway struct {
 	Type              aws.StringValue `ec2:"Type" xml:"type"`
 }
 
-// Possible values for EC2.
+// Possible values for DatafeedSubscriptionState.
 const (
 	DatafeedSubscriptionStateActive   = "Active"
 	DatafeedSubscriptionStateInactive = "Inactive"
@@ -3592,7 +3592,7 @@ type DetachVPNGatewayRequest struct {
 	VPNGatewayID aws.StringValue  `ec2:"VpnGatewayId" xml:"VpnGatewayId"`
 }
 
-// Possible values for EC2.
+// Possible values for DeviceType.
 const (
 	DeviceTypeEBS           = "ebs"
 	DeviceTypeInstanceStore = "instance-store"
@@ -3663,7 +3663,7 @@ type DiskImageDetail struct {
 	ImportManifestURL aws.StringValue `ec2:"ImportManifestUrl" xml:"importManifestUrl"`
 }
 
-// Possible values for EC2.
+// Possible values for DiskImageFormat.
 const (
 	DiskImageFormatRaw  = "RAW"
 	DiskImageFormatVHD  = "VHD"
@@ -3676,7 +3676,7 @@ type DiskImageVolumeDescription struct {
 	Size aws.LongValue   `ec2:"Size" xml:"size"`
 }
 
-// Possible values for EC2.
+// Possible values for DomainType.
 const (
 	DomainTypeStandard = "standard"
 	DomainTypeVPC      = "vpc"
@@ -3729,7 +3729,7 @@ type EnableVPCClassicLinkResult struct {
 	Return aws.BooleanValue `ec2:"Return" xml:"return"`
 }
 
-// Possible values for EC2.
+// Possible values for EventCode.
 const (
 	EventCodeInstanceReboot     = "instance-reboot"
 	EventCodeInstanceRetirement = "instance-retirement"
@@ -3738,7 +3738,7 @@ const (
 	EventCodeSystemReboot       = "system-reboot"
 )
 
-// Possible values for EC2.
+// Possible values for ExportEnvironment.
 const (
 	ExportEnvironmentCitrix    = "citrix"
 	ExportEnvironmentMicrosoft = "microsoft"
@@ -3755,7 +3755,7 @@ type ExportTask struct {
 	StatusMessage         aws.StringValue        `ec2:"StatusMessage" xml:"statusMessage"`
 }
 
-// Possible values for EC2.
+// Possible values for ExportTaskState.
 const (
 	ExportTaskStateActive     = "active"
 	ExportTaskStateCancelled  = "cancelled"
@@ -3785,7 +3785,7 @@ type Filter struct {
 	Values []string        `ec2:"Value" xml:"Value>item"`
 }
 
-// Possible values for EC2.
+// Possible values for GatewayType.
 const (
 	GatewayTypeIPsec1 = "ipsec.1"
 )
@@ -3822,7 +3822,7 @@ type GroupIdentifier struct {
 	GroupName aws.StringValue `ec2:"GroupName" xml:"groupName"`
 }
 
-// Possible values for EC2.
+// Possible values for HypervisorType.
 const (
 	HypervisorTypeOvm = "ovm"
 	HypervisorTypeXen = "xen"
@@ -3885,7 +3885,7 @@ type ImageAttribute struct {
 	SRIOVNetSupport     *AttributeValue      `ec2:"SriovNetSupport" xml:"sriovNetSupport"`
 }
 
-// Possible values for EC2.
+// Possible values for ImageAttributeName.
 const (
 	ImageAttributeNameBlockDeviceMapping = "blockDeviceMapping"
 	ImageAttributeNameDescription        = "description"
@@ -3895,13 +3895,13 @@ const (
 	ImageAttributeNameRAMDisk            = "ramdisk"
 )
 
-// Possible values for EC2.
+// Possible values for ImageState.
 const (
 	ImageStateAvailable    = "available"
 	ImageStateDeregistered = "deregistered"
 )
 
-// Possible values for EC2.
+// Possible values for ImageTypeValues.
 const (
 	ImageTypeValuesKernel  = "kernel"
 	ImageTypeValuesMachine = "machine"
@@ -4051,7 +4051,7 @@ type InstanceAttribute struct {
 	UserData                          *AttributeValue              `ec2:"UserData" xml:"userData"`
 }
 
-// Possible values for EC2.
+// Possible values for InstanceAttributeName.
 const (
 	InstanceAttributeNameBlockDeviceMapping                = "blockDeviceMapping"
 	InstanceAttributeNameDisableAPITermination             = "disableApiTermination"
@@ -4094,7 +4094,7 @@ type InstanceExportDetails struct {
 	TargetEnvironment aws.StringValue `ec2:"TargetEnvironment" xml:"targetEnvironment"`
 }
 
-// Possible values for EC2.
+// Possible values for InstanceLifecycleType.
 const (
 	InstanceLifecycleTypeSpot = "spot"
 )
@@ -4174,7 +4174,7 @@ type InstanceStateChange struct {
 	PreviousState *InstanceState  `ec2:"PreviousState" xml:"previousState"`
 }
 
-// Possible values for EC2.
+// Possible values for InstanceStateName.
 const (
 	InstanceStateNamePending      = "pending"
 	InstanceStateNameRunning      = "running"
@@ -4215,7 +4215,7 @@ type InstanceStatusSummary struct {
 	Status  aws.StringValue         `ec2:"Status" xml:"status"`
 }
 
-// Possible values for EC2.
+// Possible values for InstanceType.
 const (
 	InstanceTypeC1Medium   = "c1.medium"
 	InstanceTypeC1Xlarge   = "c1.xlarge"
@@ -4333,7 +4333,7 @@ type LaunchSpecification struct {
 	UserData            aws.StringValue                         `ec2:"UserData" xml:"userData"`
 }
 
-// Possible values for EC2.
+// Possible values for ListingState.
 const (
 	ListingStateAvailable = "available"
 	ListingStateCancelled = "cancelled"
@@ -4341,7 +4341,7 @@ const (
 	ListingStateSold      = "sold"
 )
 
-// Possible values for EC2.
+// Possible values for ListingStatus.
 const (
 	ListingStatusActive    = "active"
 	ListingStatusCancelled = "cancelled"
@@ -4451,7 +4451,7 @@ type Monitoring struct {
 	State aws.StringValue `ec2:"State" xml:"state"`
 }
 
-// Possible values for EC2.
+// Possible values for MonitoringState.
 const (
 	MonitoringStateDisabled = "disabled"
 	MonitoringStateEnabled  = "enabled"
@@ -4534,7 +4534,7 @@ type NetworkInterfaceAttachmentChanges struct {
 	DeleteOnTermination aws.BooleanValue `ec2:"DeleteOnTermination" xml:"deleteOnTermination"`
 }
 
-// Possible values for EC2.
+// Possible values for NetworkInterfaceAttribute.
 const (
 	NetworkInterfaceAttributeAttachment      = "attachment"
 	NetworkInterfaceAttributeDescription     = "description"
@@ -4550,7 +4550,7 @@ type NetworkInterfacePrivateIPAddress struct {
 	PrivateIPAddress aws.StringValue              `ec2:"PrivateIpAddress" xml:"privateIpAddress"`
 }
 
-// Possible values for EC2.
+// Possible values for NetworkInterfaceStatus.
 const (
 	NetworkInterfaceStatusAttaching = "attaching"
 	NetworkInterfaceStatusAvailable = "available"
@@ -4564,14 +4564,14 @@ type NewDHCPConfiguration struct {
 	Values []string        `ec2:"Value" xml:"Value>item"`
 }
 
-// Possible values for EC2.
+// Possible values for OfferingTypeValues.
 const (
 	OfferingTypeValuesHeavyUtilization  = "Heavy Utilization"
 	OfferingTypeValuesLightUtilization  = "Light Utilization"
 	OfferingTypeValuesMediumUtilization = "Medium Utilization"
 )
 
-// Possible values for EC2.
+// Possible values for PermissionGroup.
 const (
 	PermissionGroupAll = "all"
 )
@@ -4590,7 +4590,7 @@ type PlacementGroup struct {
 	Strategy  aws.StringValue `ec2:"Strategy" xml:"strategy"`
 }
 
-// Possible values for EC2.
+// Possible values for PlacementGroupState.
 const (
 	PlacementGroupStateAvailable = "available"
 	PlacementGroupStateDeleted   = "deleted"
@@ -4598,12 +4598,12 @@ const (
 	PlacementGroupStatePending   = "pending"
 )
 
-// Possible values for EC2.
+// Possible values for PlacementStrategy.
 const (
 	PlacementStrategyCluster = "cluster"
 )
 
-// Possible values for EC2.
+// Possible values for PlatformValues.
 const (
 	PlatformValuesWindows = "Windows"
 )
@@ -4647,7 +4647,7 @@ type ProductCode struct {
 	ProductCodeType aws.StringValue `ec2:"ProductCodeType" xml:"type"`
 }
 
-// Possible values for EC2.
+// Possible values for ProductCodeValues.
 const (
 	ProductCodeValuesDevpay      = "devpay"
 	ProductCodeValuesMarketplace = "marketplace"
@@ -4671,7 +4671,7 @@ type PurchaseReservedInstancesOfferingResult struct {
 	ReservedInstancesID aws.StringValue `ec2:"ReservedInstancesId" xml:"reservedInstancesId"`
 }
 
-// Possible values for EC2.
+// Possible values for RIProductDescription.
 const (
 	RIProductDescriptionLinuxUnix          = "Linux/UNIX"
 	RIProductDescriptionLinuxUnixamazonVPC = "Linux/UNIX (Amazon VPC)"
@@ -4691,7 +4691,7 @@ type RecurringCharge struct {
 	Frequency aws.StringValue `ec2:"Frequency" xml:"frequency"`
 }
 
-// Possible values for EC2.
+// Possible values for RecurringChargeFrequency.
 const (
 	RecurringChargeFrequencyHourly = "Hourly"
 )
@@ -4788,7 +4788,7 @@ type ReplaceRouteTableAssociationResult struct {
 	NewAssociationID aws.StringValue `ec2:"NewAssociationId" xml:"newAssociationId"`
 }
 
-// Possible values for EC2.
+// Possible values for ReportInstanceReasonCodes.
 const (
 	ReportInstanceReasonCodesInstanceStuckInState     = "instance-stuck-in-state"
 	ReportInstanceReasonCodesNotAcceptingCredentials  = "not-accepting-credentials"
@@ -4812,7 +4812,7 @@ type ReportInstanceStatusRequest struct {
 	Status      aws.StringValue  `ec2:"Status" xml:"status"`
 }
 
-// Possible values for EC2.
+// Possible values for ReportStatusType.
 const (
 	ReportStatusTypeImpaired = "impaired"
 	ReportStatusTypeOK       = "ok"
@@ -4871,7 +4871,7 @@ type ReservedInstanceLimitPrice struct {
 	CurrencyCode aws.StringValue `ec2:"CurrencyCode" xml:"currencyCode"`
 }
 
-// Possible values for EC2.
+// Possible values for ReservedInstanceState.
 const (
 	ReservedInstanceStateActive         = "active"
 	ReservedInstanceStatePaymentFailed  = "payment-failed"
@@ -4962,7 +4962,7 @@ type ReservedInstancesOffering struct {
 	UsagePrice                  aws.FloatValue    `ec2:"UsagePrice" xml:"usagePrice"`
 }
 
-// Possible values for EC2.
+// Possible values for ResetImageAttributeName.
 const (
 	ResetImageAttributeNameLaunchPermission = "launchPermission"
 )
@@ -4995,7 +4995,7 @@ type ResetSnapshotAttributeRequest struct {
 	SnapshotID aws.StringValue  `ec2:"SnapshotId" xml:"SnapshotId"`
 }
 
-// Possible values for EC2.
+// Possible values for ResourceType.
 const (
 	ResourceTypeCustomerGateway      = "customer-gateway"
 	ResourceTypeDHCPOptions          = "dhcp-options"
@@ -5055,14 +5055,14 @@ type Route struct {
 	VPCPeeringConnectionID aws.StringValue `ec2:"VpcPeeringConnectionId" xml:"vpcPeeringConnectionId"`
 }
 
-// Possible values for EC2.
+// Possible values for RouteOrigin.
 const (
 	RouteOriginCreateRoute               = "CreateRoute"
 	RouteOriginCreateRouteTable          = "CreateRouteTable"
 	RouteOriginEnableVGWRoutePropagation = "EnableVgwRoutePropagation"
 )
 
-// Possible values for EC2.
+// Possible values for RouteState.
 const (
 	RouteStateActive    = "active"
 	RouteStateBlackhole = "blackhole"
@@ -5086,7 +5086,7 @@ type RouteTableAssociation struct {
 	SubnetID                aws.StringValue  `ec2:"SubnetId" xml:"subnetId"`
 }
 
-// Possible values for EC2.
+// Possible values for RuleAction.
 const (
 	RuleActionAllow = "allow"
 	RuleActionDeny  = "deny"
@@ -5145,7 +5145,7 @@ type SecurityGroup struct {
 	VPCID               aws.StringValue `ec2:"VpcId" xml:"vpcId"`
 }
 
-// Possible values for EC2.
+// Possible values for ShutdownBehavior.
 const (
 	ShutdownBehaviorStop      = "stop"
 	ShutdownBehaviorTerminate = "terminate"
@@ -5167,13 +5167,13 @@ type Snapshot struct {
 	VolumeSize  aws.IntegerValue `ec2:"VolumeSize" xml:"volumeSize"`
 }
 
-// Possible values for EC2.
+// Possible values for SnapshotAttributeName.
 const (
 	SnapshotAttributeNameCreateVolumePermission = "createVolumePermission"
 	SnapshotAttributeNameProductCodes           = "productCodes"
 )
 
-// Possible values for EC2.
+// Possible values for SnapshotState.
 const (
 	SnapshotStateCompleted = "completed"
 	SnapshotStateError     = "error"
@@ -5209,7 +5209,7 @@ type SpotInstanceRequest struct {
 	ValidUntil               time.Time               `ec2:"ValidUntil" xml:"validUntil"`
 }
 
-// Possible values for EC2.
+// Possible values for SpotInstanceState.
 const (
 	SpotInstanceStateActive    = "active"
 	SpotInstanceStateCancelled = "cancelled"
@@ -5231,7 +5231,7 @@ type SpotInstanceStatus struct {
 	UpdateTime time.Time       `ec2:"UpdateTime" xml:"updateTime"`
 }
 
-// Possible values for EC2.
+// Possible values for SpotInstanceType.
 const (
 	SpotInstanceTypeOneTime    = "one-time"
 	SpotInstanceTypePersistent = "persistent"
@@ -5270,12 +5270,12 @@ type StateReason struct {
 	Message aws.StringValue `ec2:"Message" xml:"message"`
 }
 
-// Possible values for EC2.
+// Possible values for StatusName.
 const (
 	StatusNameReachability = "reachability"
 )
 
-// Possible values for EC2.
+// Possible values for StatusType.
 const (
 	StatusTypeFailed           = "failed"
 	StatusTypeInsufficientData = "insufficient-data"
@@ -5312,13 +5312,13 @@ type Subnet struct {
 	VPCID                   aws.StringValue  `ec2:"VpcId" xml:"vpcId"`
 }
 
-// Possible values for EC2.
+// Possible values for SubnetState.
 const (
 	SubnetStateAvailable = "available"
 	SubnetStatePending   = "pending"
 )
 
-// Possible values for EC2.
+// Possible values for SummaryStatus.
 const (
 	SummaryStatusImpaired         = "impaired"
 	SummaryStatusInsufficientData = "insufficient-data"
@@ -5340,13 +5340,13 @@ type TagDescription struct {
 	Value        aws.StringValue `ec2:"Value" xml:"value"`
 }
 
-// Possible values for EC2.
+// Possible values for TelemetryStatus.
 const (
 	TelemetryStatusDown = "DOWN"
 	TelemetryStatusUp   = "UP"
 )
 
-// Possible values for EC2.
+// Possible values for Tenancy.
 const (
 	TenancyDedicated = "dedicated"
 	TenancyDefault   = "default"
@@ -5401,7 +5401,7 @@ type VGWTelemetry struct {
 	StatusMessage      aws.StringValue  `ec2:"StatusMessage" xml:"statusMessage"`
 }
 
-// Possible values for EC2.
+// Possible values for VirtualizationType.
 const (
 	VirtualizationTypeHVM         = "hvm"
 	VirtualizationTypeParavirtual = "paravirtual"
@@ -5433,7 +5433,7 @@ type VolumeAttachment struct {
 	VolumeID            aws.StringValue  `ec2:"VolumeId" xml:"volumeId"`
 }
 
-// Possible values for EC2.
+// Possible values for VolumeAttachmentState.
 const (
 	VolumeAttachmentStateAttached  = "attached"
 	VolumeAttachmentStateAttaching = "attaching"
@@ -5441,7 +5441,7 @@ const (
 	VolumeAttachmentStateDetaching = "detaching"
 )
 
-// Possible values for EC2.
+// Possible values for VolumeAttributeName.
 const (
 	VolumeAttributeNameAutoEnableIo = "autoEnableIO"
 	VolumeAttributeNameProductCodes = "productCodes"
@@ -5452,7 +5452,7 @@ type VolumeDetail struct {
 	Size aws.LongValue `ec2:"Size" xml:"size"`
 }
 
-// Possible values for EC2.
+// Possible values for VolumeState.
 const (
 	VolumeStateAvailable = "available"
 	VolumeStateCreating  = "creating"
@@ -5491,7 +5491,7 @@ type VolumeStatusInfo struct {
 	Status  aws.StringValue       `ec2:"Status" xml:"status"`
 }
 
-// Possible values for EC2.
+// Possible values for VolumeStatusInfoStatus.
 const (
 	VolumeStatusInfoStatusImpaired         = "impaired"
 	VolumeStatusInfoStatusInsufficientData = "insufficient-data"
@@ -5507,13 +5507,13 @@ type VolumeStatusItem struct {
 	VolumeStatus     *VolumeStatusInfo    `ec2:"VolumeStatus" xml:"volumeStatus"`
 }
 
-// Possible values for EC2.
+// Possible values for VolumeStatusName.
 const (
 	VolumeStatusNameIoEnabled     = "io-enabled"
 	VolumeStatusNameIoPerformance = "io-performance"
 )
 
-// Possible values for EC2.
+// Possible values for VolumeType.
 const (
 	VolumeTypeGp2      = "gp2"
 	VolumeTypeIo1      = "io1"
@@ -5537,7 +5537,7 @@ type VPCAttachment struct {
 	VPCID aws.StringValue `ec2:"VpcId" xml:"vpcId"`
 }
 
-// Possible values for EC2.
+// Possible values for VpcAttributeName.
 const (
 	VPCAttributeNameEnableDNSHostnames = "enableDnsHostnames"
 	VPCAttributeNameEnableDNSSupport   = "enableDnsSupport"
@@ -5573,7 +5573,7 @@ type VPCPeeringConnectionVPCInfo struct {
 	VPCID     aws.StringValue `ec2:"VpcId" xml:"vpcId"`
 }
 
-// Possible values for EC2.
+// Possible values for VpcState.
 const (
 	VPCStateAvailable = "available"
 	VPCStatePending   = "pending"
@@ -5613,7 +5613,7 @@ type VPNGateway struct {
 	VPNGatewayID     aws.StringValue `ec2:"VpnGatewayId" xml:"vpnGatewayId"`
 }
 
-// Possible values for EC2.
+// Possible values for VpnState.
 const (
 	VPNStateAvailable = "available"
 	VPNStateDeleted   = "deleted"
@@ -5628,7 +5628,7 @@ type VPNStaticRoute struct {
 	State                aws.StringValue `ec2:"State" xml:"state"`
 }
 
-// Possible values for EC2.
+// Possible values for VpnStaticRouteSource.
 const (
 	VPNStaticRouteSourceStatic = "Static"
 )

--- a/gen/elasticache/elasticache.go
+++ b/gen/elasticache/elasticache.go
@@ -395,7 +395,7 @@ func (c *ElasticCache) RevokeCacheSecurityGroupIngress(req *RevokeCacheSecurityG
 	return
 }
 
-// Possible values for ElasticCache.
+// Possible values for AZMode.
 const (
 	AZModeCrossAz  = "cross-az"
 	AZModeSingleAz = "single-az"
@@ -413,7 +413,7 @@ type AuthorizeCacheSecurityGroupIngressResult struct {
 	CacheSecurityGroup *CacheSecurityGroup `query:"CacheSecurityGroup" xml:"AuthorizeCacheSecurityGroupIngressResult>CacheSecurityGroup"`
 }
 
-// Possible values for ElasticCache.
+// Possible values for AutomaticFailoverStatus.
 const (
 	AutomaticFailoverStatusDisabled  = "disabled"
 	AutomaticFailoverStatusDisabling = "disabling"
@@ -1000,7 +1000,7 @@ type ParameterNameValue struct {
 	ParameterValue aws.StringValue `query:"ParameterValue" xml:"ParameterValue"`
 }
 
-// Possible values for ElasticCache.
+// Possible values for PendingAutomaticFailoverStatus.
 const (
 	PendingAutomaticFailoverStatusDisabled = "disabled"
 	PendingAutomaticFailoverStatusEnabled  = "enabled"
@@ -1155,7 +1155,7 @@ type Snapshot struct {
 	VPCID                      aws.StringValue  `query:"VpcId" xml:"VpcId"`
 }
 
-// Possible values for ElasticCache.
+// Possible values for SourceType.
 const (
 	SourceTypeCacheCluster        = "cache-cluster"
 	SourceTypeCacheParameterGroup = "cache-parameter-group"

--- a/gen/elasticbeanstalk/elasticbeanstalk.go
+++ b/gen/elasticbeanstalk/elasticbeanstalk.go
@@ -356,7 +356,7 @@ type CheckDNSAvailabilityResultMessage struct {
 	FullyQualifiedCNAME aws.StringValue  `query:"FullyQualifiedCNAME" xml:"CheckDNSAvailabilityResult>FullyQualifiedCNAME"`
 }
 
-// Possible values for ElasticBeanstalk.
+// Possible values for ConfigurationDeploymentStatus.
 const (
 	ConfigurationDeploymentStatusDeployed = "deployed"
 	ConfigurationDeploymentStatusFailed   = "failed"
@@ -385,7 +385,7 @@ type ConfigurationOptionSetting struct {
 	Value      aws.StringValue `query:"Value" xml:"Value"`
 }
 
-// Possible values for ElasticBeanstalk.
+// Possible values for ConfigurationOptionValueType.
 const (
 	ConfigurationOptionValueTypeList   = "List"
 	ConfigurationOptionValueTypeScalar = "Scalar"
@@ -573,7 +573,7 @@ type EnvironmentDescriptionsMessage struct {
 	Environments []EnvironmentDescription `query:"Environments.member" xml:"DescribeEnvironmentsResult>Environments>member"`
 }
 
-// Possible values for ElasticBeanstalk.
+// Possible values for EnvironmentHealth.
 const (
 	EnvironmentHealthGreen  = "Green"
 	EnvironmentHealthGrey   = "Grey"
@@ -589,7 +589,7 @@ type EnvironmentInfoDescription struct {
 	SampleTimestamp time.Time       `query:"SampleTimestamp" xml:"SampleTimestamp"`
 }
 
-// Possible values for ElasticBeanstalk.
+// Possible values for EnvironmentInfoType.
 const (
 	EnvironmentInfoTypeTail = "tail"
 )
@@ -615,7 +615,7 @@ type EnvironmentResourcesDescription struct {
 	LoadBalancer *LoadBalancerDescription `query:"LoadBalancer" xml:"LoadBalancer"`
 }
 
-// Possible values for ElasticBeanstalk.
+// Possible values for EnvironmentStatus.
 const (
 	EnvironmentStatusLaunching   = "Launching"
 	EnvironmentStatusReady       = "Ready"
@@ -649,7 +649,7 @@ type EventDescriptionsMessage struct {
 	NextToken aws.StringValue    `query:"NextToken" xml:"DescribeEventsResult>NextToken"`
 }
 
-// Possible values for ElasticBeanstalk.
+// Possible values for EventSeverity.
 const (
 	EventSeverityDebug = "DEBUG"
 	EventSeverityError = "ERROR"
@@ -836,7 +836,7 @@ type ValidationMessage struct {
 	Severity   aws.StringValue `query:"Severity" xml:"Severity"`
 }
 
-// Possible values for ElasticBeanstalk.
+// Possible values for ValidationSeverity.
 const (
 	ValidationSeverityError   = "error"
 	ValidationSeverityWarning = "warning"

--- a/gen/emr/emr.go
+++ b/gen/emr/emr.go
@@ -254,7 +254,7 @@ func (c *EMR) TerminateJobFlows(req *TerminateJobFlowsInput) (err error) {
 	return
 }
 
-// Possible values for EMR.
+// Possible values for ActionOnFailure.
 const (
 	ActionOnFailureCancelAndWait    = "CANCEL_AND_WAIT"
 	ActionOnFailureContinue         = "CONTINUE"
@@ -333,7 +333,7 @@ type Cluster struct {
 	VisibleToAllUsers       aws.BooleanValue       `json:"VisibleToAllUsers,omitempty"`
 }
 
-// Possible values for EMR.
+// Possible values for ClusterState.
 const (
 	ClusterStateBootstrapping        = "BOOTSTRAPPING"
 	ClusterStateRunning              = "RUNNING"
@@ -350,7 +350,7 @@ type ClusterStateChangeReason struct {
 	Message aws.StringValue `json:"Message,omitempty"`
 }
 
-// Possible values for EMR.
+// Possible values for ClusterStateChangeReasonCode.
 const (
 	ClusterStateChangeReasonCodeAllStepsCompleted = "ALL_STEPS_COMPLETED"
 	ClusterStateChangeReasonCodeBootstrapFailure  = "BOOTSTRAP_FAILURE"
@@ -511,7 +511,7 @@ type InstanceGroupModifyConfig struct {
 	InstanceGroupID           aws.StringValue  `json:"InstanceGroupId"`
 }
 
-// Possible values for EMR.
+// Possible values for InstanceGroupState.
 const (
 	InstanceGroupStateArrested      = "ARRESTED"
 	InstanceGroupStateBootstrapping = "BOOTSTRAPPING"
@@ -531,7 +531,7 @@ type InstanceGroupStateChangeReason struct {
 	Message aws.StringValue `json:"Message,omitempty"`
 }
 
-// Possible values for EMR.
+// Possible values for InstanceGroupStateChangeReasonCode.
 const (
 	InstanceGroupStateChangeReasonCodeClusterTerminated = "CLUSTER_TERMINATED"
 	InstanceGroupStateChangeReasonCodeInstanceFailure   = "INSTANCE_FAILURE"
@@ -553,21 +553,21 @@ type InstanceGroupTimeline struct {
 	ReadyDateTime    *aws.UnixTimestamp `json:"ReadyDateTime,omitempty"`
 }
 
-// Possible values for EMR.
+// Possible values for InstanceGroupType.
 const (
 	InstanceGroupTypeCore   = "CORE"
 	InstanceGroupTypeMaster = "MASTER"
 	InstanceGroupTypeTask   = "TASK"
 )
 
-// Possible values for EMR.
+// Possible values for InstanceRoleType.
 const (
 	InstanceRoleTypeCore   = "CORE"
 	InstanceRoleTypeMaster = "MASTER"
 	InstanceRoleTypeTask   = "TASK"
 )
 
-// Possible values for EMR.
+// Possible values for InstanceState.
 const (
 	InstanceStateAwaitingFulfillment = "AWAITING_FULFILLMENT"
 	InstanceStateBootstrapping       = "BOOTSTRAPPING"
@@ -582,7 +582,7 @@ type InstanceStateChangeReason struct {
 	Message aws.StringValue `json:"Message,omitempty"`
 }
 
-// Possible values for EMR.
+// Possible values for InstanceStateChangeReasonCode.
 const (
 	InstanceStateChangeReasonCodeBootstrapFailure  = "BOOTSTRAP_FAILURE"
 	InstanceStateChangeReasonCodeClusterTerminated = "CLUSTER_TERMINATED"
@@ -621,7 +621,7 @@ type JobFlowDetail struct {
 	VisibleToAllUsers     aws.BooleanValue              `json:"VisibleToAllUsers,omitempty"`
 }
 
-// Possible values for EMR.
+// Possible values for JobFlowExecutionState.
 const (
 	JobFlowExecutionStateBootstrapping = "BOOTSTRAPPING"
 	JobFlowExecutionStateCompleted     = "COMPLETED"
@@ -750,7 +750,7 @@ type ListStepsOutput struct {
 	Steps  []StepSummary   `json:"Steps,omitempty"`
 }
 
-// Possible values for EMR.
+// Possible values for MarketType.
 const (
 	MarketTypeOnDemand = "ON_DEMAND"
 	MarketTypeSpot     = "SPOT"
@@ -838,7 +838,7 @@ type StepDetail struct {
 	StepConfig            *StepConfig                `json:"StepConfig"`
 }
 
-// Possible values for EMR.
+// Possible values for StepExecutionState.
 const (
 	StepExecutionStateCancelled   = "CANCELLED"
 	StepExecutionStateCompleted   = "COMPLETED"
@@ -858,7 +858,7 @@ type StepExecutionStatusDetail struct {
 	State                 aws.StringValue    `json:"State"`
 }
 
-// Possible values for EMR.
+// Possible values for StepState.
 const (
 	StepStateCancelled   = "CANCELLED"
 	StepStateCompleted   = "COMPLETED"
@@ -874,7 +874,7 @@ type StepStateChangeReason struct {
 	Message aws.StringValue `json:"Message,omitempty"`
 }
 
-// Possible values for EMR.
+// Possible values for StepStateChangeReasonCode.
 const (
 	StepStateChangeReasonCodeNone = "NONE"
 )

--- a/gen/glacier/glacier.go
+++ b/gen/glacier/glacier.go
@@ -1741,7 +1741,7 @@ type AbortMultipartUploadInput struct {
 	VaultName aws.StringValue `json:"-"`
 }
 
-// Possible values for Glacier.
+// Possible values for ActionCode.
 const (
 	ActionCodeArchiveRetrieval   = "ArchiveRetrieval"
 	ActionCodeInventoryRetrieval = "InventoryRetrieval"
@@ -2025,7 +2025,7 @@ type SetVaultNotificationsInput struct {
 	VaultNotificationConfig *VaultNotificationConfig `json:"vaultNotificationConfig,omitempty"`
 }
 
-// Possible values for Glacier.
+// Possible values for StatusCode.
 const (
 	StatusCodeFailed     = "Failed"
 	StatusCodeInProgress = "InProgress"

--- a/gen/iam/iam.go
+++ b/gen/iam/iam.go
@@ -1229,7 +1229,7 @@ type EnableMFADeviceRequest struct {
 	UserName            aws.StringValue `query:"UserName" xml:"UserName"`
 }
 
-// Possible values for IAM.
+// Possible values for EntityType.
 const (
 	EntityTypeGroup = "Group"
 	EntityTypeRole  = "Role"
@@ -1738,12 +1738,12 @@ type RemoveUserFromGroupRequest struct {
 	UserName  aws.StringValue `query:"UserName" xml:"UserName"`
 }
 
-// Possible values for IAM.
+// Possible values for ReportFormatType.
 const (
 	ReportFormatTypeTextCSV = "text/csv"
 )
 
-// Possible values for IAM.
+// Possible values for ReportStateType.
 const (
 	ReportStateTypeComplete   = "COMPLETE"
 	ReportStateTypeInprogress = "INPROGRESS"
@@ -1946,20 +1946,20 @@ type VirtualMFADevice struct {
 	User             *User           `query:"User" xml:"User"`
 }
 
-// Possible values for IAM.
+// Possible values for assignmentStatusType.
 const (
 	AssignmentStatusTypeAny        = "Any"
 	AssignmentStatusTypeAssigned   = "Assigned"
 	AssignmentStatusTypeUnassigned = "Unassigned"
 )
 
-// Possible values for IAM.
+// Possible values for statusType.
 const (
 	StatusTypeActive   = "Active"
 	StatusTypeInactive = "Inactive"
 )
 
-// Possible values for IAM.
+// Possible values for summaryKeyType.
 const (
 	SummaryKeyTypeAccessKeysPerUserQuota          = "AccessKeysPerUserQuota"
 	SummaryKeyTypeAccountMFAenabled               = "AccountMFAEnabled"

--- a/gen/importexport/importexport.go
+++ b/gen/importexport/importexport.go
@@ -157,7 +157,7 @@ type Job struct {
 	JobType      aws.StringValue  `query:"JobType" xml:"JobType"`
 }
 
-// Possible values for ImportExport.
+// Possible values for JobType.
 const (
 	JobTypeExport = "Export"
 	JobTypeImport = "Import"

--- a/gen/kinesis/kinesis.go
+++ b/gen/kinesis/kinesis.go
@@ -564,7 +564,7 @@ type Shard struct {
 	ShardID               aws.StringValue      `json:"ShardId"`
 }
 
-// Possible values for Kinesis.
+// Possible values for ShardIteratorType.
 const (
 	ShardIteratorTypeAfterSequenceNumber = "AFTER_SEQUENCE_NUMBER"
 	ShardIteratorTypeAtSequenceNumber    = "AT_SEQUENCE_NUMBER"
@@ -588,7 +588,7 @@ type StreamDescription struct {
 	StreamStatus  aws.StringValue  `json:"StreamStatus"`
 }
 
-// Possible values for Kinesis.
+// Possible values for StreamStatus.
 const (
 	StreamStatusActive   = "ACTIVE"
 	StreamStatusCreating = "CREATING"

--- a/gen/kms/kms.go
+++ b/gen/kms/kms.go
@@ -285,7 +285,7 @@ type CreateKeyResponse struct {
 	KeyMetadata *KeyMetadata `json:"KeyMetadata,omitempty"`
 }
 
-// Possible values for KMS.
+// Possible values for DataKeySpec.
 const (
 	DataKeySpecAES128 = "AES_128"
 	DataKeySpecAES256 = "AES_256"
@@ -431,7 +431,7 @@ type GrantListEntry struct {
 	RetiringPrincipal aws.StringValue   `json:"RetiringPrincipal,omitempty"`
 }
 
-// Possible values for KMS.
+// Possible values for GrantOperation.
 const (
 	GrantOperationCreateGrant                     = "CreateGrant"
 	GrantOperationDecrypt                         = "Decrypt"
@@ -460,7 +460,7 @@ type KeyMetadata struct {
 	KeyUsage     aws.StringValue    `json:"KeyUsage,omitempty"`
 }
 
-// Possible values for KMS.
+// Possible values for KeyUsageType.
 const (
 	KeyUsageTypeEncryptDecrypt = "ENCRYPT_DECRYPT"
 )

--- a/gen/lambda/lambda.go
+++ b/gen/lambda/lambda.go
@@ -749,7 +749,7 @@ type ListFunctionsResponse struct {
 	NextMarker aws.StringValue         `json:"NextMarker,omitempty"`
 }
 
-// Possible values for Lambda.
+// Possible values for Mode.
 const (
 	ModeEvent = "event"
 )
@@ -759,7 +759,7 @@ type RemoveEventSourceRequest struct {
 	UUID aws.StringValue `json:"-"`
 }
 
-// Possible values for Lambda.
+// Possible values for Runtime.
 const (
 	RuntimeNodejs = "nodejs"
 )

--- a/gen/opsworks/opsworks.go
+++ b/gen/opsworks/opsworks.go
@@ -809,14 +809,14 @@ type App struct {
 	Type             aws.StringValue       `json:"Type,omitempty"`
 }
 
-// Possible values for OpsWorks.
+// Possible values for AppAttributesKeys.
 const (
 	AppAttributesKeysAutoBundleOnDeploy = "AutoBundleOnDeploy"
 	AppAttributesKeysDocumentRoot       = "DocumentRoot"
 	AppAttributesKeysRailsEnv           = "RailsEnv"
 )
 
-// Possible values for OpsWorks.
+// Possible values for AppType.
 const (
 	AppTypeJava   = "java"
 	AppTypeNodejs = "nodejs"
@@ -826,7 +826,7 @@ const (
 	AppTypeStatic = "static"
 )
 
-// Possible values for OpsWorks.
+// Possible values for Architecture.
 const (
 	ArchitectureI386  = "i386"
 	ArchitectureX8664 = "x86_64"
@@ -866,7 +866,7 @@ type AutoScalingThresholds struct {
 	ThresholdsWaitTime aws.IntegerValue `json:"ThresholdsWaitTime,omitempty"`
 }
 
-// Possible values for OpsWorks.
+// Possible values for AutoScalingType.
 const (
 	AutoScalingTypeLoad  = "load"
 	AutoScalingTypeTimer = "timer"
@@ -1103,7 +1103,7 @@ type DeploymentCommand struct {
 	Name aws.StringValue     `json:"Name"`
 }
 
-// Possible values for OpsWorks.
+// Possible values for DeploymentCommandName.
 const (
 	DeploymentCommandNameDeploy                = "deploy"
 	DeploymentCommandNameExecuteRecipes        = "execute_recipes"
@@ -1484,7 +1484,7 @@ type Layer struct {
 	VolumeConfigurations        []VolumeConfiguration        `json:"VolumeConfigurations,omitempty"`
 }
 
-// Possible values for OpsWorks.
+// Possible values for LayerAttributesKeys.
 const (
 	LayerAttributesKeysBundlerVersion              = "BundlerVersion"
 	LayerAttributesKeysEnableHaproxyStats          = "EnableHaproxyStats"
@@ -1512,7 +1512,7 @@ const (
 	LayerAttributesKeysRubygemsVersion             = "RubygemsVersion"
 )
 
-// Possible values for OpsWorks.
+// Possible values for LayerType.
 const (
 	LayerTypeCustom           = "custom"
 	LayerTypeDBMaster         = "db-master"
@@ -1645,7 +1645,7 @@ type ReportedOS struct {
 	Version aws.StringValue `json:"Version,omitempty"`
 }
 
-// Possible values for OpsWorks.
+// Possible values for RootDeviceType.
 const (
 	RootDeviceTypeEBS           = "ebs"
 	RootDeviceTypeInstanceStore = "instance-store"
@@ -1708,7 +1708,7 @@ type Source struct {
 	Username aws.StringValue `json:"Username,omitempty"`
 }
 
-// Possible values for OpsWorks.
+// Possible values for SourceType.
 const (
 	SourceTypeArchive = "archive"
 	SourceTypeGit     = "git"
@@ -1748,7 +1748,7 @@ type Stack struct {
 	VPCID                     aws.StringValue            `json:"VpcId,omitempty"`
 }
 
-// Possible values for OpsWorks.
+// Possible values for StackAttributesKeys.
 const (
 	StackAttributesKeysColor = "Color"
 )
@@ -1917,7 +1917,7 @@ type UserProfile struct {
 	SSHUsername         aws.StringValue  `json:"SshUsername,omitempty"`
 }
 
-// Possible values for OpsWorks.
+// Possible values for VirtualizationType.
 const (
 	VirtualizationTypeHVM         = "hvm"
 	VirtualizationTypeParavirtual = "paravirtual"

--- a/gen/rds/rds.go
+++ b/gen/rds/rds.go
@@ -634,7 +634,7 @@ type AddTagsToResourceMessage struct {
 	Tags         []Tag           `query:"Tags.member" xml:"Tags>Tag"`
 }
 
-// Possible values for RDS.
+// Possible values for ApplyMethod.
 const (
 	ApplyMethodImmediate     = "immediate"
 	ApplyMethodPendingReboot = "pending-reboot"
@@ -1782,7 +1782,7 @@ type RevokeDBSecurityGroupIngressResult struct {
 	DBSecurityGroup *DBSecurityGroup `query:"DBSecurityGroup" xml:"RevokeDBSecurityGroupIngressResult>DBSecurityGroup"`
 }
 
-// Possible values for RDS.
+// Possible values for SourceType.
 const (
 	SourceTypeDBInstance       = "db-instance"
 	SourceTypeDBParameterGroup = "db-parameter-group"

--- a/gen/redshift/redshift.go
+++ b/gen/redshift/redshift.go
@@ -1764,7 +1764,7 @@ type SnapshotMessage struct {
 	Snapshots []Snapshot      `query:"Snapshots.member" xml:"DescribeClusterSnapshotsResult>Snapshots>Snapshot"`
 }
 
-// Possible values for RedShift.
+// Possible values for SourceType.
 const (
 	SourceTypeCluster               = "cluster"
 	SourceTypeClusterParameterGroup = "cluster-parameter-group"

--- a/gen/route53/route53.go
+++ b/gen/route53/route53.go
@@ -1650,7 +1650,7 @@ func (v *Change) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	return aws.MarshalXML(v, e, start)
 }
 
-// Possible values for Route53.
+// Possible values for ChangeAction.
 const (
 	ChangeActionCreate = "CREATE"
 	ChangeActionDelete = "DELETE"
@@ -1706,7 +1706,7 @@ func (v *ChangeResourceRecordSetsResponse) MarshalXML(e *xml.Encoder, start xml.
 	return aws.MarshalXML(v, e, start)
 }
 
-// Possible values for Route53.
+// Possible values for ChangeStatus.
 const (
 	ChangeStatusInsync  = "INSYNC"
 	ChangeStatusPending = "PENDING"
@@ -2183,7 +2183,7 @@ func (v *HealthCheckObservation) MarshalXML(e *xml.Encoder, start xml.StartEleme
 	return aws.MarshalXML(v, e, start)
 }
 
-// Possible values for Route53.
+// Possible values for HealthCheckType.
 const (
 	HealthCheckTypeHTTP          = "HTTP"
 	HealthCheckTypeHTTPS         = "HTTPS"
@@ -2408,7 +2408,7 @@ func (v *ListTagsForResourcesResponse) MarshalXML(e *xml.Encoder, start xml.Star
 	return aws.MarshalXML(v, e, start)
 }
 
-// Possible values for Route53.
+// Possible values for RRType.
 const (
 	RRTypeA     = "A"
 	RRTypeAaaa  = "AAAA"
@@ -2454,13 +2454,13 @@ func (v *ResourceRecordSet) MarshalXML(e *xml.Encoder, start xml.StartElement) e
 	return aws.MarshalXML(v, e, start)
 }
 
-// Possible values for Route53.
+// Possible values for ResourceRecordSetFailover.
 const (
 	ResourceRecordSetFailoverPrimary   = "PRIMARY"
 	ResourceRecordSetFailoverSecondary = "SECONDARY"
 )
 
-// Possible values for Route53.
+// Possible values for ResourceRecordSetRegion.
 const (
 	ResourceRecordSetRegionApNortheast1 = "ap-northeast-1"
 	ResourceRecordSetRegionApSoutheast1 = "ap-southeast-1"
@@ -2511,7 +2511,7 @@ func (v *Tag) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	return aws.MarshalXML(v, e, start)
 }
 
-// Possible values for Route53.
+// Possible values for TagResourceType.
 const (
 	TagResourceTypeHealthcheck = "healthcheck"
 	TagResourceTypeHostedzone  = "hostedzone"
@@ -2581,7 +2581,7 @@ func (v *VPC) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	return aws.MarshalXML(v, e, start)
 }
 
-// Possible values for Route53.
+// Possible values for VPCRegion.
 const (
 	VPCRegionApNortheast1 = "ap-northeast-1"
 	VPCRegionApSoutheast1 = "ap-southeast-1"

--- a/gen/route53domains/route53domains.go
+++ b/gen/route53domains/route53domains.go
@@ -255,7 +255,7 @@ type ContactDetail struct {
 	ZipCode          aws.StringValue `json:"ZipCode,omitempty"`
 }
 
-// Possible values for Route53Domains.
+// Possible values for ContactType.
 const (
 	ContactTypeAssociation = "ASSOCIATION"
 	ContactTypeCompany     = "COMPANY"
@@ -264,7 +264,7 @@ const (
 	ContactTypeReseller    = "RESELLER"
 )
 
-// Possible values for Route53Domains.
+// Possible values for CountryCode.
 const (
 	CountryCodeAd = "AD"
 	CountryCodeAe = "AE"
@@ -516,7 +516,7 @@ type DisableDomainTransferLockResponse struct {
 	OperationID aws.StringValue `json:"OperationId"`
 }
 
-// Possible values for Route53Domains.
+// Possible values for DomainAvailability.
 const (
 	DomainAvailabilityAvailable             = "AVAILABLE"
 	DomainAvailabilityAvailablePreorder     = "AVAILABLE_PREORDER"
@@ -560,7 +560,7 @@ type ExtraParam struct {
 	Value aws.StringValue `json:"Value"`
 }
 
-// Possible values for Route53Domains.
+// Possible values for ExtraParamName.
 const (
 	ExtraParamNameAuIDNumber          = "AU_ID_NUMBER"
 	ExtraParamNameAuIDType            = "AU_ID_TYPE"
@@ -656,7 +656,7 @@ type Nameserver struct {
 	Name    aws.StringValue `json:"Name"`
 }
 
-// Possible values for Route53Domains.
+// Possible values for OperationStatus.
 const (
 	OperationStatusError      = "ERROR"
 	OperationStatusFailed     = "FAILED"
@@ -673,7 +673,7 @@ type OperationSummary struct {
 	Type          aws.StringValue    `json:"Type"`
 }
 
-// Possible values for Route53Domains.
+// Possible values for OperationType.
 const (
 	OperationTypeChangePrivacyProtection = "CHANGE_PRIVACY_PROTECTION"
 	OperationTypeDeleteDomain            = "DELETE_DOMAIN"

--- a/gen/s3/s3.go
+++ b/gen/s3/s3.go
@@ -3641,7 +3641,7 @@ func (v *Bucket) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	return aws.MarshalXML(v, e, start)
 }
 
-// Possible values for S3.
+// Possible values for BucketCannedACL.
 const (
 	BucketCannedACLAuthenticatedRead = "authenticated-read"
 	BucketCannedACLPrivate           = "private"
@@ -3649,7 +3649,7 @@ const (
 	BucketCannedACLPublicReadWrite   = "public-read-write"
 )
 
-// Possible values for S3.
+// Possible values for BucketLocationConstraint.
 const (
 	BucketLocationConstraintApNortheast1 = "ap-northeast-1"
 	BucketLocationConstraintApSoutheast1 = "ap-southeast-1"
@@ -3674,14 +3674,14 @@ func (v *BucketLoggingStatus) MarshalXML(e *xml.Encoder, start xml.StartElement)
 	return aws.MarshalXML(v, e, start)
 }
 
-// Possible values for S3.
+// Possible values for BucketLogsPermission.
 const (
 	BucketLogsPermissionFullControl = "FULL_CONTROL"
 	BucketLogsPermissionRead        = "READ"
 	BucketLogsPermissionWrite       = "WRITE"
 )
 
-// Possible values for S3.
+// Possible values for BucketVersioningStatus.
 const (
 	BucketVersioningStatusEnabled   = "Enabled"
 	BucketVersioningStatusSuspended = "Suspended"
@@ -4133,7 +4133,7 @@ func (v *DeletedObject) MarshalXML(e *xml.Encoder, start xml.StartElement) error
 	return aws.MarshalXML(v, e, start)
 }
 
-// Possible values for S3.
+// Possible values for EncodingType.
 const (
 	EncodingTypeURL = "url"
 )
@@ -4163,7 +4163,7 @@ func (v *ErrorDocument) MarshalXML(e *xml.Encoder, start xml.StartElement) error
 	return aws.MarshalXML(v, e, start)
 }
 
-// Possible values for S3.
+// Possible values for Event.
 const (
 	EventS3ObjectCreatedCompleteMultipartUpload = "s3:ObjectCreated:CompleteMultipartUpload"
 	EventS3ObjectCreatedCopy                    = "s3:ObjectCreated:Copy"
@@ -4172,7 +4172,7 @@ const (
 	EventS3ReducedRedundancyLostObject          = "s3:ReducedRedundancyLostObject"
 )
 
-// Possible values for S3.
+// Possible values for ExpirationStatus.
 const (
 	ExpirationStatusDisabled = "Disabled"
 	ExpirationStatusEnabled  = "Enabled"
@@ -4846,19 +4846,19 @@ func (v *LoggingEnabled) MarshalXML(e *xml.Encoder, start xml.StartElement) erro
 	return aws.MarshalXML(v, e, start)
 }
 
-// Possible values for S3.
+// Possible values for MFADelete.
 const (
 	MFADeleteDisabled = "Disabled"
 	MFADeleteEnabled  = "Enabled"
 )
 
-// Possible values for S3.
+// Possible values for MFADeleteStatus.
 const (
 	MFADeleteStatusDisabled = "Disabled"
 	MFADeleteStatusEnabled  = "Enabled"
 )
 
-// Possible values for S3.
+// Possible values for MetadataDirective.
 const (
 	MetadataDirectiveCopy    = "COPY"
 	MetadataDirectiveReplace = "REPLACE"
@@ -4932,7 +4932,7 @@ func (v *Object) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	return aws.MarshalXML(v, e, start)
 }
 
-// Possible values for S3.
+// Possible values for ObjectCannedACL.
 const (
 	ObjectCannedACLAuthenticatedRead      = "authenticated-read"
 	ObjectCannedACLBucketOwnerFullControl = "bucket-owner-full-control"
@@ -4954,7 +4954,7 @@ func (v *ObjectIdentifier) MarshalXML(e *xml.Encoder, start xml.StartElement) er
 	return aws.MarshalXML(v, e, start)
 }
 
-// Possible values for S3.
+// Possible values for ObjectStorageClass.
 const (
 	ObjectStorageClassGlacier           = "GLACIER"
 	ObjectStorageClassReducedRedundancy = "REDUCED_REDUNDANCY"
@@ -4979,7 +4979,7 @@ func (v *ObjectVersion) MarshalXML(e *xml.Encoder, start xml.StartElement) error
 	return aws.MarshalXML(v, e, start)
 }
 
-// Possible values for S3.
+// Possible values for ObjectVersionStorageClass.
 const (
 	ObjectVersionStorageClassStandard = "STANDARD"
 )
@@ -5010,13 +5010,13 @@ func (v *Part) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	return aws.MarshalXML(v, e, start)
 }
 
-// Possible values for S3.
+// Possible values for Payer.
 const (
 	PayerBucketOwner = "BucketOwner"
 	PayerRequester   = "Requester"
 )
 
-// Possible values for S3.
+// Possible values for Permission.
 const (
 	PermissionFullControl = "FULL_CONTROL"
 	PermissionRead        = "READ"
@@ -5025,7 +5025,7 @@ const (
 	PermissionWriteAcp    = "WRITE_ACP"
 )
 
-// Possible values for S3.
+// Possible values for Protocol.
 const (
 	ProtocolHTTP  = "http"
 	ProtocolHTTPS = "https"
@@ -5345,12 +5345,12 @@ func (v *Rule) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	return aws.MarshalXML(v, e, start)
 }
 
-// Possible values for S3.
+// Possible values for ServerSideEncryption.
 const (
 	ServerSideEncryptionAES256 = "AES256"
 )
 
-// Possible values for S3.
+// Possible values for StorageClass.
 const (
 	StorageClassReducedRedundancy = "REDUCED_REDUNDANCY"
 	StorageClassStandard          = "STANDARD"
@@ -5418,12 +5418,12 @@ func (v *Transition) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	return aws.MarshalXML(v, e, start)
 }
 
-// Possible values for S3.
+// Possible values for TransitionStorageClass.
 const (
 	TransitionStorageClassGlacier = "GLACIER"
 )
 
-// Possible values for S3.
+// Possible values for Type.
 const (
 	TypeAmazonCustomerByEmail = "AmazonCustomerByEmail"
 	TypeCanonicalUser         = "CanonicalUser"

--- a/gen/ses/ses.go
+++ b/gen/ses/ses.go
@@ -390,7 +390,7 @@ type IdentityNotificationAttributes struct {
 	ForwardingEnabled aws.BooleanValue `query:"ForwardingEnabled" xml:"ForwardingEnabled"`
 }
 
-// Possible values for SES.
+// Possible values for IdentityType.
 const (
 	IdentityTypeDomain       = "Domain"
 	IdentityTypeEmailAddress = "EmailAddress"
@@ -450,7 +450,7 @@ func (m *NotificationAttributes) UnmarshalXML(d *xml.Decoder, start xml.StartEle
 	return nil
 }
 
-// Possible values for SES.
+// Possible values for NotificationType.
 const (
 	NotificationTypeBounce    = "Bounce"
 	NotificationTypeComplaint = "Complaint"
@@ -552,7 +552,7 @@ func (m *VerificationAttributes) UnmarshalXML(d *xml.Decoder, start xml.StartEle
 	return nil
 }
 
-// Possible values for SES.
+// Possible values for VerificationStatus.
 const (
 	VerificationStatusFailed           = "Failed"
 	VerificationStatusNotStarted       = "NotStarted"

--- a/gen/sqs/sqs.go
+++ b/gen/sqs/sqs.go
@@ -578,7 +578,7 @@ type PurgeQueueRequest struct {
 	QueueURL aws.StringValue `query:"QueueUrl" xml:"QueueUrl"`
 }
 
-// Possible values for SQS.
+// Possible values for QueueAttributeName.
 const (
 	QueueAttributeNameApproximateNumberOfMessages           = "ApproximateNumberOfMessages"
 	QueueAttributeNameApproximateNumberOfMessagesDelayed    = "ApproximateNumberOfMessagesDelayed"

--- a/gen/storagegateway/storagegateway.go
+++ b/gen/storagegateway/storagegateway.go
@@ -1117,7 +1117,7 @@ type Disk struct {
 	DiskStatus             aws.StringValue `json:"DiskStatus,omitempty"`
 }
 
-// Possible values for StorageGateway.
+// Possible values for ErrorCode.
 const (
 	ErrorCodeActivationKeyExpired              = "ActivationKeyExpired"
 	ErrorCodeActivationKeyInvalid              = "ActivationKeyInvalid"

--- a/gen/swf/swf.go
+++ b/gen/swf/swf.go
@@ -841,7 +841,7 @@ type ActivityTaskTimedOutEventAttributes struct {
 	TimeoutType      aws.StringValue `json:"timeoutType"`
 }
 
-// Possible values for SWF.
+// Possible values for ActivityTaskTimeoutType.
 const (
 	ActivityTaskTimeoutTypeHeartbeat       = "HEARTBEAT"
 	ActivityTaskTimeoutTypeScheduleToClose = "SCHEDULE_TO_CLOSE"
@@ -891,7 +891,7 @@ type CancelTimerDecisionAttributes struct {
 	TimerID aws.StringValue `json:"timerId"`
 }
 
-// Possible values for SWF.
+// Possible values for CancelTimerFailedCause.
 const (
 	CancelTimerFailedCauseOperationNotPermitted = "OPERATION_NOT_PERMITTED"
 	CancelTimerFailedCauseTimerIDUnknown        = "TIMER_ID_UNKNOWN"
@@ -909,7 +909,7 @@ type CancelWorkflowExecutionDecisionAttributes struct {
 	Details aws.StringValue `json:"details,omitempty"`
 }
 
-// Possible values for SWF.
+// Possible values for CancelWorkflowExecutionFailedCause.
 const (
 	CancelWorkflowExecutionFailedCauseOperationNotPermitted = "OPERATION_NOT_PERMITTED"
 	CancelWorkflowExecutionFailedCauseUnhandledDecision     = "UNHANDLED_DECISION"
@@ -921,7 +921,7 @@ type CancelWorkflowExecutionFailedEventAttributes struct {
 	DecisionTaskCompletedEventID aws.LongValue   `json:"decisionTaskCompletedEventId"`
 }
 
-// Possible values for SWF.
+// Possible values for ChildPolicy.
 const (
 	ChildPolicyAbandon       = "ABANDON"
 	ChildPolicyRequestCancel = "REQUEST_CANCEL"
@@ -980,7 +980,7 @@ type ChildWorkflowExecutionTimedOutEventAttributes struct {
 	WorkflowType      *WorkflowType      `json:"workflowType"`
 }
 
-// Possible values for SWF.
+// Possible values for CloseStatus.
 const (
 	CloseStatusCanceled       = "CANCELED"
 	CloseStatusCompleted      = "COMPLETED"
@@ -1000,7 +1000,7 @@ type CompleteWorkflowExecutionDecisionAttributes struct {
 	Result aws.StringValue `json:"result,omitempty"`
 }
 
-// Possible values for SWF.
+// Possible values for CompleteWorkflowExecutionFailedCause.
 const (
 	CompleteWorkflowExecutionFailedCauseOperationNotPermitted = "OPERATION_NOT_PERMITTED"
 	CompleteWorkflowExecutionFailedCauseUnhandledDecision     = "UNHANDLED_DECISION"
@@ -1024,7 +1024,7 @@ type ContinueAsNewWorkflowExecutionDecisionAttributes struct {
 	WorkflowTypeVersion          aws.StringValue `json:"workflowTypeVersion,omitempty"`
 }
 
-// Possible values for SWF.
+// Possible values for ContinueAsNewWorkflowExecutionFailedCause.
 const (
 	ContinueAsNewWorkflowExecutionFailedCauseContinueAsNewWorkflowExecutionRateExceeded   = "CONTINUE_AS_NEW_WORKFLOW_EXECUTION_RATE_EXCEEDED"
 	ContinueAsNewWorkflowExecutionFailedCauseDefaultChildPolicyUndefined                  = "DEFAULT_CHILD_POLICY_UNDEFINED"
@@ -1130,12 +1130,12 @@ type DecisionTaskTimedOutEventAttributes struct {
 	TimeoutType      aws.StringValue `json:"timeoutType"`
 }
 
-// Possible values for SWF.
+// Possible values for DecisionTaskTimeoutType.
 const (
 	DecisionTaskTimeoutTypeStartToClose = "START_TO_CLOSE"
 )
 
-// Possible values for SWF.
+// Possible values for DecisionType.
 const (
 	DecisionTypeCancelTimer                            = "CancelTimer"
 	DecisionTypeCancelWorkflowExecution                = "CancelWorkflowExecution"
@@ -1215,7 +1215,7 @@ type DomainInfos struct {
 	NextPageToken aws.StringValue `json:"nextPageToken,omitempty"`
 }
 
-// Possible values for SWF.
+// Possible values for EventType.
 const (
 	EventTypeActivityTaskCancelRequested                     = "ActivityTaskCancelRequested"
 	EventTypeActivityTaskCanceled                            = "ActivityTaskCanceled"
@@ -1266,7 +1266,7 @@ const (
 	EventTypeWorkflowExecutionTimedOut                       = "WorkflowExecutionTimedOut"
 )
 
-// Possible values for SWF.
+// Possible values for ExecutionStatus.
 const (
 	ExecutionStatusClosed = "CLOSED"
 	ExecutionStatusOpen   = "OPEN"
@@ -1296,7 +1296,7 @@ type FailWorkflowExecutionDecisionAttributes struct {
 	Reason  aws.StringValue `json:"reason,omitempty"`
 }
 
-// Possible values for SWF.
+// Possible values for FailWorkflowExecutionFailedCause.
 const (
 	FailWorkflowExecutionFailedCauseOperationNotPermitted = "OPERATION_NOT_PERMITTED"
 	FailWorkflowExecutionFailedCauseUnhandledDecision     = "UNHANDLED_DECISION"
@@ -1473,7 +1473,7 @@ type RecordMarkerDecisionAttributes struct {
 	MarkerName aws.StringValue `json:"markerName"`
 }
 
-// Possible values for SWF.
+// Possible values for RecordMarkerFailedCause.
 const (
 	RecordMarkerFailedCauseOperationNotPermitted = "OPERATION_NOT_PERMITTED"
 )
@@ -1519,7 +1519,7 @@ type RegisterWorkflowTypeInput struct {
 	Version                             aws.StringValue `json:"version"`
 }
 
-// Possible values for SWF.
+// Possible values for RegistrationStatus.
 const (
 	RegistrationStatusDeprecated = "DEPRECATED"
 	RegistrationStatusRegistered = "REGISTERED"
@@ -1530,7 +1530,7 @@ type RequestCancelActivityTaskDecisionAttributes struct {
 	ActivityID aws.StringValue `json:"activityId"`
 }
 
-// Possible values for SWF.
+// Possible values for RequestCancelActivityTaskFailedCause.
 const (
 	RequestCancelActivityTaskFailedCauseActivityIDUnknown     = "ACTIVITY_ID_UNKNOWN"
 	RequestCancelActivityTaskFailedCauseOperationNotPermitted = "OPERATION_NOT_PERMITTED"
@@ -1550,7 +1550,7 @@ type RequestCancelExternalWorkflowExecutionDecisionAttributes struct {
 	WorkflowID aws.StringValue `json:"workflowId"`
 }
 
-// Possible values for SWF.
+// Possible values for RequestCancelExternalWorkflowExecutionFailedCause.
 const (
 	RequestCancelExternalWorkflowExecutionFailedCauseOperationNotPermitted                              = "OPERATION_NOT_PERMITTED"
 	RequestCancelExternalWorkflowExecutionFailedCauseRequestCancelExternalWorkflowExecutionRateExceeded = "REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_RATE_EXCEEDED"
@@ -1627,7 +1627,7 @@ type ScheduleActivityTaskDecisionAttributes struct {
 	TaskPriority           aws.StringValue `json:"taskPriority,omitempty"`
 }
 
-// Possible values for SWF.
+// Possible values for ScheduleActivityTaskFailedCause.
 const (
 	ScheduleActivityTaskFailedCauseActivityCreationRateExceeded           = "ACTIVITY_CREATION_RATE_EXCEEDED"
 	ScheduleActivityTaskFailedCauseActivityIDAlreadyInUse                 = "ACTIVITY_ID_ALREADY_IN_USE"
@@ -1659,7 +1659,7 @@ type SignalExternalWorkflowExecutionDecisionAttributes struct {
 	WorkflowID aws.StringValue `json:"workflowId"`
 }
 
-// Possible values for SWF.
+// Possible values for SignalExternalWorkflowExecutionFailedCause.
 const (
 	SignalExternalWorkflowExecutionFailedCauseOperationNotPermitted                       = "OPERATION_NOT_PERMITTED"
 	SignalExternalWorkflowExecutionFailedCauseSignalExternalWorkflowExecutionRateExceeded = "SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_RATE_EXCEEDED"
@@ -1709,7 +1709,7 @@ type StartChildWorkflowExecutionDecisionAttributes struct {
 	WorkflowType                 *WorkflowType   `json:"workflowType"`
 }
 
-// Possible values for SWF.
+// Possible values for StartChildWorkflowExecutionFailedCause.
 const (
 	StartChildWorkflowExecutionFailedCauseChildCreationRateExceeded                    = "CHILD_CREATION_RATE_EXCEEDED"
 	StartChildWorkflowExecutionFailedCauseDefaultChildPolicyUndefined                  = "DEFAULT_CHILD_POLICY_UNDEFINED"
@@ -1756,7 +1756,7 @@ type StartTimerDecisionAttributes struct {
 	TimerID            aws.StringValue `json:"timerId"`
 }
 
-// Possible values for SWF.
+// Possible values for StartTimerFailedCause.
 const (
 	StartTimerFailedCauseOpenTimersLimitExceeded   = "OPEN_TIMERS_LIMIT_EXCEEDED"
 	StartTimerFailedCauseOperationNotPermitted     = "OPERATION_NOT_PERMITTED"
@@ -1832,7 +1832,7 @@ type WorkflowExecution struct {
 	WorkflowID aws.StringValue `json:"workflowId"`
 }
 
-// Possible values for SWF.
+// Possible values for WorkflowExecutionCancelRequestedCause.
 const (
 	WorkflowExecutionCancelRequestedCauseChildPolicyApplied = "CHILD_POLICY_APPLIED"
 )
@@ -1956,7 +1956,7 @@ type WorkflowExecutionStartedEventAttributes struct {
 	WorkflowType                 *WorkflowType      `json:"workflowType"`
 }
 
-// Possible values for SWF.
+// Possible values for WorkflowExecutionTerminatedCause.
 const (
 	WorkflowExecutionTerminatedCauseChildPolicyApplied = "CHILD_POLICY_APPLIED"
 	WorkflowExecutionTerminatedCauseEventLimitExceeded = "EVENT_LIMIT_EXCEEDED"
@@ -1977,7 +1977,7 @@ type WorkflowExecutionTimedOutEventAttributes struct {
 	TimeoutType aws.StringValue `json:"timeoutType"`
 }
 
-// Possible values for SWF.
+// Possible values for WorkflowExecutionTimeoutType.
 const (
 	WorkflowExecutionTimeoutTypeStartToClose = "START_TO_CLOSE"
 )

--- a/model/templates.go
+++ b/model/templates.go
@@ -116,7 +116,7 @@ type {{ exportable $name }} struct {
 
 {{ end }}
 {{ else if $s.Enum }}
-// Possible values for {{ $.Name }}.
+// Possible values for {{ $s.Name }}.
 const (
 {{ range $name, $value := $s.Enums }}
 {{ $name }} = {{ $value }}{{ end }}
@@ -216,7 +216,7 @@ type {{ exportable $name }} struct {
 
 {{ end }}
 {{ else if $s.Enum }}
-// Possible values for {{ $.Name }}.
+// Possible values for {{ $s.Name }}.
 const (
 {{ range $name, $value := $s.Enums }}
 {{ $name }} = {{ $value }}{{ end }}
@@ -296,7 +296,7 @@ type {{ exportable $name }} struct {
 
 {{ end }}
 {{ else if $s.Enum }}
-// Possible values for {{ $.Name }}.
+// Possible values for {{ $s.Name }}.
 const (
 {{ range $name, $value := $s.Enums }}
 {{ $name }} = {{ $value }}{{ end }}
@@ -650,7 +650,7 @@ func (v *{{ exportable $name }}) MarshalXML(e *xml.Encoder, start xml.StartEleme
 
 {{ end }}
 {{ else if $s.Enum }}
-// Possible values for {{ $.Name }}.
+// Possible values for {{ $s.Name }}.
 const (
 {{ range $name, $value := $s.Enums }}
 {{ $name }} = {{ $value }}{{ end }}
@@ -806,7 +806,7 @@ type {{ exportable $name }} struct {
 
 {{ end }}
 {{ else if $s.Enum }}
-// Possible values for {{ $.Name }}.
+// Possible values for {{ $s.Name }}.
 const (
 {{ range $name, $value := $s.Enums }}
 {{ $name }} = {{ $value }}{{ end }}


### PR DESCRIPTION
This fix only affects a few generated comments, but it's something that bugged me every time I looked at the Godocs for an enum.

The non-generated change is fixing a typo in `model/templates.go` for how comments are generated for 'enum' const groups.