### PR TITLE
fix json file path error

### DIFF
--- a/internal/fixtures/integration/generate.go
+++ b/internal/fixtures/integration/generate.go
@@ -78,7 +78,7 @@ func Test{{ .TestName }}(t *testing.T) {
 func (t *TestSuite) setup() {
 	_, d, _, _ := runtime.Caller(1)
 	file := filepath.Join(path.Dir(d), "..", "..", "..", "apis",
-		t.PackageName+"-"+t.APIVersion+".normal.json")
+		t.PackageName, t.APIVersion+".normal.json")
 
 	t.API = &api.API{}
 	t.API.Attach(file)


### PR DESCRIPTION
step:
make test

response:
panic: open /Users/nick/aws-sdk-go/apis/autoscaling-2011-01-01.normal.json: no such file or directory