### PR TITLE
Specify marshal key in json tag

### DIFF
--- a/internal/model/api/shape.go
+++ b/internal/model/api/shape.go
@@ -203,7 +203,7 @@ func (ref *ShapeRef) GoTags(toplevel bool) string {
 	if ref.Location != "" { // omit non-body location elements from JSON/XML
 		code += `json:"-" xml:"-" `
 	} else if strings.Contains(ref.API.Metadata.Protocol, "json") {
-		code += `json:",omitempty"`
+		code += `json:"` + ref.LocationName + `,omitempty"`
 	}
 
 	return strings.TrimSpace(code) + "`"


### PR DESCRIPTION
This affects generated 'api.go' files such that their keys, when json marshalled, are named as they were in the json shape definition.

For example, in ECS, the Cluster struct has the following diff:
```
type Cluster struct {
-       ClusterARN  *string `locationName:"clusterArn" type:"string" json:",omitempty"`
-       ClusterName *string `locationName:"clusterName" type:"string" json:",omitempty"`
-       Status      *string `locationName:"status" type:"string" json:",omitempty"`
+       ClusterARN  *string `locationName:"clusterArn" type:"string" json:"clusterArn,omitempty"`
+       ClusterName *string `locationName:"clusterName" type:"string" json:"clusterName,omitempty"`
+       Status      *string `locationName:"status" type:"string" json:"status,omitempty"`

       	metadataCluster `json:"-", xml:"-"`
 }
```

I also checked what it sends over the wire and verified it changed as expected for the subset of shapes I tried. This change matches what boto sends over the wire as well (again for that subset).

It's possible there is a better way to accomplish this or there's further ramifications I don't realize.