### PR TITLE
Add full ECS API.

### DIFF
--- a/apis/ecs/2014-11-13.normal.json
+++ b/apis/ecs/2014-11-13.normal.json
@@ -33,7 +33,30 @@
           "documentation":"<p>These errors are usually caused by something the client did, such as use an action or resource on behalf of a user that doesn't have permission to use the action or resource, or specify an identifier that is not valid.</p>"
         }
       ],
-      "documentation":"<p>Creates a new Amazon ECS cluster. By default, your account will receive a <code>default</code> cluster when you launch your first container instance. However, you can create your own cluster with a unique name with the <code>CreateCluster</code> action.</p> <important> <p>During the preview, each account is limited to two clusters.</p> </important>"
+      "documentation":"<p>Creates a new Amazon ECS cluster. By default, your account will receive a <code>default</code> cluster when you launch your first container instance. However, you can create your own cluster with a unique name with the <code>CreateCluster</code> action.</p>"
+    },
+    "CreateService":{
+      "name":"CreateService",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"CreateServiceRequest"},
+      "output":{"shape":"CreateServiceResponse"},
+      "errors":[
+        {
+          "shape":"ServerException",
+          "exception":true,
+          "fault":true,
+          "documentation":"<p>These errors are usually caused by a server-side issue.</p>"
+        },
+        {
+          "shape":"ClientException",
+          "exception":true,
+          "documentation":"<p>These errors are usually caused by something the client did, such as use an action or resource on behalf of a user that doesn't have permission to use the action or resource, or specify an identifier that is not valid.</p>"
+        }
+      ],
+      "documentation":"<p>Runs and maintains a desired number of tasks from a specified task definition. If the number of tasks running in a service drops below <code>desiredCount</code>, Amazon ECS will spawn another instantiation of the task in the specified cluster.</p>"
     },
     "DeleteCluster":{
       "name":"DeleteCluster",
@@ -57,6 +80,29 @@
         }
       ],
       "documentation":"<p>Deletes the specified cluster. You must deregister all container instances from this cluster before you may delete it. You can list the container instances in a cluster with <a>ListContainerInstances</a> and deregister them with <a>DeregisterContainerInstance</a>.</p>"
+    },
+    "DeleteService":{
+      "name":"DeleteService",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"DeleteServiceRequest"},
+      "output":{"shape":"DeleteServiceResponse"},
+      "errors":[
+        {
+          "shape":"ServerException",
+          "exception":true,
+          "fault":true,
+          "documentation":"<p>These errors are usually caused by a server-side issue.</p>"
+        },
+        {
+          "shape":"ClientException",
+          "exception":true,
+          "documentation":"<p>These errors are usually caused by something the client did, such as use an action or resource on behalf of a user that doesn't have permission to use the action or resource, or specify an identifier that is not valid.</p>"
+        }
+      ],
+      "documentation":"<p>Deletes a specified service within a cluster.</p>"
     },
     "DeregisterContainerInstance":{
       "name":"DeregisterContainerInstance",
@@ -149,6 +195,29 @@
         }
       ],
       "documentation":"<p>Describes Amazon EC2 Container Service container instances. Returns metadata about registered and remaining resources on each container instance requested.</p>"
+    },
+    "DescribeServices":{
+      "name":"DescribeServices",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"DescribeServicesRequest"},
+      "output":{"shape":"DescribeServicesResponse"},
+      "errors":[
+        {
+          "shape":"ServerException",
+          "exception":true,
+          "fault":true,
+          "documentation":"<p>These errors are usually caused by a server-side issue.</p>"
+        },
+        {
+          "shape":"ClientException",
+          "exception":true,
+          "documentation":"<p>These errors are usually caused by something the client did, such as use an action or resource on behalf of a user that doesn't have permission to use the action or resource, or specify an identifier that is not valid.</p>"
+        }
+      ],
+      "documentation":"<p>Describes the specified services running in your cluster.</p>"
     },
     "DescribeTaskDefinition":{
       "name":"DescribeTaskDefinition",
@@ -264,6 +333,29 @@
         }
       ],
       "documentation":"<p>Returns a list of container instances in a specified cluster.</p>"
+    },
+    "ListServices":{
+      "name":"ListServices",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"ListServicesRequest"},
+      "output":{"shape":"ListServicesResponse"},
+      "errors":[
+        {
+          "shape":"ServerException",
+          "exception":true,
+          "fault":true,
+          "documentation":"<p>These errors are usually caused by a server-side issue.</p>"
+        },
+        {
+          "shape":"ClientException",
+          "exception":true,
+          "documentation":"<p>These errors are usually caused by something the client did, such as use an action or resource on behalf of a user that doesn't have permission to use the action or resource, or specify an identifier that is not valid.</p>"
+        }
+      ],
+      "documentation":"<p>Lists the services that are running in a specified cluster.</p>"
     },
     "ListTaskDefinitionFamilies":{
       "name":"ListTaskDefinitionFamilies",
@@ -401,7 +493,7 @@
           "documentation":"<p>These errors are usually caused by something the client did, such as use an action or resource on behalf of a user that doesn't have permission to use the action or resource, or specify an identifier that is not valid.</p>"
         }
       ],
-      "documentation":"<p>Start a task using random placement and the default Amazon ECS scheduler. If you want to use your own scheduler or place a task on a specific container instance, use <code>StartTask</code> instead.</p>"
+      "documentation":"<p>Start a task using random placement and the default Amazon ECS scheduler. If you want to use your own scheduler or place a task on a specific container instance, use <code>StartTask</code> instead.</p> <important> <p>The <code>count</code> parameter is limited to 10 tasks per call.</p> </important>"
     },
     "StartTask":{
       "name":"StartTask",
@@ -424,7 +516,7 @@
           "documentation":"<p>These errors are usually caused by something the client did, such as use an action or resource on behalf of a user that doesn't have permission to use the action or resource, or specify an identifier that is not valid.</p>"
         }
       ],
-      "documentation":"<p>Starts a new task from the specified task definition on the specified container instance or instances. If you want to use the default Amazon ECS scheduler to place your task, use <code>RunTask</code> instead.</p>"
+      "documentation":"<p>Starts a new task from the specified task definition on the specified container instance or instances. If you want to use the default Amazon ECS scheduler to place your task, use <code>RunTask</code> instead.</p> <important> <p>The list of container instances to start tasks on is limited to 10.</p> </important>"
     },
     "StopTask":{
       "name":"StopTask",
@@ -494,6 +586,29 @@
         }
       ],
       "documentation":"<note><p>This action is only used by the Amazon EC2 Container Service agent, and it is not intended for use outside of the agent.</p></note> <p>Sent to acknowledge that a task changed states.</p>"
+    },
+    "UpdateService":{
+      "name":"UpdateService",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"UpdateServiceRequest"},
+      "output":{"shape":"UpdateServiceResponse"},
+      "errors":[
+        {
+          "shape":"ServerException",
+          "exception":true,
+          "fault":true,
+          "documentation":"<p>These errors are usually caused by a server-side issue.</p>"
+        },
+        {
+          "shape":"ClientException",
+          "exception":true,
+          "documentation":"<p>These errors are usually caused by something the client did, such as use an action or resource on behalf of a user that doesn't have permission to use the action or resource, or specify an identifier that is not valid.</p>"
+        }
+      ],
+      "documentation":"<p>Modify the desired count or task definition used in a service.</p> <p>You can add to or subtract from the number of instantiations of a task definition in a service by specifying the cluster that the service is running in and a new <code>desiredCount</code> parameter.</p> <p>You can use <code>UpdateService</code> to modify your task definition and deploy a new version of your service, one task at a time. If you modify the task definition with <code>UpdateService</code>, Amazon ECS spawns a task with the new version of the task definition and then stops an old task after the new version is running. Because <code>UpdateService</code> starts a new version of the task before stopping an old version, your cluster must have capacity to support one more instantiation of the task when <code>UpdateService</code> is run. If your cluster cannot support another instantiation of the task used in your service, you can reduce the desired count of your service by one before modifying the task definition.</p>"
     }
   },
   "shapes":{
@@ -528,6 +643,18 @@
         "status":{
           "shape":"String",
           "documentation":"<p>The status of the cluster. The valid values are <code>ACTIVE</code> or <code>INACTIVE</code>. <code>ACTIVE</code> indicates that you can register container instances with the cluster and the associated instances can accept tasks.</p>"
+        },
+        "registeredContainerInstancesCount":{
+          "shape":"Integer",
+          "documentation":"<p>The number of container instances registered into the cluster.</p>"
+        },
+        "runningTasksCount":{
+          "shape":"Integer",
+          "documentation":"<p>The number of tasks in the cluster that are in the <code>RUNNING</code> state.</p>"
+        },
+        "pendingTasksCount":{
+          "shape":"Integer",
+          "documentation":"<p>The number of tasks in the cluster that are in the <code>PENDING</code> state.</p>"
         }
       },
       "documentation":"<p>A regional grouping of one or more container instances on which you can run task requests. Each account receives a default cluster the first time you use the Amazon ECS service, but you may also create other clusters. Clusters may contain more than one instance type simultaneously.</p> <important> <p>During the preview, each account is limited to two clusters.</p> </important>"
@@ -650,6 +777,14 @@
         "agentConnected":{
           "shape":"Boolean",
           "documentation":"<p>This parameter returns <code>true</code> if the agent is actually connected to Amazon ECS. Registered instances with an agent that may be unhealthy or stopped will return <code>false</code>, and instances without a connected agent cannot accept placement request.</p>"
+        },
+        "runningTasksCount":{
+          "shape":"Integer",
+          "documentation":"<p>The number of tasks on the container instance that are in the <code>RUNNING</code> status.</p>"
+        },
+        "pendingTasksCount":{
+          "shape":"Integer",
+          "documentation":"<p>The number of tasks on the container instance that are in the <code>PENDING</code> status.</p>"
         }
       },
       "documentation":"<p>An Amazon EC2 instance that is running the Amazon ECS agent and has been registered with a cluster.</p>"
@@ -667,9 +802,10 @@
         },
         "command":{
           "shape":"StringList",
-          "documentation":"<p>The command to send to the container that receives the override.</p>"
+          "documentation":"<p>The command to send to the container that overrides the default command from the Docker image or the task definition.</p>"
         }
-      }
+      },
+      "documentation":"<p>The name of a container in a task definition and the command it should run instead of its default.</p>"
     },
     "ContainerOverrides":{
       "type":"list",
@@ -684,7 +820,7 @@
       "members":{
         "clusterName":{
           "shape":"String",
-          "documentation":"<p>The name of your cluster. If you do not specify a name for your cluster, you will create a cluster named <code>default</code>.</p>"
+          "documentation":"<p>The name of your cluster. If you do not specify a name for your cluster, you will create a cluster named <code>default</code>. Up to 255 letters (uppercase and lowercase), numbers, hyphens, and underscores are allowed.</p>"
         }
       }
     },
@@ -694,6 +830,49 @@
         "cluster":{
           "shape":"Cluster",
           "documentation":"<p>The full description of your new cluster.</p>"
+        }
+      }
+    },
+    "CreateServiceRequest":{
+      "type":"structure",
+      "required":["serviceName"],
+      "members":{
+        "cluster":{
+          "shape":"String",
+          "documentation":"<p>The short name or full Amazon Resource Name (ARN) of the cluster that you want to run your service on. If you do not specify a cluster, the default cluster is assumed.</p>"
+        },
+        "serviceName":{
+          "shape":"String",
+          "documentation":"<p>The name of your service. Up to 255 letters (uppercase and lowercase), numbers, hyphens, and underscores are allowed.</p>"
+        },
+        "taskDefinition":{
+          "shape":"String",
+          "documentation":"<p>The <code>family</code> and <code>revision</code> (<code>family:revision</code>) or full Amazon Resource Name (ARN) of the task definition that you want to run in your service.</p>"
+        },
+        "loadBalancers":{
+          "shape":"LoadBalancers",
+          "documentation":"<p>A list of load balancer objects, containing the load balancer name, the container name (as it appears in a container definition), and the container port to access from the load balancer.</p>"
+        },
+        "desiredCount":{
+          "shape":"BoxedInteger",
+          "documentation":"<p>The number of instantiations of the specified task definition that you would like to place and keep running on your cluster.</p>"
+        },
+        "clientToken":{
+          "shape":"String",
+          "documentation":"<p>Unique, case-sensitive identifier you provide to ensure the idempotency of the request. Up to 32 ASCII characters are allowed.</p>"
+        },
+        "role":{
+          "shape":"String",
+          "documentation":"<p>The name or full Amazon Resource Name (ARN) of the IAM role that allows your Amazon ECS container agent to make calls to your load balancer on your behalf. This parameter is only required if you are using a load balancer with your service.</p>"
+        }
+      }
+    },
+    "CreateServiceResponse":{
+      "type":"structure",
+      "members":{
+        "service":{
+          "shape":"Service",
+          "documentation":"<p>The full description of your service following the create call.</p>"
         }
       }
     },
@@ -715,6 +894,67 @@
           "documentation":"<p>The full description of the deleted cluster.</p>"
         }
       }
+    },
+    "DeleteServiceRequest":{
+      "type":"structure",
+      "required":["service"],
+      "members":{
+        "cluster":{
+          "shape":"String",
+          "documentation":"<p>The name of the cluster that hosts the service you want to delete.</p>"
+        },
+        "service":{
+          "shape":"String",
+          "documentation":"<p>The name of the service you want to delete.</p>"
+        }
+      }
+    },
+    "DeleteServiceResponse":{
+      "type":"structure",
+      "members":{
+        "service":{"shape":"Service"}
+      }
+    },
+    "Deployment":{
+      "type":"structure",
+      "members":{
+        "id":{
+          "shape":"String",
+          "documentation":"<p>The ID of the deployment.</p>"
+        },
+        "status":{
+          "shape":"String",
+          "documentation":"<p>The status of the deployment. Valid values are <code>PRIMARY</code> (for the most recent deployment), <code>ACTIVE</code> (for previous deployments that still have tasks running, but are being replaced with the <code>PRIMARY</code> deployment), and <code>INACTIVE</code> (for deployments that have been completely replaced).</p>"
+        },
+        "taskDefinition":{
+          "shape":"String",
+          "documentation":"<p>The most recent task definition that was specified for the service to use.</p>"
+        },
+        "desiredCount":{
+          "shape":"Integer",
+          "documentation":"<p>The most recent desired count of tasks that was specified for the service to deploy and/or maintain.</p>"
+        },
+        "pendingCount":{
+          "shape":"Integer",
+          "documentation":"<p>The number of tasks in the deployment that are in the <code>PENDING</code> status.</p>"
+        },
+        "runningCount":{
+          "shape":"Integer",
+          "documentation":"<p>The number of tasks in the deployment that are in the <code>RUNNING</code> status.</p>"
+        },
+        "createdAt":{
+          "shape":"Timestamp",
+          "documentation":"<p>The Unix time in seconds and milliseconds when the service was created.</p>"
+        },
+        "updatedAt":{
+          "shape":"Timestamp",
+          "documentation":"<p>The Unix time in seconds and milliseconds when the service was last updated.</p>"
+        }
+      }
+    },
+    "Deployments":{
+      "type":"list",
+      "member":{"shape":"Deployment"}
     },
     "DeregisterContainerInstanceRequest":{
       "type":"structure",
@@ -800,6 +1040,33 @@
           "documentation":"<p>The list of container instances.</p>"
         },
         "failures":{"shape":"Failures"}
+      }
+    },
+    "DescribeServicesRequest":{
+      "type":"structure",
+      "required":["services"],
+      "members":{
+        "cluster":{
+          "shape":"String",
+          "documentation":"<p>The name of the cluster that hosts the service you want to describe.</p>"
+        },
+        "services":{
+          "shape":"StringList",
+          "documentation":"<p>A list of services you want to describe.</p>"
+        }
+      }
+    },
+    "DescribeServicesResponse":{
+      "type":"structure",
+      "members":{
+        "services":{
+          "shape":"Services",
+          "documentation":"<p>The list of services described.</p>"
+        },
+        "failures":{
+          "shape":"Failures",
+          "documentation":"<p>Any failures associated with the call.</p>"
+        }
       }
     },
     "DescribeTaskDefinitionRequest":{
@@ -968,6 +1235,36 @@
         }
       }
     },
+    "ListServicesRequest":{
+      "type":"structure",
+      "members":{
+        "cluster":{
+          "shape":"String",
+          "documentation":"<p>The short name or full Amazon Resource Name (ARN) of the cluster that hosts the services you want to list. If you do not specify a cluster, the default cluster is assumed..</p>"
+        },
+        "nextToken":{
+          "shape":"String",
+          "documentation":"<p>The <code>nextToken</code> value returned from a previous paginated <code>ListServices</code> request where <code>maxResults</code> was used and the results exceeded the value of that parameter. Pagination continues from the end of the previous results that returned the <code>nextToken</code> value. This value is <code>null</code> when there are no more results to return.</p>"
+        },
+        "maxResults":{
+          "shape":"BoxedInteger",
+          "documentation":"<p>The maximum number of container instance results returned by <code>ListServices</code> in paginated output. When this parameter is used, <code>ListServices</code> only returns <code>maxResults</code> results in a single page along with a <code>nextToken</code> response element. The remaining results of the initial request can be seen by sending another <code>ListServices</code> request with the returned <code>nextToken</code> value. This value can be between 1 and 100. If this parameter is not used, then <code>ListServices</code> returns up to 100 results and a <code>nextToken</code> value if applicable.</p>"
+        }
+      }
+    },
+    "ListServicesResponse":{
+      "type":"structure",
+      "members":{
+        "serviceArns":{
+          "shape":"StringList",
+          "documentation":"<p>The list of full Amazon Resource Name (ARN) entries for each service associated with the specified cluster.</p>"
+        },
+        "nextToken":{
+          "shape":"String",
+          "documentation":"<p>The <code>nextToken</code> value to include in a future <code>ListServices</code> request. When the results of a <code>ListServices</code> request exceed <code>maxResults</code>, this value can be used to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>"
+        }
+      }
+    },
     "ListTaskDefinitionFamiliesRequest":{
       "type":"structure",
       "members":{
@@ -1050,6 +1347,14 @@
         "maxResults":{
           "shape":"BoxedInteger",
           "documentation":"<p>The maximum number of task results returned by <code>ListTasks</code> in paginated output. When this parameter is used, <code>ListTasks</code> only returns <code>maxResults</code> results in a single page along with a <code>nextToken</code> response element. The remaining results of the initial request can be seen by sending another <code>ListTasks</code> request with the returned <code>nextToken</code> value. This value can be between 1 and 100. If this parameter is not used, then <code>ListTasks</code> returns up to 100 results and a <code>nextToken</code> value if applicable.</p>"
+        },
+        "startedBy":{
+          "shape":"String",
+          "documentation":"<p>The <code>startedBy</code> value that you want to filter the task results with. Specifying a <code>startedBy</code> value will limit the results to tasks that were started with that value.</p>"
+        },
+        "serviceName":{
+          "shape":"String",
+          "documentation":"<p>The name of the service that you want to filter the <code>ListTasks</code> results with. Specifying a <code>serviceName</code> will limit the results to tasks that belong to that service.</p>"
         }
       }
     },
@@ -1065,6 +1370,27 @@
           "documentation":"<p>The <code>nextToken</code> value to include in a future <code>ListTasks</code> request. When the results of a <code>ListTasks</code> request exceed <code>maxResults</code>, this value can be used to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>"
         }
       }
+    },
+    "LoadBalancer":{
+      "type":"structure",
+      "members":{
+        "loadBalancerName":{
+          "shape":"String",
+          "documentation":"<p>The name of the load balancer.</p>"
+        },
+        "containerName":{
+          "shape":"String",
+          "documentation":"<p>The name of the container to associate with the load balancer.</p>"
+        },
+        "containerPort":{
+          "shape":"BoxedInteger",
+          "documentation":"<p>The port on the container to associate with the load balancer.</p>"
+        }
+      }
+    },
+    "LoadBalancers":{
+      "type":"list",
+      "member":{"shape":"LoadBalancer"}
     },
     "Long":{"type":"long"},
     "MountPoint":{
@@ -1136,7 +1462,8 @@
         },
         "instanceIdentityDocument":{"shape":"String"},
         "instanceIdentityDocumentSignature":{"shape":"String"},
-        "totalResources":{"shape":"Resources"}
+        "totalResources":{"shape":"Resources"},
+        "versionInfo":{"shape":"VersionInfo"}
       }
     },
     "RegisterContainerInstanceResponse":{
@@ -1154,7 +1481,7 @@
       "members":{
         "family":{
           "shape":"String",
-          "documentation":"<p>You must specify a <code>family</code> for a task definition, which allows you to track multiple versions of the same task definition. You can think of the <code>family</code> as a name for your task definition.</p>"
+          "documentation":"<p>You must specify a <code>family</code> for a task definition, which allows you to track multiple versions of the same task definition. You can think of the <code>family</code> as a name for your task definition. Up to 255 letters (uppercase and lowercase), numbers, hyphens, and underscores are allowed.</p>"
         },
         "containerDefinitions":{
           "shape":"ContainerDefinitions",
@@ -1218,10 +1545,17 @@
           "shape":"String",
           "documentation":"<p>The <code>family</code> and <code>revision</code> (<code>family:revision</code>) or full Amazon Resource Name (ARN) of the task definition that you want to run.</p>"
         },
-        "overrides":{"shape":"TaskOverride"},
+        "overrides":{
+          "shape":"TaskOverride",
+          "documentation":"<p>A list of container overrides in JSON format that specify the name of a container in the specified task definition and the command it should run instead of its default. A total of 8192 characters are allowed for overrides. This limit includes the JSON formatting characters of the override structure.</p>"
+        },
         "count":{
           "shape":"BoxedInteger",
-          "documentation":"<p>The number of instances of the specified task that you would like to place on your cluster.</p>"
+          "documentation":"<p>The number of instantiations of the specified task that you would like to place on your cluster.</p> <important> <p>The <code>count</code> parameter is limited to 10 tasks per call.</p> </important>"
+        },
+        "startedBy":{
+          "shape":"String",
+          "documentation":"<p>An optional tag specified when a task is started. For example if you automatically trigger a task to run a batch process job, you could apply a unique identifier for that job to your task with the <code>startedBy</code> parameter. You can then identify which tasks belong to that job by filtering the results of a <a>ListTasks</a> call with the <code>startedBy</code> value.</p> <p>If a task is started by an Amazon ECS service, then the <code>startedBy</code> parameter contains the deployment ID of the service that starts it.</p>"
         }
       }
     },
@@ -1247,6 +1581,84 @@
       "fault":true,
       "documentation":"<p>These errors are usually caused by a server-side issue.</p>"
     },
+    "Service":{
+      "type":"structure",
+      "members":{
+        "serviceArn":{
+          "shape":"String",
+          "documentation":"<p>The Amazon Resource Name (ARN) that identifies the service. The ARN contains the <code>arn:aws:ecs</code> namespace, followed by the region of the service, the AWS account ID of the service owner, the <code>service</code> namespace, and then the service name. For example, arn:aws:ecs:<i>region</i>:<i>012345678910</i>:service/<i>my-service</i>.</p>"
+        },
+        "serviceName":{
+          "shape":"String",
+          "documentation":"<p>A user-generated string that you can use to identify your service.</p>"
+        },
+        "clusterArn":{
+          "shape":"String",
+          "documentation":"<p>The Amazon Resource Name (ARN) of the of the cluster that hosts the service.</p>"
+        },
+        "loadBalancers":{
+          "shape":"LoadBalancers",
+          "documentation":"<p>A list of load balancer objects, containing the load balancer name, the container name (as it appears in a container definition), and the container port to access from the load balancer.</p>"
+        },
+        "status":{
+          "shape":"String",
+          "documentation":"<p>The status of the service. The valid values are <code>ACTIVE</code>, <code>DRAINING</code>, or <code>INACTIVE</code>.</p>"
+        },
+        "desiredCount":{
+          "shape":"Integer",
+          "documentation":"<p>The desired number of instantiations of the task definition to keep running on the service. This value is specified when the service is created with <a>CreateService</a>, and it can be modified with <a>UpdateService</a>.</p>"
+        },
+        "runningCount":{
+          "shape":"Integer",
+          "documentation":"<p>The number of tasks in the cluster that are in the <code>RUNNING</code> state.</p>"
+        },
+        "pendingCount":{
+          "shape":"Integer",
+          "documentation":"<p>The number of tasks in the cluster that are in the <code>PENDING</code> state.</p>"
+        },
+        "taskDefinition":{
+          "shape":"String",
+          "documentation":"<p>The task definition to use for tasks in the service. This value is specified when the service is created with <a>CreateService</a>, and it can be modified with <a>UpdateService</a>.</p>"
+        },
+        "deployments":{
+          "shape":"Deployments",
+          "documentation":"<p>The current state of deployments for the service.</p>"
+        },
+        "roleArn":{
+          "shape":"String",
+          "documentation":"<p>The Amazon Resource Name (ARN) of the IAM role associated with the service that allows the Amazon ECS container agent to register container instances with a load balancer. </p>"
+        },
+        "events":{
+          "shape":"ServiceEvents",
+          "documentation":"<p>The event stream for your service. A maximum of 100 of the latest events are displayed.</p>"
+        }
+      }
+    },
+    "ServiceEvent":{
+      "type":"structure",
+      "members":{
+        "id":{
+          "shape":"String",
+          "documentation":"<p>The ID string of the event.</p>"
+        },
+        "createdAt":{
+          "shape":"Timestamp",
+          "documentation":"<p>The Unix time in seconds and milliseconds when the event was triggered.</p>"
+        },
+        "message":{
+          "shape":"String",
+          "documentation":"<p>The event message.</p>"
+        }
+      }
+    },
+    "ServiceEvents":{
+      "type":"list",
+      "member":{"shape":"ServiceEvent"}
+    },
+    "Services":{
+      "type":"list",
+      "member":{"shape":"Service"}
+    },
     "StartTaskRequest":{
       "type":"structure",
       "required":[
@@ -1262,10 +1674,17 @@
           "shape":"String",
           "documentation":"<p>The <code>family</code> and <code>revision</code> (<code>family:revision</code>) or full Amazon Resource Name (ARN) of the task definition that you want to start.</p>"
         },
-        "overrides":{"shape":"TaskOverride"},
+        "overrides":{
+          "shape":"TaskOverride",
+          "documentation":"<p>A list of container overrides in JSON format that specify the name of a container in the specified task definition and the command it should run instead of its default. A total of 8192 characters are allowed for overrides. This limit includes the JSON formatting characters of the override structure.</p>"
+        },
         "containerInstances":{
           "shape":"StringList",
-          "documentation":"<p>The container instance UUIDs or full Amazon Resource Name (ARN) entries for the container instances on which you would like to place your task.</p>"
+          "documentation":"<p>The container instance UUIDs or full Amazon Resource Name (ARN) entries for the container instances on which you would like to place your task.</p> <important> <p>The list of container instances to start tasks on is limited to 10.</p> </important>"
+        },
+        "startedBy":{
+          "shape":"String",
+          "documentation":"<p>An optional tag specified when a task is started. For example if you automatically trigger a task to run a batch process job, you could apply a unique identifier for that job to your task with the <code>startedBy</code> parameter. You can then identify which tasks belong to that job by filtering the results of a <a>ListTasks</a> call with the <code>startedBy</code> value.</p> <p>If a task is started by an Amazon ECS service, then the <code>startedBy</code> parameter contains the deployment ID of the service that starts it.</p>"
         }
       }
     },
@@ -1413,6 +1832,10 @@
         "containers":{
           "shape":"Containers",
           "documentation":"<p>The containers associated with the task.</p>"
+        },
+        "startedBy":{
+          "shape":"String",
+          "documentation":"<p>The tag specified when a task is started. If the task is started by an Amazon ECS service, then the <code>startedBy</code> parameter contains the deployment ID of the service that starts it.</p>"
         }
       }
     },
@@ -1446,13 +1869,63 @@
       "members":{
         "containerOverrides":{
           "shape":"ContainerOverrides",
-          "documentation":"<p>One or more container overrides to send when running a task.</p>"
+          "documentation":"<p>One or more container overrides sent to a task.</p>"
         }
-      }
+      },
+      "documentation":"<p>A list of container overrides in JSON format that specify the name of a container in a task definition and the command it should run instead of its default.</p>"
     },
     "Tasks":{
       "type":"list",
       "member":{"shape":"Task"}
+    },
+    "Timestamp":{"type":"timestamp"},
+    "UpdateServiceRequest":{
+      "type":"structure",
+      "required":["service"],
+      "members":{
+        "cluster":{
+          "shape":"String",
+          "documentation":"<p>The short name or full Amazon Resource Name (ARN) of the cluster that your service is running on. If you do not specify a cluster, the default cluster is assumed.</p>"
+        },
+        "service":{
+          "shape":"String",
+          "documentation":"<p>The name of the service that you want to update.</p>"
+        },
+        "desiredCount":{
+          "shape":"BoxedInteger",
+          "documentation":"<p>The number of instantiations of the task that you would like to place and keep running in your service.</p>"
+        },
+        "taskDefinition":{
+          "shape":"String",
+          "documentation":"<p>The <code>family</code> and <code>revision</code> (<code>family:revision</code>) or full Amazon Resource Name (ARN) of the task definition that you want to run in your service. If you modify the task definition with <code>UpdateService</code>, Amazon ECS spawns a task with the new version of the task definition and then stops an old task after the new version is running.</p>"
+        }
+      }
+    },
+    "UpdateServiceResponse":{
+      "type":"structure",
+      "members":{
+        "service":{
+          "shape":"Service",
+          "documentation":"<p>The full description of your service following the update call.</p>"
+        }
+      }
+    },
+    "VersionInfo":{
+      "type":"structure",
+      "members":{
+        "agentVersion":{
+          "shape":"String",
+          "documentation":"<p>The version number of the Amazon ECS container agent.</p>"
+        },
+        "agentHash":{
+          "shape":"String",
+          "documentation":"<p>The Git commit hash for the Amazon ECS container agent build on the <a href=\"https://github.com/aws/amazon-ecs-agent/commits/master\">amazon-ecs-agent </a> GitHub repository.</p>"
+        },
+        "dockerVersion":{
+          "shape":"String",
+          "documentation":"<p>The Docker version running on the container instance.</p>"
+        }
+      }
     },
     "Volume":{
       "type":"structure",

--- a/internal/model/api/inflections.csv
+++ b/internal/model/api/inflections.csv
@@ -1532,3 +1532,4 @@ Color:
 Space:
 Descending:
 Charged:
+Docker:

--- a/service/ecs/api.go
+++ b/service/ecs/api.go
@@ -5,6 +5,7 @@ package ecs
 
 import (
 	"sync"
+	"time"
 
 	"github.com/awslabs/aws-sdk-go/aws"
 )
@@ -37,8 +38,6 @@ func (c *ECS) CreateClusterRequest(input *CreateClusterInput) (req *aws.Request,
 // Creates a new Amazon ECS cluster. By default, your account will receive a
 // default cluster when you launch your first container instance. However, you
 // can create your own cluster with a unique name with the CreateCluster action.
-//
-//  During the preview, each account is limited to two clusters.
 func (c *ECS) CreateCluster(input *CreateClusterInput) (output *CreateClusterOutput, err error) {
 	req, out := c.CreateClusterRequest(input)
 	output = out
@@ -47,6 +46,41 @@ func (c *ECS) CreateCluster(input *CreateClusterInput) (output *CreateClusterOut
 }
 
 var opCreateCluster *aws.Operation
+
+// CreateServiceRequest generates a request for the CreateService operation.
+func (c *ECS) CreateServiceRequest(input *CreateServiceInput) (req *aws.Request, output *CreateServiceOutput) {
+	oprw.Lock()
+	defer oprw.Unlock()
+
+	if opCreateService == nil {
+		opCreateService = &aws.Operation{
+			Name:       "CreateService",
+			HTTPMethod: "POST",
+			HTTPPath:   "/",
+		}
+	}
+
+	if input == nil {
+		input = &CreateServiceInput{}
+	}
+
+	req = c.newRequest(opCreateService, input, output)
+	output = &CreateServiceOutput{}
+	req.Data = output
+	return
+}
+
+// Runs and maintains a desired number of tasks from a specified task definition.
+// If the number of tasks running in a service drops below desiredCount, Amazon
+// ECS will spawn another instantiation of the task in the specified cluster.
+func (c *ECS) CreateService(input *CreateServiceInput) (output *CreateServiceOutput, err error) {
+	req, out := c.CreateServiceRequest(input)
+	output = out
+	err = req.Send()
+	return
+}
+
+var opCreateService *aws.Operation
 
 // DeleteClusterRequest generates a request for the DeleteCluster operation.
 func (c *ECS) DeleteClusterRequest(input *DeleteClusterInput) (req *aws.Request, output *DeleteClusterOutput) {
@@ -82,6 +116,39 @@ func (c *ECS) DeleteCluster(input *DeleteClusterInput) (output *DeleteClusterOut
 }
 
 var opDeleteCluster *aws.Operation
+
+// DeleteServiceRequest generates a request for the DeleteService operation.
+func (c *ECS) DeleteServiceRequest(input *DeleteServiceInput) (req *aws.Request, output *DeleteServiceOutput) {
+	oprw.Lock()
+	defer oprw.Unlock()
+
+	if opDeleteService == nil {
+		opDeleteService = &aws.Operation{
+			Name:       "DeleteService",
+			HTTPMethod: "POST",
+			HTTPPath:   "/",
+		}
+	}
+
+	if input == nil {
+		input = &DeleteServiceInput{}
+	}
+
+	req = c.newRequest(opDeleteService, input, output)
+	output = &DeleteServiceOutput{}
+	req.Data = output
+	return
+}
+
+// Deletes a specified service within a cluster.
+func (c *ECS) DeleteService(input *DeleteServiceInput) (output *DeleteServiceOutput, err error) {
+	req, out := c.DeleteServiceRequest(input)
+	output = out
+	err = req.Send()
+	return
+}
+
+var opDeleteService *aws.Operation
 
 // DeregisterContainerInstanceRequest generates a request for the DeregisterContainerInstance operation.
 func (c *ECS) DeregisterContainerInstanceRequest(input *DeregisterContainerInstanceInput) (req *aws.Request, output *DeregisterContainerInstanceOutput) {
@@ -219,6 +286,39 @@ func (c *ECS) DescribeContainerInstances(input *DescribeContainerInstancesInput)
 }
 
 var opDescribeContainerInstances *aws.Operation
+
+// DescribeServicesRequest generates a request for the DescribeServices operation.
+func (c *ECS) DescribeServicesRequest(input *DescribeServicesInput) (req *aws.Request, output *DescribeServicesOutput) {
+	oprw.Lock()
+	defer oprw.Unlock()
+
+	if opDescribeServices == nil {
+		opDescribeServices = &aws.Operation{
+			Name:       "DescribeServices",
+			HTTPMethod: "POST",
+			HTTPPath:   "/",
+		}
+	}
+
+	if input == nil {
+		input = &DescribeServicesInput{}
+	}
+
+	req = c.newRequest(opDescribeServices, input, output)
+	output = &DescribeServicesOutput{}
+	req.Data = output
+	return
+}
+
+// Describes the specified services running in your cluster.
+func (c *ECS) DescribeServices(input *DescribeServicesInput) (output *DescribeServicesOutput, err error) {
+	req, out := c.DescribeServicesRequest(input)
+	output = out
+	err = req.Send()
+	return
+}
+
+var opDescribeServices *aws.Operation
 
 // DescribeTaskDefinitionRequest generates a request for the DescribeTaskDefinition operation.
 func (c *ECS) DescribeTaskDefinitionRequest(input *DescribeTaskDefinitionInput) (req *aws.Request, output *DescribeTaskDefinitionOutput) {
@@ -390,6 +490,39 @@ func (c *ECS) ListContainerInstances(input *ListContainerInstancesInput) (output
 }
 
 var opListContainerInstances *aws.Operation
+
+// ListServicesRequest generates a request for the ListServices operation.
+func (c *ECS) ListServicesRequest(input *ListServicesInput) (req *aws.Request, output *ListServicesOutput) {
+	oprw.Lock()
+	defer oprw.Unlock()
+
+	if opListServices == nil {
+		opListServices = &aws.Operation{
+			Name:       "ListServices",
+			HTTPMethod: "POST",
+			HTTPPath:   "/",
+		}
+	}
+
+	if input == nil {
+		input = &ListServicesInput{}
+	}
+
+	req = c.newRequest(opListServices, input, output)
+	output = &ListServicesOutput{}
+	req.Data = output
+	return
+}
+
+// Lists the services that are running in a specified cluster.
+func (c *ECS) ListServices(input *ListServicesInput) (output *ListServicesOutput, err error) {
+	req, out := c.ListServicesRequest(input)
+	output = out
+	err = req.Send()
+	return
+}
+
+var opListServices *aws.Operation
 
 // ListTaskDefinitionFamiliesRequest generates a request for the ListTaskDefinitionFamilies operation.
 func (c *ECS) ListTaskDefinitionFamiliesRequest(input *ListTaskDefinitionFamiliesInput) (req *aws.Request, output *ListTaskDefinitionFamiliesOutput) {
@@ -594,6 +727,8 @@ func (c *ECS) RunTaskRequest(input *RunTaskInput) (req *aws.Request, output *Run
 // Start a task using random placement and the default Amazon ECS scheduler.
 // If you want to use your own scheduler or place a task on a specific container
 // instance, use StartTask instead.
+//
+//  The count parameter is limited to 10 tasks per call.
 func (c *ECS) RunTask(input *RunTaskInput) (output *RunTaskOutput, err error) {
 	req, out := c.RunTaskRequest(input)
 	output = out
@@ -629,6 +764,8 @@ func (c *ECS) StartTaskRequest(input *StartTaskInput) (req *aws.Request, output 
 // Starts a new task from the specified task definition on the specified container
 // instance or instances. If you want to use the default Amazon ECS scheduler
 // to place your task, use RunTask instead.
+//
+//  The list of container instances to start tasks on is limited to 10.
 func (c *ECS) StartTask(input *StartTaskInput) (output *StartTaskOutput, err error) {
 	req, out := c.StartTaskRequest(input)
 	output = out
@@ -743,6 +880,53 @@ func (c *ECS) SubmitTaskStateChange(input *SubmitTaskStateChangeInput) (output *
 
 var opSubmitTaskStateChange *aws.Operation
 
+// UpdateServiceRequest generates a request for the UpdateService operation.
+func (c *ECS) UpdateServiceRequest(input *UpdateServiceInput) (req *aws.Request, output *UpdateServiceOutput) {
+	oprw.Lock()
+	defer oprw.Unlock()
+
+	if opUpdateService == nil {
+		opUpdateService = &aws.Operation{
+			Name:       "UpdateService",
+			HTTPMethod: "POST",
+			HTTPPath:   "/",
+		}
+	}
+
+	if input == nil {
+		input = &UpdateServiceInput{}
+	}
+
+	req = c.newRequest(opUpdateService, input, output)
+	output = &UpdateServiceOutput{}
+	req.Data = output
+	return
+}
+
+// Modify the desired count or task definition used in a service.
+//
+// You can add to or subtract from the number of instantiations of a task definition
+// in a service by specifying the cluster that the service is running in and
+// a new desiredCount parameter.
+//
+// You can use UpdateService to modify your task definition and deploy a new
+// version of your service, one task at a time. If you modify the task definition
+// with UpdateService, Amazon ECS spawns a task with the new version of the
+// task definition and then stops an old task after the new version is running.
+// Because UpdateService starts a new version of the task before stopping an
+// old version, your cluster must have capacity to support one more instantiation
+// of the task when UpdateService is run. If your cluster cannot support another
+// instantiation of the task used in your service, you can reduce the desired
+// count of your service by one before modifying the task definition.
+func (c *ECS) UpdateService(input *UpdateServiceInput) (output *UpdateServiceOutput, err error) {
+	req, out := c.UpdateServiceRequest(input)
+	output = out
+	err = req.Send()
+	return
+}
+
+var opUpdateService *aws.Operation
+
 // A regional grouping of one or more container instances on which you can run
 // task requests. Each account receives a default cluster the first time you
 // use the Amazon ECS service, but you may also create other clusters. Clusters
@@ -758,6 +942,15 @@ type Cluster struct {
 
 	// A user-generated string that you can use to identify your cluster.
 	ClusterName *string `locationName:"clusterName" type:"string"`
+
+	// The number of tasks in the cluster that are in the PENDING state.
+	PendingTasksCount *int64 `locationName:"pendingTasksCount" type:"integer"`
+
+	// The number of container instances registered into the cluster.
+	RegisteredContainerInstancesCount *int64 `locationName:"registeredContainerInstancesCount" type:"integer"`
+
+	// The number of tasks in the cluster that are in the RUNNING state.
+	RunningTasksCount *int64 `locationName:"runningTasksCount" type:"integer"`
 
 	// The status of the cluster. The valid values are ACTIVE or INACTIVE. ACTIVE
 	// indicates that you can register container instances with the cluster and
@@ -883,6 +1076,9 @@ type ContainerInstance struct {
 	// The Amazon EC2 instance ID of the container instance.
 	EC2InstanceID *string `locationName:"ec2InstanceId" type:"string"`
 
+	// The number of tasks on the container instance that are in the PENDING status.
+	PendingTasksCount *int64 `locationName:"pendingTasksCount" type:"integer"`
+
 	// The registered resources on the container instance that are in use by current
 	// tasks.
 	RegisteredResources []*Resource `locationName:"registeredResources" type:"list"`
@@ -890,6 +1086,9 @@ type ContainerInstance struct {
 	// The remaining resources of the container instance that are available for
 	// new tasks.
 	RemainingResources []*Resource `locationName:"remainingResources" type:"list"`
+
+	// The number of tasks on the container instance that are in the RUNNING status.
+	RunningTasksCount *int64 `locationName:"runningTasksCount" type:"integer"`
 
 	// The status of the container instance. The valid values are ACTIVE or INACTIVE.
 	// ACTIVE indicates that the container instance can accept tasks.
@@ -902,8 +1101,11 @@ type metadataContainerInstance struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// The name of a container in a task definition and the command it should run
+// instead of its default.
 type ContainerOverride struct {
-	// The command to send to the container that receives the override.
+	// The command to send to the container that overrides the default command from
+	// the Docker image or the task definition.
 	Command []*string `locationName:"command" type:"list"`
 
 	// The name of the container that receives the override.
@@ -918,7 +1120,8 @@ type metadataContainerOverride struct {
 
 type CreateClusterInput struct {
 	// The name of your cluster. If you do not specify a name for your cluster,
-	// you will create a cluster named default.
+	// you will create a cluster named default. Up to 255 letters (uppercase and
+	// lowercase), numbers, hyphens, and underscores are allowed.
 	ClusterName *string `locationName:"clusterName" type:"string"`
 
 	metadataCreateClusterInput `json:"-", xml:"-"`
@@ -936,6 +1139,57 @@ type CreateClusterOutput struct {
 }
 
 type metadataCreateClusterOutput struct {
+	SDKShapeTraits bool `type:"structure"`
+}
+
+type CreateServiceInput struct {
+	// Unique, case-sensitive identifier you provide to ensure the idempotency of
+	// the request. Up to 32 ASCII characters are allowed.
+	ClientToken *string `locationName:"clientToken" type:"string"`
+
+	// The short name or full Amazon Resource Name (ARN) of the cluster that you
+	// want to run your service on. If you do not specify a cluster, the default
+	// cluster is assumed.
+	Cluster *string `locationName:"cluster" type:"string"`
+
+	// The number of instantiations of the specified task definition that you would
+	// like to place and keep running on your cluster.
+	DesiredCount *int64 `locationName:"desiredCount" type:"integer"`
+
+	// A list of load balancer objects, containing the load balancer name, the container
+	// name (as it appears in a container definition), and the container port to
+	// access from the load balancer.
+	LoadBalancers []*LoadBalancer `locationName:"loadBalancers" type:"list"`
+
+	// The name or full Amazon Resource Name (ARN) of the IAM role that allows your
+	// Amazon ECS container agent to make calls to your load balancer on your behalf.
+	// This parameter is only required if you are using a load balancer with your
+	// service.
+	Role *string `locationName:"role" type:"string"`
+
+	// The name of your service. Up to 255 letters (uppercase and lowercase), numbers,
+	// hyphens, and underscores are allowed.
+	ServiceName *string `locationName:"serviceName" type:"string" required:"true"`
+
+	// The family and revision (family:revision) or full Amazon Resource Name (ARN)
+	// of the task definition that you want to run in your service.
+	TaskDefinition *string `locationName:"taskDefinition" type:"string"`
+
+	metadataCreateServiceInput `json:"-", xml:"-"`
+}
+
+type metadataCreateServiceInput struct {
+	SDKShapeTraits bool `type:"structure"`
+}
+
+type CreateServiceOutput struct {
+	// The full description of your service following the create call.
+	Service *Service `locationName:"service" type:"structure"`
+
+	metadataCreateServiceOutput `json:"-", xml:"-"`
+}
+
+type metadataCreateServiceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
@@ -959,6 +1213,66 @@ type DeleteClusterOutput struct {
 }
 
 type metadataDeleteClusterOutput struct {
+	SDKShapeTraits bool `type:"structure"`
+}
+
+type DeleteServiceInput struct {
+	// The name of the cluster that hosts the service you want to delete.
+	Cluster *string `locationName:"cluster" type:"string"`
+
+	// The name of the service you want to delete.
+	Service *string `locationName:"service" type:"string" required:"true"`
+
+	metadataDeleteServiceInput `json:"-", xml:"-"`
+}
+
+type metadataDeleteServiceInput struct {
+	SDKShapeTraits bool `type:"structure"`
+}
+
+type DeleteServiceOutput struct {
+	Service *Service `locationName:"service" type:"structure"`
+
+	metadataDeleteServiceOutput `json:"-", xml:"-"`
+}
+
+type metadataDeleteServiceOutput struct {
+	SDKShapeTraits bool `type:"structure"`
+}
+
+type Deployment struct {
+	// The Unix time in seconds and milliseconds when the service was created.
+	CreatedAt *time.Time `locationName:"createdAt" type:"timestamp" timestampFormat:"unix"`
+
+	// The most recent desired count of tasks that was specified for the service
+	// to deploy and/or maintain.
+	DesiredCount *int64 `locationName:"desiredCount" type:"integer"`
+
+	// The ID of the deployment.
+	ID *string `locationName:"id" type:"string"`
+
+	// The number of tasks in the deployment that are in the PENDING status.
+	PendingCount *int64 `locationName:"pendingCount" type:"integer"`
+
+	// The number of tasks in the deployment that are in the RUNNING status.
+	RunningCount *int64 `locationName:"runningCount" type:"integer"`
+
+	// The status of the deployment. Valid values are PRIMARY (for the most recent
+	// deployment), ACTIVE (for previous deployments that still have tasks running,
+	// but are being replaced with the PRIMARY deployment), and INACTIVE (for deployments
+	// that have been completely replaced).
+	Status *string `locationName:"status" type:"string"`
+
+	// The most recent task definition that was specified for the service to use.
+	TaskDefinition *string `locationName:"taskDefinition" type:"string"`
+
+	// The Unix time in seconds and milliseconds when the service was last updated.
+	UpdatedAt *time.Time `locationName:"updatedAt" type:"timestamp" timestampFormat:"unix"`
+
+	metadataDeployment `json:"-", xml:"-"`
+}
+
+type metadataDeployment struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
@@ -1075,6 +1389,34 @@ type DescribeContainerInstancesOutput struct {
 }
 
 type metadataDescribeContainerInstancesOutput struct {
+	SDKShapeTraits bool `type:"structure"`
+}
+
+type DescribeServicesInput struct {
+	// The name of the cluster that hosts the service you want to describe.
+	Cluster *string `locationName:"cluster" type:"string"`
+
+	// A list of services you want to describe.
+	Services []*string `locationName:"services" type:"list" required:"true"`
+
+	metadataDescribeServicesInput `json:"-", xml:"-"`
+}
+
+type metadataDescribeServicesInput struct {
+	SDKShapeTraits bool `type:"structure"`
+}
+
+type DescribeServicesOutput struct {
+	// Any failures associated with the call.
+	Failures []*Failure `locationName:"failures" type:"list"`
+
+	// The list of services described.
+	Services []*Service `locationName:"services" type:"list"`
+
+	metadataDescribeServicesOutput `json:"-", xml:"-"`
+}
+
+type metadataDescribeServicesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
@@ -1290,6 +1632,52 @@ type metadataListContainerInstancesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+type ListServicesInput struct {
+	// The short name or full Amazon Resource Name (ARN) of the cluster that hosts
+	// the services you want to list. If you do not specify a cluster, the default
+	// cluster is assumed..
+	Cluster *string `locationName:"cluster" type:"string"`
+
+	// The maximum number of container instance results returned by ListServices
+	// in paginated output. When this parameter is used, ListServices only returns
+	// maxResults results in a single page along with a nextToken response element.
+	// The remaining results of the initial request can be seen by sending another
+	// ListServices request with the returned nextToken value. This value can be
+	// between 1 and 100. If this parameter is not used, then ListServices returns
+	// up to 100 results and a nextToken value if applicable.
+	MaxResults *int64 `locationName:"maxResults" type:"integer"`
+
+	// The nextToken value returned from a previous paginated ListServices request
+	// where maxResults was used and the results exceeded the value of that parameter.
+	// Pagination continues from the end of the previous results that returned the
+	// nextToken value. This value is null when there are no more results to return.
+	NextToken *string `locationName:"nextToken" type:"string"`
+
+	metadataListServicesInput `json:"-", xml:"-"`
+}
+
+type metadataListServicesInput struct {
+	SDKShapeTraits bool `type:"structure"`
+}
+
+type ListServicesOutput struct {
+	// The nextToken value to include in a future ListServices request. When the
+	// results of a ListServices request exceed maxResults, this value can be used
+	// to retrieve the next page of results. This value is null when there are no
+	// more results to return.
+	NextToken *string `locationName:"nextToken" type:"string"`
+
+	// The list of full Amazon Resource Name (ARN) entries for each service associated
+	// with the specified cluster.
+	ServiceARNs []*string `locationName:"serviceArns" type:"list"`
+
+	metadataListServicesOutput `json:"-", xml:"-"`
+}
+
+type metadataListServicesOutput struct {
+	SDKShapeTraits bool `type:"structure"`
+}
+
 type ListTaskDefinitionFamiliesInput struct {
 	// The familyPrefix is a string that is used to filter the results of ListTaskDefinitionFamilies.
 	// If you specify a familyPrefix, only task definition family names that begin
@@ -1416,6 +1804,16 @@ type ListTasksInput struct {
 	// nextToken value. This value is null when there are no more results to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
+	// The name of the service that you want to filter the ListTasks results with.
+	// Specifying a serviceName will limit the results to tasks that belong to that
+	// service.
+	ServiceName *string `locationName:"serviceName" type:"string"`
+
+	// The startedBy value that you want to filter the task results with. Specifying
+	// a startedBy value will limit the results to tasks that were started with
+	// that value.
+	StartedBy *string `locationName:"startedBy" type:"string"`
+
 	metadataListTasksInput `json:"-", xml:"-"`
 }
 
@@ -1437,6 +1835,23 @@ type ListTasksOutput struct {
 }
 
 type metadataListTasksOutput struct {
+	SDKShapeTraits bool `type:"structure"`
+}
+
+type LoadBalancer struct {
+	// The name of the container to associate with the load balancer.
+	ContainerName *string `locationName:"containerName" type:"string"`
+
+	// The port on the container to associate with the load balancer.
+	ContainerPort *int64 `locationName:"containerPort" type:"integer"`
+
+	// The name of the load balancer.
+	LoadBalancerName *string `locationName:"loadBalancerName" type:"string"`
+
+	metadataLoadBalancer `json:"-", xml:"-"`
+}
+
+type metadataLoadBalancer struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
@@ -1521,6 +1936,8 @@ type RegisterContainerInstanceInput struct {
 
 	TotalResources []*Resource `locationName:"totalResources" type:"list"`
 
+	VersionInfo *VersionInfo `locationName:"versionInfo" type:"structure"`
+
 	metadataRegisterContainerInstanceInput `json:"-", xml:"-"`
 }
 
@@ -1547,7 +1964,8 @@ type RegisterTaskDefinitionInput struct {
 
 	// You must specify a family for a task definition, which allows you to track
 	// multiple versions of the same task definition. You can think of the family
-	// as a name for your task definition.
+	// as a name for your task definition. Up to 255 letters (uppercase and lowercase),
+	// numbers, hyphens, and underscores are allowed.
 	Family *string `locationName:"family" type:"string" required:"true"`
 
 	// A list of volume definitions in JSON format that containers in your task
@@ -1607,11 +2025,27 @@ type RunTaskInput struct {
 	// is assumed..
 	Cluster *string `locationName:"cluster" type:"string"`
 
-	// The number of instances of the specified task that you would like to place
-	// on your cluster.
+	// The number of instantiations of the specified task that you would like to
+	// place on your cluster.
+	//
+	//  The count parameter is limited to 10 tasks per call.
 	Count *int64 `locationName:"count" type:"integer"`
 
+	// A list of container overrides in JSON format that specify the name of a container
+	// in the specified task definition and the command it should run instead of
+	// its default. A total of 8192 characters are allowed for overrides. This limit
+	// includes the JSON formatting characters of the override structure.
 	Overrides *TaskOverride `locationName:"overrides" type:"structure"`
+
+	// An optional tag specified when a task is started. For example if you automatically
+	// trigger a task to run a batch process job, you could apply a unique identifier
+	// for that job to your task with the startedBy parameter. You can then identify
+	// which tasks belong to that job by filtering the results of a ListTasks call
+	// with the startedBy value.
+	//
+	// If a task is started by an Amazon ECS service, then the startedBy parameter
+	// contains the deployment ID of the service that starts it.
+	StartedBy *string `locationName:"startedBy" type:"string"`
 
 	// The family and revision (family:revision) or full Amazon Resource Name (ARN)
 	// of the task definition that you want to run.
@@ -1639,6 +2073,79 @@ type metadataRunTaskOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+type Service struct {
+	// The Amazon Resource Name (ARN) of the of the cluster that hosts the service.
+	ClusterARN *string `locationName:"clusterArn" type:"string"`
+
+	// The current state of deployments for the service.
+	Deployments []*Deployment `locationName:"deployments" type:"list"`
+
+	// The desired number of instantiations of the task definition to keep running
+	// on the service. This value is specified when the service is created with
+	// CreateService, and it can be modified with UpdateService.
+	DesiredCount *int64 `locationName:"desiredCount" type:"integer"`
+
+	// The event stream for your service. A maximum of 100 of the latest events
+	// are displayed.
+	Events []*ServiceEvent `locationName:"events" type:"list"`
+
+	// A list of load balancer objects, containing the load balancer name, the container
+	// name (as it appears in a container definition), and the container port to
+	// access from the load balancer.
+	LoadBalancers []*LoadBalancer `locationName:"loadBalancers" type:"list"`
+
+	// The number of tasks in the cluster that are in the PENDING state.
+	PendingCount *int64 `locationName:"pendingCount" type:"integer"`
+
+	// The Amazon Resource Name (ARN) of the IAM role associated with the service
+	// that allows the Amazon ECS container agent to register container instances
+	// with a load balancer.
+	RoleARN *string `locationName:"roleArn" type:"string"`
+
+	// The number of tasks in the cluster that are in the RUNNING state.
+	RunningCount *int64 `locationName:"runningCount" type:"integer"`
+
+	// The Amazon Resource Name (ARN) that identifies the service. The ARN contains
+	// the arn:aws:ecs namespace, followed by the region of the service, the AWS
+	// account ID of the service owner, the service namespace, and then the service
+	// name. For example, arn:aws:ecs:region:012345678910:service/my-service.
+	ServiceARN *string `locationName:"serviceArn" type:"string"`
+
+	// A user-generated string that you can use to identify your service.
+	ServiceName *string `locationName:"serviceName" type:"string"`
+
+	// The status of the service. The valid values are ACTIVE, DRAINING, or INACTIVE.
+	Status *string `locationName:"status" type:"string"`
+
+	// The task definition to use for tasks in the service. This value is specified
+	// when the service is created with CreateService, and it can be modified with
+	// UpdateService.
+	TaskDefinition *string `locationName:"taskDefinition" type:"string"`
+
+	metadataService `json:"-", xml:"-"`
+}
+
+type metadataService struct {
+	SDKShapeTraits bool `type:"structure"`
+}
+
+type ServiceEvent struct {
+	// The Unix time in seconds and milliseconds when the event was triggered.
+	CreatedAt *time.Time `locationName:"createdAt" type:"timestamp" timestampFormat:"unix"`
+
+	// The ID string of the event.
+	ID *string `locationName:"id" type:"string"`
+
+	// The event message.
+	Message *string `locationName:"message" type:"string"`
+
+	metadataServiceEvent `json:"-", xml:"-"`
+}
+
+type metadataServiceEvent struct {
+	SDKShapeTraits bool `type:"structure"`
+}
+
 type StartTaskInput struct {
 	// The short name or full Amazon Resource Name (ARN) of the cluster that you
 	// want to start your task on. If you do not specify a cluster, the default
@@ -1647,9 +2154,25 @@ type StartTaskInput struct {
 
 	// The container instance UUIDs or full Amazon Resource Name (ARN) entries for
 	// the container instances on which you would like to place your task.
+	//
+	//  The list of container instances to start tasks on is limited to 10.
 	ContainerInstances []*string `locationName:"containerInstances" type:"list" required:"true"`
 
+	// A list of container overrides in JSON format that specify the name of a container
+	// in the specified task definition and the command it should run instead of
+	// its default. A total of 8192 characters are allowed for overrides. This limit
+	// includes the JSON formatting characters of the override structure.
 	Overrides *TaskOverride `locationName:"overrides" type:"structure"`
+
+	// An optional tag specified when a task is started. For example if you automatically
+	// trigger a task to run a batch process job, you could apply a unique identifier
+	// for that job to your task with the startedBy parameter. You can then identify
+	// which tasks belong to that job by filtering the results of a ListTasks call
+	// with the startedBy value.
+	//
+	// If a task is started by an Amazon ECS service, then the startedBy parameter
+	// contains the deployment ID of the service that starts it.
+	StartedBy *string `locationName:"startedBy" type:"string"`
 
 	// The family and revision (family:revision) or full Amazon Resource Name (ARN)
 	// of the task definition that you want to start.
@@ -1798,6 +2321,11 @@ type Task struct {
 	// One or more container overrides.
 	Overrides *TaskOverride `locationName:"overrides" type:"structure"`
 
+	// The tag specified when a task is started. If the task is started by an Amazon
+	// ECS service, then the startedBy parameter contains the deployment ID of the
+	// service that starts it.
+	StartedBy *string `locationName:"startedBy" type:"string"`
+
 	// The Amazon Resource Name (ARN) of the task.
 	TaskARN *string `locationName:"taskArn" type:"string"`
 
@@ -1845,14 +2373,72 @@ type metadataTaskDefinition struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// A list of container overrides in JSON format that specify the name of a container
+// in a task definition and the command it should run instead of its default.
 type TaskOverride struct {
-	// One or more container overrides to send when running a task.
+	// One or more container overrides sent to a task.
 	ContainerOverrides []*ContainerOverride `locationName:"containerOverrides" type:"list"`
 
 	metadataTaskOverride `json:"-", xml:"-"`
 }
 
 type metadataTaskOverride struct {
+	SDKShapeTraits bool `type:"structure"`
+}
+
+type UpdateServiceInput struct {
+	// The short name or full Amazon Resource Name (ARN) of the cluster that your
+	// service is running on. If you do not specify a cluster, the default cluster
+	// is assumed.
+	Cluster *string `locationName:"cluster" type:"string"`
+
+	// The number of instantiations of the task that you would like to place and
+	// keep running in your service.
+	DesiredCount *int64 `locationName:"desiredCount" type:"integer"`
+
+	// The name of the service that you want to update.
+	Service *string `locationName:"service" type:"string" required:"true"`
+
+	// The family and revision (family:revision) or full Amazon Resource Name (ARN)
+	// of the task definition that you want to run in your service. If you modify
+	// the task definition with UpdateService, Amazon ECS spawns a task with the
+	// new version of the task definition and then stops an old task after the new
+	// version is running.
+	TaskDefinition *string `locationName:"taskDefinition" type:"string"`
+
+	metadataUpdateServiceInput `json:"-", xml:"-"`
+}
+
+type metadataUpdateServiceInput struct {
+	SDKShapeTraits bool `type:"structure"`
+}
+
+type UpdateServiceOutput struct {
+	// The full description of your service following the update call.
+	Service *Service `locationName:"service" type:"structure"`
+
+	metadataUpdateServiceOutput `json:"-", xml:"-"`
+}
+
+type metadataUpdateServiceOutput struct {
+	SDKShapeTraits bool `type:"structure"`
+}
+
+type VersionInfo struct {
+	// The Git commit hash for the Amazon ECS container agent build on the amazon-ecs-agent
+	//  (https://github.com/aws/amazon-ecs-agent/commits/master) GitHub repository.
+	AgentHash *string `locationName:"agentHash" type:"string"`
+
+	// The version number of the Amazon ECS container agent.
+	AgentVersion *string `locationName:"agentVersion" type:"string"`
+
+	// The Docker version running on the container instance.
+	DockerVersion *string `locationName:"dockerVersion" type:"string"`
+
+	metadataVersionInfo `json:"-", xml:"-"`
+}
+
+type metadataVersionInfo struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 

--- a/service/ecs/examples_test.go
+++ b/service/ecs/examples_test.go
@@ -33,6 +33,39 @@ func ExampleECS_CreateCluster() {
 	fmt.Println(awsutil.StringValue(resp))
 }
 
+func ExampleECS_CreateService() {
+	svc := ecs.New(nil)
+
+	params := &ecs.CreateServiceInput{
+		ServiceName:  aws.String("String"), // Required
+		ClientToken:  aws.String("String"),
+		Cluster:      aws.String("String"),
+		DesiredCount: aws.Long(1),
+		LoadBalancers: []*ecs.LoadBalancer{
+			&ecs.LoadBalancer{ // Required
+				ContainerName:    aws.String("String"),
+				ContainerPort:    aws.Long(1),
+				LoadBalancerName: aws.String("String"),
+			},
+			// More values...
+		},
+		Role:           aws.String("String"),
+		TaskDefinition: aws.String("String"),
+	}
+	resp, err := svc.CreateService(params)
+
+	if awserr := aws.Error(err); awserr != nil {
+		// A service error occurred.
+		fmt.Println("Error:", awserr.Code, awserr.Message)
+	} else if err != nil {
+		// A non-service error occurred.
+		panic(err)
+	}
+
+	// Pretty-print the response data.
+	fmt.Println(awsutil.StringValue(resp))
+}
+
 func ExampleECS_DeleteCluster() {
 	svc := ecs.New(nil)
 
@@ -40,6 +73,27 @@ func ExampleECS_DeleteCluster() {
 		Cluster: aws.String("String"), // Required
 	}
 	resp, err := svc.DeleteCluster(params)
+
+	if awserr := aws.Error(err); awserr != nil {
+		// A service error occurred.
+		fmt.Println("Error:", awserr.Code, awserr.Message)
+	} else if err != nil {
+		// A non-service error occurred.
+		panic(err)
+	}
+
+	// Pretty-print the response data.
+	fmt.Println(awsutil.StringValue(resp))
+}
+
+func ExampleECS_DeleteService() {
+	svc := ecs.New(nil)
+
+	params := &ecs.DeleteServiceInput{
+		Service: aws.String("String"), // Required
+		Cluster: aws.String("String"),
+	}
+	resp, err := svc.DeleteService(params)
 
 	if awserr := aws.Error(err); awserr != nil {
 		// A service error occurred.
@@ -129,6 +183,30 @@ func ExampleECS_DescribeContainerInstances() {
 		Cluster: aws.String("String"),
 	}
 	resp, err := svc.DescribeContainerInstances(params)
+
+	if awserr := aws.Error(err); awserr != nil {
+		// A service error occurred.
+		fmt.Println("Error:", awserr.Code, awserr.Message)
+	} else if err != nil {
+		// A non-service error occurred.
+		panic(err)
+	}
+
+	// Pretty-print the response data.
+	fmt.Println(awsutil.StringValue(resp))
+}
+
+func ExampleECS_DescribeServices() {
+	svc := ecs.New(nil)
+
+	params := &ecs.DescribeServicesInput{
+		Services: []*string{ // Required
+			aws.String("String"), // Required
+			// More values...
+		},
+		Cluster: aws.String("String"),
+	}
+	resp, err := svc.DescribeServices(params)
 
 	if awserr := aws.Error(err); awserr != nil {
 		// A service error occurred.
@@ -250,6 +328,28 @@ func ExampleECS_ListContainerInstances() {
 	fmt.Println(awsutil.StringValue(resp))
 }
 
+func ExampleECS_ListServices() {
+	svc := ecs.New(nil)
+
+	params := &ecs.ListServicesInput{
+		Cluster:    aws.String("String"),
+		MaxResults: aws.Long(1),
+		NextToken:  aws.String("String"),
+	}
+	resp, err := svc.ListServices(params)
+
+	if awserr := aws.Error(err); awserr != nil {
+		// A service error occurred.
+		fmt.Println("Error:", awserr.Code, awserr.Message)
+	} else if err != nil {
+		// A non-service error occurred.
+		panic(err)
+	}
+
+	// Pretty-print the response data.
+	fmt.Println(awsutil.StringValue(resp))
+}
+
 func ExampleECS_ListTaskDefinitionFamilies() {
 	svc := ecs.New(nil)
 
@@ -303,6 +403,8 @@ func ExampleECS_ListTasks() {
 		Family:            aws.String("String"),
 		MaxResults:        aws.Long(1),
 		NextToken:         aws.String("String"),
+		ServiceName:       aws.String("String"),
+		StartedBy:         aws.String("String"),
 	}
 	resp, err := svc.ListTasks(params)
 
@@ -338,6 +440,11 @@ func ExampleECS_RegisterContainerInstance() {
 				Type: aws.String("String"),
 			},
 			// More values...
+		},
+		VersionInfo: &ecs.VersionInfo{
+			AgentHash:     aws.String("String"),
+			AgentVersion:  aws.String("String"),
+			DockerVersion: aws.String("String"),
 		},
 	}
 	resp, err := svc.RegisterContainerInstance(params)
@@ -453,6 +560,7 @@ func ExampleECS_RunTask() {
 				// More values...
 			},
 		},
+		StartedBy: aws.String("String"),
 	}
 	resp, err := svc.RunTask(params)
 
@@ -490,6 +598,7 @@ func ExampleECS_StartTask() {
 				// More values...
 			},
 		},
+		StartedBy: aws.String("String"),
 	}
 	resp, err := svc.StartTask(params)
 
@@ -569,6 +678,29 @@ func ExampleECS_SubmitTaskStateChange() {
 		Task:    aws.String("String"),
 	}
 	resp, err := svc.SubmitTaskStateChange(params)
+
+	if awserr := aws.Error(err); awserr != nil {
+		// A service error occurred.
+		fmt.Println("Error:", awserr.Code, awserr.Message)
+	} else if err != nil {
+		// A non-service error occurred.
+		panic(err)
+	}
+
+	// Pretty-print the response data.
+	fmt.Println(awsutil.StringValue(resp))
+}
+
+func ExampleECS_UpdateService() {
+	svc := ecs.New(nil)
+
+	params := &ecs.UpdateServiceInput{
+		Service:        aws.String("String"), // Required
+		Cluster:        aws.String("String"),
+		DesiredCount:   aws.Long(1),
+		TaskDefinition: aws.String("String"),
+	}
+	resp, err := svc.UpdateService(params)
 
 	if awserr := aws.Error(err); awserr != nil {
 		// A service error occurred.


### PR DESCRIPTION
Similar to https://github.com/awslabs/aws-sdk-go/pull/191 but runs `go generate` to generate the Go code. Also uses the latest json api definition from [boto/botocore](http://github.com/boto/botocore) and adds the inflection for `Docker`.