### PR TITLE
Support marshaling structs to/from DynamoDB JSON

### DIFF
--- a/service/dynamodb/api.go
+++ b/service/dynamodb/api.go
@@ -627,34 +627,34 @@ type metadataAttributeDefinition struct {
 // attribute is a set; duplicate values are not allowed.
 type AttributeValue struct {
 	// A Binary data type.
-	B []byte `type:"blob"`
+	B []byte `json:"B,omitempty", type:"blob"`
 
 	// A Boolean data type.
-	BOOL *bool `type:"boolean"`
+	BOOL *bool `json:"BOOL,omitempty", type:"boolean"`
 
 	// A Binary Set data type.
-	BS [][]byte `type:"list"`
+	BS [][]byte `json:"BS,omitempty", type:"list"`
 
 	// A List of attribute values.
-	L []*AttributeValue `type:"list"`
+	L []*AttributeValue `json:"L,omitempty", type:"list"`
 
 	// A Map of attribute values.
-	M *map[string]*AttributeValue `type:"map"`
+	M *map[string]*AttributeValue `json:"M,omitempty", type:"map"`
 
 	// A Number data type.
-	N *string `type:"string"`
+	N *string `json:"N,omitempty", type:"string"`
 
 	// A Number Set data type.
-	NS []*string `type:"list"`
+	NS []*string `json:"NS,omitempty", type:"list"`
 
 	// A Null data type.
-	NULL *bool `type:"boolean"`
+	NULL *bool `json:"NULL,omitempty", type:"boolean"`
 
 	// A String data type.
-	S *string `type:"string"`
+	S *string `json:"S,omitempty", type:"string"`
 
 	// A String Set data type.
-	SS []*string `type:"list"`
+	SS []*string `json:"SS,omitempty", type:"list"`
 
 	metadataAttributeValue `json:"-", xml:"-"`
 }

--- a/service/dynamodb/marshal.go
+++ b/service/dynamodb/marshal.go
@@ -1,0 +1,233 @@
+package dynamodb
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"runtime"
+	"strconv"
+)
+
+// Marshal accepts a map or struct in basic JSON format and converts it to a
+// map which can be JSON-encoded into the DynamoDB format.
+//
+// If in is a struct, we first JSON encode/decode it to get the data as a map.
+// This can/should be optimized later.
+func Marshal(in interface{}) (item map[string]*AttributeValue, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			if e, ok := r.(runtime.Error); ok {
+				err = e
+			} else if s, ok := r.(string); ok {
+				err = errors.New(s)
+			} else {
+				err = r.(error)
+			}
+			item = nil
+		}
+	}()
+
+	v := reflect.ValueOf(in)
+	switch v.Kind() {
+	case reflect.Struct:
+		item = marshalStruct(in)
+	case reflect.Map:
+		if v.Type().Key().Kind() != reflect.String {
+			return nil, errors.New("item must be a map[string]interface{} or struct (or a non-nil pointer to one), got " + v.Type().String())
+		}
+		item = marshalMap(in)
+	case reflect.Ptr:
+		if v.IsNil() {
+			return nil, errors.New("item must not be nil")
+		}
+		return Marshal(v.Elem().Interface())
+	default:
+		return nil, errors.New("item must be a map[string]interface{} or struct (or a non-nil pointer to one), got " + v.Type().String())
+	}
+	return item, nil
+}
+
+// Unmarshal takes a map of DynamoDB attributes and converts it into a map or
+// struct in basic JSON format.
+//
+// If v points to a struct, we first convert it to a basic map, then JSON
+// encode/decode it to convert to a struct. This can/should be optimized later.
+func Unmarshal(item map[string]*AttributeValue, v interface{}) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			if e, ok := r.(runtime.Error); ok {
+				err = e
+			} else if s, ok := r.(string); ok {
+				err = errors.New(s)
+			} else {
+				err = r.(error)
+			}
+			item = nil
+		}
+	}()
+
+	m := make(map[string]interface{})
+	for k, v := range item {
+		m[k] = unmarshal(v)
+	}
+
+	rv := reflect.ValueOf(v)
+	if rv.Kind() != reflect.Ptr || rv.IsNil() {
+		return errors.New("v must be a non-nil pointer to a map[string]interface{} or struct, got " + rv.Type().String())
+	}
+
+	switch rv.Elem().Kind() {
+	case reflect.Struct:
+		// TODO: We convert basic maps into structs by JSON encoding/decoding.
+		// This can be made more efficient by simplying recursing over the
+		// struct and populating it from the map.
+		b, err := json.Marshal(m)
+		if err != nil {
+			return err
+		}
+		return json.Unmarshal(b, v)
+	case reflect.Map:
+		if rv.Elem().Type().Key().Kind() != reflect.String {
+			return errors.New("v must be a non-nil pointer to a map[string]interface{} or struct, got " + rv.Type().String())
+		}
+		rv.Elem().Set(reflect.ValueOf(m))
+	default:
+		return errors.New("v must be a non-nil pointer to a map[string]interface{} or struct, got " + rv.Type().String())
+	}
+
+	return nil
+}
+
+func marshalStruct(in interface{}) map[string]*AttributeValue {
+	// TODO: We convert structs into basic maps by JSON encoding/decoding. This
+	// can be made more efficient by recursing over the struct directly.
+	b, err := json.Marshal(in)
+	if err != nil {
+		panic(err)
+	}
+
+	var m map[string]interface{}
+	decoder := json.NewDecoder(bytes.NewReader(b))
+	decoder.UseNumber()
+	err = decoder.Decode(&m)
+	if err != nil {
+		panic(err)
+	}
+
+	return marshalMap(m)
+}
+
+func marshalMap(in interface{}) map[string]*AttributeValue {
+	item := make(map[string]*AttributeValue)
+	m := in.(map[string]interface{})
+	for k, v := range m {
+		item[k] = marshal(v)
+	}
+	return item
+}
+
+func marshal(in interface{}) *AttributeValue {
+	a := &AttributeValue{}
+
+	if in == nil {
+		a.NULL = new(bool)
+		*a.NULL = true
+		return a
+	}
+
+	if m, ok := in.(map[string]interface{}); ok {
+		mp := make(map[string]*AttributeValue)
+		for k, v := range m {
+			mp[k] = marshal(v)
+		}
+		a.M = &mp
+		return a
+	}
+
+	if l, ok := in.([]interface{}); ok {
+		a.L = make([]*AttributeValue, len(l))
+		for index, v := range l {
+			a.L[index] = marshal(v)
+		}
+		return a
+	}
+
+	// Only primitive types should remain.
+	v := reflect.ValueOf(in)
+	switch v.Kind() {
+	case reflect.Bool:
+		a.BOOL = new(bool)
+		*a.BOOL = v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		a.N = new(string)
+		*a.N = strconv.FormatInt(v.Int(), 10)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		a.N = new(string)
+		*a.N = strconv.FormatUint(v.Uint(), 10)
+	case reflect.Float32, reflect.Float64:
+		a.N = new(string)
+		*a.N = strconv.FormatFloat(v.Float(), 'f', -1, 64)
+	case reflect.String:
+		if n, ok := in.(json.Number); ok {
+			a.N = new(string)
+			*a.N = n.String()
+		} else {
+			a.S = new(string)
+			*a.S = v.String()
+		}
+	default:
+		panic(fmt.Sprintf(`the type %s is not supported`, v.Type().String()))
+	}
+
+	return a
+}
+
+func unmarshal(a *AttributeValue) interface{} {
+	if a.S != nil {
+		return *a.S
+	}
+
+	if a.N != nil {
+		// Number is tricky b/c we don't know which numeric type to use. Here we
+		// simply try the different types from most to least restrictive.
+		if n, err := strconv.ParseInt(*a.N, 10, 64); err == nil {
+			return int(n)
+		}
+		if n, err := strconv.ParseUint(*a.N, 10, 64); err == nil {
+			return uint(n)
+		}
+		n, err := strconv.ParseFloat(*a.N, 64)
+		if err != nil {
+			panic(err)
+		}
+		return n
+	}
+
+	if a.BOOL != nil {
+		return *a.BOOL
+	}
+
+	if a.NULL != nil {
+		return nil
+	}
+
+	if a.M != nil {
+		m := make(map[string]interface{})
+		for k, v := range *a.M {
+			m[k] = unmarshal(v)
+		}
+		return m
+	}
+
+	if a.L != nil {
+		l := make([]interface{}, len(a.L))
+		for index, v := range a.L {
+			l[index] = unmarshal(v)
+		}
+		return l
+	}
+
+	panic(fmt.Sprintf("unsupported dynamo attribute %#v", a))
+}

--- a/service/dynamodb/marshal_test.go
+++ b/service/dynamodb/marshal_test.go
@@ -1,0 +1,169 @@
+package dynamodb
+
+import (
+	"bytes"
+	"encoding/json"
+	"math"
+	"reflect"
+	"testing"
+)
+
+type mySimpleStruct struct {
+	String  string
+	Int     int
+	Uint    uint
+	Float32 float32
+	Float64 float64
+	Bool    bool
+	Null    *interface{}
+}
+
+type myComplexStruct struct {
+	Simple []mySimpleStruct
+}
+
+type marshalTestInput struct {
+	input    interface{}
+	expected string
+}
+
+var marshalTestInputs = []marshalTestInput{
+	// Scalar tests
+	marshalTestInput{
+		input:    map[string]interface{}{"string": "some string"},
+		expected: `{"string":{"S":"some string"}}`},
+	marshalTestInput{
+		input:    map[string]interface{}{"bool": true},
+		expected: `{"bool":{"BOOL":true}}`},
+	marshalTestInput{
+		input:    map[string]interface{}{"bool": false},
+		expected: `{"bool":{"BOOL":false}}`},
+	marshalTestInput{
+		input:    map[string]interface{}{"null": nil},
+		expected: `{"null":{"NULL":true}}`},
+	marshalTestInput{
+		input:    map[string]interface{}{"float": 3.14},
+		expected: `{"float":{"N":"3.14"}}`},
+	marshalTestInput{
+		input:    map[string]interface{}{"float": math.MaxFloat32},
+		expected: `{"float":{"N":"340282346638528860000000000000000000000"}}`},
+	marshalTestInput{
+		input:    map[string]interface{}{"float": math.MaxFloat64},
+		expected: `{"float":{"N":"179769313486231570000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"}}`},
+	marshalTestInput{
+		input:    map[string]interface{}{"int": int(12)},
+		expected: `{"int":{"N":"12"}}`},
+	// List
+	marshalTestInput{
+		input:    map[string]interface{}{"list": []interface{}{"a string", 12, 3.14, true, nil, false}},
+		expected: `{"list":{"L":[{"S":"a string"},{"N":"12"},{"N":"3.14"},{"BOOL":true},{"NULL":true},{"BOOL":false}]}}`},
+	// Map
+	marshalTestInput{
+		input:    map[string]interface{}{"map": map[string]interface{}{"nestedint": 12}},
+		expected: `{"map":{"M":{"nestedint":{"N":"12"}}}}`},
+	marshalTestInput{
+		input:    &map[string]interface{}{"map": map[string]interface{}{"nestedint": 12}},
+		expected: `{"map":{"M":{"nestedint":{"N":"12"}}}}`},
+	// Structs
+	marshalTestInput{
+		input:    mySimpleStruct{},
+		expected: `{"Bool":{"BOOL":false},"Float32":{"N":"0"},"Float64":{"N":"0"},"Int":{"N":"0"},"Null":{"NULL":true},"String":{"S":""},"Uint":{"N":"0"}}`},
+	marshalTestInput{
+		input:    &mySimpleStruct{},
+		expected: `{"Bool":{"BOOL":false},"Float32":{"N":"0"},"Float64":{"N":"0"},"Int":{"N":"0"},"Null":{"NULL":true},"String":{"S":""},"Uint":{"N":"0"}}`},
+	marshalTestInput{
+		input:    myComplexStruct{},
+		expected: `{"Simple":{"NULL":true}}`},
+	marshalTestInput{
+		input:    myComplexStruct{Simple: []mySimpleStruct{mySimpleStruct{}, mySimpleStruct{}}},
+		expected: `{"Simple":{"L":[{"M":{"Bool":{"BOOL":false},"Float32":{"N":"0"},"Float64":{"N":"0"},"Int":{"N":"0"},"Null":{"NULL":true},"String":{"S":""},"Uint":{"N":"0"}}},{"M":{"Bool":{"BOOL":false},"Float32":{"N":"0"},"Float64":{"N":"0"},"Int":{"N":"0"},"Null":{"NULL":true},"String":{"S":""},"Uint":{"N":"0"}}}]}}`},
+}
+
+func TestMarshal(t *testing.T) {
+	for _, test := range marshalTestInputs {
+		testMarshal(t, test.input, test.expected)
+	}
+}
+
+func testMarshal(t *testing.T, in interface{}, expectedString string) {
+	var expected interface{}
+	var buf bytes.Buffer
+	buf.WriteString(expectedString)
+	if err := json.Unmarshal(buf.Bytes(), &expected); err != nil {
+		t.Error(err)
+	}
+	actual, err := Marshal(in)
+	if err != nil {
+		t.Error(err)
+	}
+	compareObjects(t, expected, actual)
+}
+
+func TestUnmarshal(t *testing.T) {
+	// Using the same inputs from TestMarshal, test the reverse mapping.
+	for _, test := range marshalTestInputs {
+		testUnmarshal(t, test.expected, test.input)
+	}
+}
+
+func testUnmarshal(t *testing.T, inputString string, expected interface{}) {
+	var item map[string]*AttributeValue
+	var buf bytes.Buffer
+	buf.WriteString(inputString)
+	if err := json.Unmarshal(buf.Bytes(), &item); err != nil {
+		t.Error(err)
+	}
+	var actual map[string]interface{}
+	if err := Unmarshal(item, &actual); err != nil {
+		t.Error(err)
+	}
+	compareObjects(t, expected, actual)
+}
+
+func TestStruct(t *testing.T) {
+	// Test that we get a typed struct back
+	expected := mySimpleStruct{String: "this is a string", Int: 1000000, Uint: 18446744073709551615, Float64: 3.14}
+	dynamized, err := Marshal(expected)
+	if err != nil {
+		t.Error(err)
+	}
+	var actual mySimpleStruct
+	err = Unmarshal(dynamized, &actual)
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Did not get back the expected typed struct")
+	}
+}
+
+// What we're trying to do here is compare the JSON encoded values, but we can't
+// to a simple encode + string compare since JSON encoding is not ordered. So
+// what we do is JSON encode, then JSON decode into untyped maps, and then
+// finally do a recursive comparison.
+func compareObjects(t *testing.T, expected interface{}, actual interface{}) {
+	expectedBytes, eerr := json.Marshal(expected)
+	if eerr != nil {
+		t.Error(eerr)
+		return
+	}
+	actualBytes, aerr := json.Marshal(actual)
+	if aerr != nil {
+		t.Error(aerr)
+		return
+	}
+	var expectedUntyped, actualUntyped map[string]interface{}
+	eerr = json.Unmarshal(expectedBytes, &expectedUntyped)
+	if eerr != nil {
+		t.Error(eerr)
+		return
+	}
+	aerr = json.Unmarshal(actualBytes, &actualUntyped)
+	if aerr != nil {
+		t.Error(aerr)
+		return
+	}
+	if !reflect.DeepEqual(expectedUntyped, actualUntyped) {
+		t.Errorf("Expected %s, got %s", string(expectedBytes), string(actualBytes))
+	}
+}


### PR DESCRIPTION
Fixes #72 

@lsegal This relies on the JSON `omitempty` struct tags for each field in `AttributeValue`. I added them manually for now to api.go, but I know that file is automatically generated. Should I look into editing the generator code to support them, or are they intentionally absent?