### PR TITLE
Improve error reporting in IAM credentials

### DIFF
--- a/aws/credentials.go
+++ b/aws/credentials.go
@@ -246,7 +246,7 @@ func (p *iamProvider) Credentials() (*Credentials, error) {
 
 	resp, err := IAMClient.Get(metadataCredentialsEndpoint)
 	if err != nil {
-		return nil, fmt.Errorf("listing IAM credentials")
+		return nil, fmt.Errorf("%s listing IAM credentials", err)
 	}
 	defer func() {
 		_ = resp.Body.Close()


### PR DESCRIPTION
I have just hit this error and have no way of knowing what caused it.

This PR just includes the original error in the message.