### PR TITLE
gen/endpoints: search for override backwards

### DIFF
--- a/gen/endpoints/endpoints.go
+++ b/gen/endpoints/endpoints.go
@@ -160,7 +160,8 @@ func format(uri, service, region string) string {
 }
 
 func findOverride(service, region string) *override {
-	for _, override := range overrides {
+	for i := len(overrides) - 1; i >= 0; i-- {
+		override := overrides[i]
 		if strings.ToUpper(override.service) == strings.ToUpper(service) &&
 			override.region == region {
 			return &override

--- a/model/endpoints.go
+++ b/model/endpoints.go
@@ -184,9 +184,10 @@ func format(uri, service, region string) string {
 }
 
 func findOverride(service, region string) *override {
-	for _, override := range overrides {
+	for i := len(overrides)-1; i >= 0; i-- {
+		override := overrides[i]
 		if strings.ToUpper(override.service) == strings.ToUpper(service) &&
-            override.region == region {
+			override.region == region {
 			return &override
 		}
 	}


### PR DESCRIPTION
This make it possible for overriding an override.

IMO, A more elegant approach would be to convert the overrides slice to a map (with a composed key). Since it would mean a larger change, I decided to propose this change, and open the pull request so we can both talk about the approach and the code itself.