### PR TITLE
Replace mechanism to get the current user dir.

### DIFF
--- a/aws/credentials.go
+++ b/aws/credentials.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"path"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -152,7 +152,7 @@ func ProfileCreds(filename, profile string, expiry time.Duration) (CredentialsPr
 			return nil, errors.New("User home directory not found.")
 		}
 
-		filename = path.Join(homeDir, ".aws", "credentials")
+		filename = filepath.Join(homeDir, ".aws", "credentials")
 	}
 
 	if profile == "" {

--- a/aws/credentials.go
+++ b/aws/credentials.go
@@ -3,10 +3,10 @@ package aws
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
-	"os/user"
 	"path"
 	"sync"
 	"time"
@@ -144,12 +144,15 @@ func IAMCreds() CredentialsProvider {
 // configuration file.
 func ProfileCreds(filename, profile string, expiry time.Duration) (CredentialsProvider, error) {
 	if filename == "" {
-		u, err := user.Current()
-		if err != nil {
-			return nil, err
+		homeDir := os.Getenv("HOME") // *nix
+		if homeDir == "" {           // Windows
+			homeDir = os.Getenv("USERPROFILE")
+		}
+		if homeDir == "" {
+			return nil, errors.New("User home directory not found.")
 		}
 
-		filename = path.Join(u.HomeDir, ".aws", "credentials")
+		filename = path.Join(homeDir, ".aws", "credentials")
 	}
 
 	if profile == "" {


### PR DESCRIPTION
user.Current() relies on CGO causing it to fail if cross compiled. It
has been replaced by checking environment variables HOME and
USERPROFILE. Fixes #107