### PR TITLE
Merge in extra inflections.csv in the cwd

### DIFF
--- a/internal/model/api/passes.go
+++ b/internal/model/api/passes.go
@@ -257,8 +257,14 @@ var whitelistExportNames = func() map[string]string {
 	if err != nil {
 		panic(err)
 	}
-
 	str := string(b)
+
+	if f, err := os.Open("inflections.csv"); err == nil {
+		if additionalInflections, err := ioutil.ReadAll(f); err == nil {
+			str += "\n" + string(additionalInflections)
+		}
+	}
+
 	for _, line := range strings.Split(str, "\n") {
 		line = strings.Replace(line, "\r", "", -1)
 		if strings.HasPrefix(line, ";") {


### PR DESCRIPTION
I'm not sure what the long-term expected way to work with inflections.csv is.
Right now I'm generating a json model which is not covered by the existing inflections and I think it makes sense for me to commit an 'inflections.csv' along with the model so that gen-api works for it. This change allows for that.
This change does prefer the local inflections.csv and could behave badly if someone had a file by that name present, but I don't think that's a major issue.

If you think there's a better approach I'd be happy to discuss.