### PR TITLE
Correct metadata xml tags

### DIFF
--- a/internal/fixtures/helpers/param_filler.go
+++ b/internal/fixtures/helpers/param_filler.go
@@ -51,7 +51,9 @@ func (f paramFiller) paramsStructAny(value interface{}, shape *api.Shape) string
 		}
 	case "blob":
 		v := reflect.Indirect(reflect.ValueOf(value))
-		if v.IsValid() {
+		if v.IsValid() && shape.Streaming {
+			return fmt.Sprintf("aws.ReadSeekCloser(bytes.NewBufferString(%#v))", v.Interface())
+		} else if v.IsValid() {
 			return fmt.Sprintf("[]byte(%#v)", v.Interface())
 		}
 	case "boolean":

--- a/internal/fixtures/integration/generate.go
+++ b/internal/fixtures/integration/generate.go
@@ -42,8 +42,7 @@ type TestAssertion struct {
 	Expected  interface{}
 }
 
-var tplTestSuite = template.Must(template.New("testsuite").Parse(`
-// +build integration
+var tplTestSuite = template.Must(template.New("testsuite").Parse(`// +build integration
 
 package {{ .API.PackageName }}_test
 

--- a/internal/fixtures/protocol/generate.go
+++ b/internal/fixtures/protocol/generate.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"text/template"
@@ -251,8 +252,15 @@ func GenerateTestSuite(filename string) string {
 		suite.API.Setup()
 		suite.API.Metadata.EndpointPrefix = suite.API.PackageName()
 
-		for n, s := range suite.API.Shapes {
-			s.Rename(svcPrefix + "TestShape" + n)
+		// Sort in order for deterministic test generation
+		names := make([]string, 0, len(suite.API.Shapes))
+		for n, _ := range suite.API.Shapes {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			s := suite.API.Shapes[name]
+			s.Rename(svcPrefix + "TestShape" + name)
 		}
 
 		svcCode := addImports(suite.API.ServiceGoCode())

--- a/internal/model/api/operation.go
+++ b/internal/model/api/operation.go
@@ -12,7 +12,7 @@ import (
 )
 
 type Operation struct {
-	API           *API `json: "-"`
+	API           *API `json:"-"`
 	ExportedName  string
 	Name          string
 	Documentation string

--- a/internal/model/api/shape.go
+++ b/internal/model/api/shape.go
@@ -9,8 +9,8 @@ import (
 )
 
 type ShapeRef struct {
-	API           *API   `json: "-"`
-	Shape         *Shape `json: "-"`
+	API           *API   `json:"-"`
+	Shape         *Shape `json:"-"`
 	Documentation string
 	ShapeName     string `json:"shape"`
 	Location      string
@@ -29,7 +29,7 @@ type XMLInfo struct {
 }
 
 type Shape struct {
-	API           *API `json: "-"`
+	API           *API `json:"-"`
 	ShapeName     string
 	Documentation string
 	MemberRefs    map[string]*ShapeRef `json:"members"`
@@ -256,7 +256,7 @@ func (s *Shape) GoCode() string {
 		}
 		metaStruct := "metadata" + s.ShapeName
 		ref := &ShapeRef{ShapeName: s.ShapeName, API: s.API, Shape: s}
-		code += "\n" + metaStruct + "  `json:\"-\", xml:\"-\"`\n"
+		code += "\n" + metaStruct + "  `json:\"-\" xml:\"-\"`\n"
 		code += "}\n\n"
 		code += "type " + metaStruct + " struct {\n"
 		code += "SDKShapeTraits bool " + ref.GoTags(true, false)

--- a/internal/protocol/ec2query/build_test.go
+++ b/internal/protocol/ec2query/build_test.go
@@ -95,7 +95,7 @@ func (c *InputService1ProtocolTest) InputService1TestCaseOperation1(input *Input
 var opInputService1TestCaseOperation1 *aws.Operation
 
 type InputService1TestShapeInputService1TestCaseOperation1Output struct {
-	metadataInputService1TestShapeInputService1TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService1TestShapeInputService1TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService1TestShapeInputService1TestCaseOperation1Output struct {
@@ -107,7 +107,7 @@ type InputService1TestShapeInputShape struct {
 
 	Foo *string `type:"string"`
 
-	metadataInputService1TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService1TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService1TestShapeInputShape struct {
@@ -179,7 +179,7 @@ func (c *InputService2ProtocolTest) InputService2TestCaseOperation1(input *Input
 var opInputService2TestCaseOperation1 *aws.Operation
 
 type InputService2TestShapeInputService2TestCaseOperation1Output struct {
-	metadataInputService2TestShapeInputService2TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService2TestShapeInputService2TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService2TestShapeInputService2TestCaseOperation1Output struct {
@@ -193,7 +193,7 @@ type InputService2TestShapeInputShape struct {
 
 	Yuck *string `locationName:"yuckLocationName" queryName:"yuckQueryName" type:"string"`
 
-	metadataInputService2TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService2TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService2TestShapeInputShape struct {
@@ -265,7 +265,7 @@ func (c *InputService3ProtocolTest) InputService3TestCaseOperation1(input *Input
 var opInputService3TestCaseOperation1 *aws.Operation
 
 type InputService3TestShapeInputService3TestCaseOperation1Output struct {
-	metadataInputService3TestShapeInputService3TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService3TestShapeInputService3TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService3TestShapeInputService3TestCaseOperation1Output struct {
@@ -275,7 +275,7 @@ type metadataInputService3TestShapeInputService3TestCaseOperation1Output struct 
 type InputService3TestShapeInputShape struct {
 	StructArg *InputService3TestShapeStructType `locationName:"Struct" type:"structure"`
 
-	metadataInputService3TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService3TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService3TestShapeInputShape struct {
@@ -285,7 +285,7 @@ type metadataInputService3TestShapeInputShape struct {
 type InputService3TestShapeStructType struct {
 	ScalarArg *string `locationName:"Scalar" type:"string"`
 
-	metadataInputService3TestShapeStructType `json:"-", xml:"-"`
+	metadataInputService3TestShapeStructType `json:"-" xml:"-"`
 }
 
 type metadataInputService3TestShapeStructType struct {
@@ -357,7 +357,7 @@ func (c *InputService4ProtocolTest) InputService4TestCaseOperation1(input *Input
 var opInputService4TestCaseOperation1 *aws.Operation
 
 type InputService4TestShapeInputService4TestCaseOperation1Output struct {
-	metadataInputService4TestShapeInputService4TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService4TestShapeInputService4TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService4TestShapeInputService4TestCaseOperation1Output struct {
@@ -367,7 +367,7 @@ type metadataInputService4TestShapeInputService4TestCaseOperation1Output struct 
 type InputService4TestShapeInputShape struct {
 	ListArg []*string `type:"list"`
 
-	metadataInputService4TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService4TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService4TestShapeInputShape struct {
@@ -439,7 +439,7 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation1(input *Input
 var opInputService5TestCaseOperation1 *aws.Operation
 
 type InputService5TestShapeInputService5TestCaseOperation1Output struct {
-	metadataInputService5TestShapeInputService5TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService5TestShapeInputService5TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService5TestShapeInputService5TestCaseOperation1Output struct {
@@ -449,7 +449,7 @@ type metadataInputService5TestShapeInputService5TestCaseOperation1Output struct 
 type InputService5TestShapeInputShape struct {
 	ListArg []*string `locationName:"ListMemberName" locationNameList:"item" type:"list"`
 
-	metadataInputService5TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService5TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService5TestShapeInputShape struct {
@@ -521,7 +521,7 @@ func (c *InputService6ProtocolTest) InputService6TestCaseOperation1(input *Input
 var opInputService6TestCaseOperation1 *aws.Operation
 
 type InputService6TestShapeInputService6TestCaseOperation1Output struct {
-	metadataInputService6TestShapeInputService6TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService6TestShapeInputService6TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService6TestShapeInputService6TestCaseOperation1Output struct {
@@ -531,7 +531,7 @@ type metadataInputService6TestShapeInputService6TestCaseOperation1Output struct 
 type InputService6TestShapeInputShape struct {
 	ListArg []*string `locationName:"ListMemberName" queryName:"ListQueryName" locationNameList:"item" type:"list"`
 
-	metadataInputService6TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService6TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService6TestShapeInputShape struct {
@@ -603,7 +603,7 @@ func (c *InputService7ProtocolTest) InputService7TestCaseOperation1(input *Input
 var opInputService7TestCaseOperation1 *aws.Operation
 
 type InputService7TestShapeInputService7TestCaseOperation1Output struct {
-	metadataInputService7TestShapeInputService7TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService7TestShapeInputService7TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService7TestShapeInputService7TestCaseOperation1Output struct {
@@ -613,7 +613,7 @@ type metadataInputService7TestShapeInputService7TestCaseOperation1Output struct 
 type InputService7TestShapeInputShape struct {
 	BlobArg []byte `type:"blob"`
 
-	metadataInputService7TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService7TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService7TestShapeInputShape struct {
@@ -685,7 +685,7 @@ func (c *InputService8ProtocolTest) InputService8TestCaseOperation1(input *Input
 var opInputService8TestCaseOperation1 *aws.Operation
 
 type InputService8TestShapeInputService8TestCaseOperation1Output struct {
-	metadataInputService8TestShapeInputService8TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService8TestShapeInputService8TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService8TestShapeInputService8TestCaseOperation1Output struct {
@@ -695,7 +695,7 @@ type metadataInputService8TestShapeInputService8TestCaseOperation1Output struct 
 type InputService8TestShapeInputShape struct {
 	TimeArg *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataInputService8TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService8TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService8TestShapeInputShape struct {

--- a/internal/protocol/ec2query/unmarshal_test.go
+++ b/internal/protocol/ec2query/unmarshal_test.go
@@ -67,7 +67,7 @@ func (c *OutputService1ProtocolTest) newRequest(op *aws.Operation, params, data 
 }
 
 // OutputService1TestCaseOperation1Request generates a request for the OutputService1TestCaseOperation1 operation.
-func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1Request(input *OutputService1TestShapeOutputService1TestCaseOperation1Input) (req *aws.Request, output *OutputService1TestShapeOutputService1TestShapeOutputShape) {
+func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1Request(input *OutputService1TestShapeOutputService1TestCaseOperation1Input) (req *aws.Request, output *OutputService1TestShapeOutputShape) {
 
 	if opOutputService1TestCaseOperation1 == nil {
 		opOutputService1TestCaseOperation1 = &aws.Operation{
@@ -80,12 +80,12 @@ func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1Request(inp
 	}
 
 	req = c.newRequest(opOutputService1TestCaseOperation1, input, output)
-	output = &OutputService1TestShapeOutputService1TestShapeOutputShape{}
+	output = &OutputService1TestShapeOutputShape{}
 	req.Data = output
 	return
 }
 
-func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1(input *OutputService1TestShapeOutputService1TestCaseOperation1Input) (output *OutputService1TestShapeOutputService1TestShapeOutputShape, err error) {
+func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1(input *OutputService1TestShapeOutputService1TestCaseOperation1Input) (output *OutputService1TestShapeOutputShape, err error) {
 	req, out := c.OutputService1TestCaseOperation1Request(input)
 	output = out
 	err = req.Send()
@@ -95,14 +95,14 @@ func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1(input *Out
 var opOutputService1TestCaseOperation1 *aws.Operation
 
 type OutputService1TestShapeOutputService1TestCaseOperation1Input struct {
-	metadataOutputService1TestShapeOutputService1TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService1TestShapeOutputService1TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService1TestShapeOutputService1TestCaseOperation1Input struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
-type OutputService1TestShapeOutputService1TestShapeOutputShape struct {
+type OutputService1TestShapeOutputShape struct {
 	Char *string `type:"character"`
 
 	Double *float64 `type:"double"`
@@ -119,10 +119,10 @@ type OutputService1TestShapeOutputService1TestShapeOutputShape struct {
 
 	TrueBool *bool `type:"boolean"`
 
-	metadataOutputService1TestShapeOutputService1TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService1TestShapeOutputShape `json:"-" xml:"-"`
 }
 
-type metadataOutputService1TestShapeOutputService1TestShapeOutputShape struct {
+type metadataOutputService1TestShapeOutputShape struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
@@ -191,7 +191,7 @@ func (c *OutputService2ProtocolTest) OutputService2TestCaseOperation1(input *Out
 var opOutputService2TestCaseOperation1 *aws.Operation
 
 type OutputService2TestShapeOutputService2TestCaseOperation1Input struct {
-	metadataOutputService2TestShapeOutputService2TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService2TestShapeOutputService2TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService2TestShapeOutputService2TestCaseOperation1Input struct {
@@ -201,7 +201,7 @@ type metadataOutputService2TestShapeOutputService2TestCaseOperation1Input struct
 type OutputService2TestShapeOutputShape struct {
 	Blob []byte `type:"blob"`
 
-	metadataOutputService2TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService2TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService2TestShapeOutputShape struct {
@@ -273,7 +273,7 @@ func (c *OutputService3ProtocolTest) OutputService3TestCaseOperation1(input *Out
 var opOutputService3TestCaseOperation1 *aws.Operation
 
 type OutputService3TestShapeOutputService3TestCaseOperation1Input struct {
-	metadataOutputService3TestShapeOutputService3TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService3TestShapeOutputService3TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService3TestShapeOutputService3TestCaseOperation1Input struct {
@@ -283,7 +283,7 @@ type metadataOutputService3TestShapeOutputService3TestCaseOperation1Input struct
 type OutputService3TestShapeOutputShape struct {
 	ListMember []*string `type:"list"`
 
-	metadataOutputService3TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService3TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService3TestShapeOutputShape struct {
@@ -355,7 +355,7 @@ func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation1(input *Out
 var opOutputService4TestCaseOperation1 *aws.Operation
 
 type OutputService4TestShapeOutputService4TestCaseOperation1Input struct {
-	metadataOutputService4TestShapeOutputService4TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService4TestShapeOutputService4TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService4TestShapeOutputService4TestCaseOperation1Input struct {
@@ -365,7 +365,7 @@ type metadataOutputService4TestShapeOutputService4TestCaseOperation1Input struct
 type OutputService4TestShapeOutputShape struct {
 	ListMember []*string `locationNameList:"item" type:"list"`
 
-	metadataOutputService4TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService4TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService4TestShapeOutputShape struct {
@@ -437,7 +437,7 @@ func (c *OutputService5ProtocolTest) OutputService5TestCaseOperation1(input *Out
 var opOutputService5TestCaseOperation1 *aws.Operation
 
 type OutputService5TestShapeOutputService5TestCaseOperation1Input struct {
-	metadataOutputService5TestShapeOutputService5TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService5TestShapeOutputService5TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService5TestShapeOutputService5TestCaseOperation1Input struct {
@@ -447,7 +447,7 @@ type metadataOutputService5TestShapeOutputService5TestCaseOperation1Input struct
 type OutputService5TestShapeOutputShape struct {
 	ListMember []*string `type:"list" flattened:"true"`
 
-	metadataOutputService5TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService5TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService5TestShapeOutputShape struct {
@@ -519,7 +519,7 @@ func (c *OutputService6ProtocolTest) OutputService6TestCaseOperation1(input *Out
 var opOutputService6TestCaseOperation1 *aws.Operation
 
 type OutputService6TestShapeOutputService6TestCaseOperation1Input struct {
-	metadataOutputService6TestShapeOutputService6TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService6TestShapeOutputService6TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService6TestShapeOutputService6TestCaseOperation1Input struct {
@@ -529,7 +529,7 @@ type metadataOutputService6TestShapeOutputService6TestCaseOperation1Input struct
 type OutputService6TestShapeOutputShape struct {
 	Map *map[string]*OutputService6TestShapeStructureType `type:"map"`
 
-	metadataOutputService6TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService6TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService6TestShapeOutputShape struct {
@@ -539,7 +539,7 @@ type metadataOutputService6TestShapeOutputShape struct {
 type OutputService6TestShapeStructureType struct {
 	Foo *string `locationName:"foo" type:"string"`
 
-	metadataOutputService6TestShapeStructureType `json:"-", xml:"-"`
+	metadataOutputService6TestShapeStructureType `json:"-" xml:"-"`
 }
 
 type metadataOutputService6TestShapeStructureType struct {
@@ -611,7 +611,7 @@ func (c *OutputService7ProtocolTest) OutputService7TestCaseOperation1(input *Out
 var opOutputService7TestCaseOperation1 *aws.Operation
 
 type OutputService7TestShapeOutputService7TestCaseOperation1Input struct {
-	metadataOutputService7TestShapeOutputService7TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService7TestShapeOutputService7TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService7TestShapeOutputService7TestCaseOperation1Input struct {
@@ -621,7 +621,7 @@ type metadataOutputService7TestShapeOutputService7TestCaseOperation1Input struct
 type OutputService7TestShapeOutputShape struct {
 	Map *map[string]*string `type:"map" flattened:"true"`
 
-	metadataOutputService7TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService7TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService7TestShapeOutputShape struct {
@@ -693,7 +693,7 @@ func (c *OutputService8ProtocolTest) OutputService8TestCaseOperation1(input *Out
 var opOutputService8TestCaseOperation1 *aws.Operation
 
 type OutputService8TestShapeOutputService8TestCaseOperation1Input struct {
-	metadataOutputService8TestShapeOutputService8TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService8TestShapeOutputService8TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService8TestShapeOutputService8TestCaseOperation1Input struct {
@@ -703,7 +703,7 @@ type metadataOutputService8TestShapeOutputService8TestCaseOperation1Input struct
 type OutputService8TestShapeOutputShape struct {
 	Map *map[string]*string `locationNameKey:"foo" locationNameValue:"bar" type:"map" flattened:"true"`
 
-	metadataOutputService8TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService8TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService8TestShapeOutputShape struct {

--- a/internal/protocol/jsonrpc/build_test.go
+++ b/internal/protocol/jsonrpc/build_test.go
@@ -98,7 +98,7 @@ func (c *InputService1ProtocolTest) InputService1TestCaseOperation1(input *Input
 var opInputService1TestCaseOperation1 *aws.Operation
 
 type InputService1TestShapeInputService1TestCaseOperation1Output struct {
-	metadataInputService1TestShapeInputService1TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService1TestShapeInputService1TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService1TestShapeInputService1TestCaseOperation1Output struct {
@@ -108,7 +108,7 @@ type metadataInputService1TestShapeInputService1TestCaseOperation1Output struct 
 type InputService1TestShapeInputShape struct {
 	Name *string `type:"string"`
 
-	metadataInputService1TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService1TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService1TestShapeInputShape struct {
@@ -182,7 +182,7 @@ func (c *InputService2ProtocolTest) InputService2TestCaseOperation1(input *Input
 var opInputService2TestCaseOperation1 *aws.Operation
 
 type InputService2TestShapeInputService2TestCaseOperation1Output struct {
-	metadataInputService2TestShapeInputService2TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService2TestShapeInputService2TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService2TestShapeInputService2TestCaseOperation1Output struct {
@@ -192,7 +192,7 @@ type metadataInputService2TestShapeInputService2TestCaseOperation1Output struct 
 type InputService2TestShapeInputShape struct {
 	TimeArg *time.Time `type:"timestamp" timestampFormat:"unix"`
 
-	metadataInputService2TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService2TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService2TestShapeInputShape struct {
@@ -294,7 +294,7 @@ func (c *InputService3ProtocolTest) InputService3TestCaseOperation2(input *Input
 var opInputService3TestCaseOperation2 *aws.Operation
 
 type InputService3TestShapeInputService3TestCaseOperation1Output struct {
-	metadataInputService3TestShapeInputService3TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService3TestShapeInputService3TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService3TestShapeInputService3TestCaseOperation1Output struct {
@@ -302,7 +302,7 @@ type metadataInputService3TestShapeInputService3TestCaseOperation1Output struct 
 }
 
 type InputService3TestShapeInputService3TestCaseOperation2Output struct {
-	metadataInputService3TestShapeInputService3TestCaseOperation2Output `json:"-", xml:"-"`
+	metadataInputService3TestShapeInputService3TestCaseOperation2Output `json:"-" xml:"-"`
 }
 
 type metadataInputService3TestShapeInputService3TestCaseOperation2Output struct {
@@ -314,7 +314,7 @@ type InputService3TestShapeInputShape struct {
 
 	BlobMap *map[string][]byte `type:"map"`
 
-	metadataInputService3TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService3TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService3TestShapeInputShape struct {
@@ -389,7 +389,7 @@ func (c *InputService4ProtocolTest) InputService4TestCaseOperation1(input *Input
 var opInputService4TestCaseOperation1 *aws.Operation
 
 type InputService4TestShapeInputService4TestCaseOperation1Output struct {
-	metadataInputService4TestShapeInputService4TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService4TestShapeInputService4TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService4TestShapeInputService4TestCaseOperation1Output struct {
@@ -399,7 +399,7 @@ type metadataInputService4TestShapeInputService4TestCaseOperation1Output struct 
 type InputService4TestShapeInputShape struct {
 	ListParam [][]byte `type:"list"`
 
-	metadataInputService4TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService4TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService4TestShapeInputShape struct {
@@ -445,7 +445,7 @@ func (c *InputService5ProtocolTest) newRequest(op *aws.Operation, params, data i
 }
 
 // InputService5TestCaseOperation1Request generates a request for the InputService5TestCaseOperation1 operation.
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation1Request(input *InputService5TestShapeInputShape) (req *aws.Request, output *InputService5TestShapeInputService5TestShapeInputService5TestCaseOperation1Output) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation1Request(input *InputService5TestShapeInputShape) (req *aws.Request, output *InputService5TestShapeInputService5TestCaseOperation1Output) {
 
 	if opInputService5TestCaseOperation1 == nil {
 		opInputService5TestCaseOperation1 = &aws.Operation{
@@ -458,12 +458,12 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation1Request(input
 	}
 
 	req = c.newRequest(opInputService5TestCaseOperation1, input, output)
-	output = &InputService5TestShapeInputService5TestShapeInputService5TestCaseOperation1Output{}
+	output = &InputService5TestShapeInputService5TestCaseOperation1Output{}
 	req.Data = output
 	return
 }
 
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation1(input *InputService5TestShapeInputShape) (output *InputService5TestShapeInputService5TestShapeInputService5TestCaseOperation1Output, err error) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation1(input *InputService5TestShapeInputShape) (output *InputService5TestShapeInputService5TestCaseOperation1Output, err error) {
 	req, out := c.InputService5TestCaseOperation1Request(input)
 	output = out
 	err = req.Send()
@@ -473,7 +473,7 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation1(input *Input
 var opInputService5TestCaseOperation1 *aws.Operation
 
 // InputService5TestCaseOperation2Request generates a request for the InputService5TestCaseOperation2 operation.
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation2Request(input *InputService5TestShapeInputShape) (req *aws.Request, output *InputService5TestShapeInputService5TestCaseOperation2Output) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation2Request(input *InputService5TestShapeInputShape) (req *aws.Request, output *InputService5TestShapeInputService5TestShapeInputService5TestCaseOperation2Output) {
 
 	if opInputService5TestCaseOperation2 == nil {
 		opInputService5TestCaseOperation2 = &aws.Operation{
@@ -486,12 +486,12 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation2Request(input
 	}
 
 	req = c.newRequest(opInputService5TestCaseOperation2, input, output)
-	output = &InputService5TestShapeInputService5TestCaseOperation2Output{}
+	output = &InputService5TestShapeInputService5TestShapeInputService5TestCaseOperation2Output{}
 	req.Data = output
 	return
 }
 
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation2(input *InputService5TestShapeInputShape) (output *InputService5TestShapeInputService5TestCaseOperation2Output, err error) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation2(input *InputService5TestShapeInputShape) (output *InputService5TestShapeInputService5TestShapeInputService5TestCaseOperation2Output, err error) {
 	req, out := c.InputService5TestCaseOperation2Request(input)
 	output = out
 	err = req.Send()
@@ -585,7 +585,7 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation5(input *Input
 var opInputService5TestCaseOperation5 *aws.Operation
 
 // InputService5TestCaseOperation6Request generates a request for the InputService5TestCaseOperation6 operation.
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation6Request(input *InputService5TestShapeInputShape) (req *aws.Request, output *InputService5TestShapeInputService5TestCaseOperation6Output) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation6Request(input *InputService5TestShapeInputShape) (req *aws.Request, output *InputService5TestShapeInputService5TestShapeInputService5TestCaseOperation6Output) {
 
 	if opInputService5TestCaseOperation6 == nil {
 		opInputService5TestCaseOperation6 = &aws.Operation{
@@ -598,12 +598,12 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation6Request(input
 	}
 
 	req = c.newRequest(opInputService5TestCaseOperation6, input, output)
-	output = &InputService5TestShapeInputService5TestCaseOperation6Output{}
+	output = &InputService5TestShapeInputService5TestShapeInputService5TestCaseOperation6Output{}
 	req.Data = output
 	return
 }
 
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation6(input *InputService5TestShapeInputShape) (output *InputService5TestShapeInputService5TestCaseOperation6Output, err error) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation6(input *InputService5TestShapeInputShape) (output *InputService5TestShapeInputService5TestShapeInputService5TestCaseOperation6Output, err error) {
 	req, out := c.InputService5TestCaseOperation6Request(input)
 	output = out
 	err = req.Send()
@@ -612,16 +612,16 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation6(input *Input
 
 var opInputService5TestCaseOperation6 *aws.Operation
 
-type InputService5TestShapeInputService5TestCaseOperation2Output struct {
-	metadataInputService5TestShapeInputService5TestCaseOperation2Output `json:"-", xml:"-"`
+type InputService5TestShapeInputService5TestCaseOperation1Output struct {
+	metadataInputService5TestShapeInputService5TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
-type metadataInputService5TestShapeInputService5TestCaseOperation2Output struct {
+type metadataInputService5TestShapeInputService5TestCaseOperation1Output struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
 type InputService5TestShapeInputService5TestCaseOperation3Output struct {
-	metadataInputService5TestShapeInputService5TestCaseOperation3Output `json:"-", xml:"-"`
+	metadataInputService5TestShapeInputService5TestCaseOperation3Output `json:"-" xml:"-"`
 }
 
 type metadataInputService5TestShapeInputService5TestCaseOperation3Output struct {
@@ -629,7 +629,7 @@ type metadataInputService5TestShapeInputService5TestCaseOperation3Output struct 
 }
 
 type InputService5TestShapeInputService5TestCaseOperation4Output struct {
-	metadataInputService5TestShapeInputService5TestCaseOperation4Output `json:"-", xml:"-"`
+	metadataInputService5TestShapeInputService5TestCaseOperation4Output `json:"-" xml:"-"`
 }
 
 type metadataInputService5TestShapeInputService5TestCaseOperation4Output struct {
@@ -637,26 +637,26 @@ type metadataInputService5TestShapeInputService5TestCaseOperation4Output struct 
 }
 
 type InputService5TestShapeInputService5TestCaseOperation5Output struct {
-	metadataInputService5TestShapeInputService5TestCaseOperation5Output `json:"-", xml:"-"`
+	metadataInputService5TestShapeInputService5TestCaseOperation5Output `json:"-" xml:"-"`
 }
 
 type metadataInputService5TestShapeInputService5TestCaseOperation5Output struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
-type InputService5TestShapeInputService5TestCaseOperation6Output struct {
-	metadataInputService5TestShapeInputService5TestCaseOperation6Output `json:"-", xml:"-"`
+type InputService5TestShapeInputService5TestShapeInputService5TestCaseOperation2Output struct {
+	metadataInputService5TestShapeInputService5TestShapeInputService5TestCaseOperation2Output `json:"-" xml:"-"`
 }
 
-type metadataInputService5TestShapeInputService5TestCaseOperation6Output struct {
+type metadataInputService5TestShapeInputService5TestShapeInputService5TestCaseOperation2Output struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
-type InputService5TestShapeInputService5TestShapeInputService5TestCaseOperation1Output struct {
-	metadataInputService5TestShapeInputService5TestShapeInputService5TestCaseOperation1Output `json:"-", xml:"-"`
+type InputService5TestShapeInputService5TestShapeInputService5TestCaseOperation6Output struct {
+	metadataInputService5TestShapeInputService5TestShapeInputService5TestCaseOperation6Output `json:"-" xml:"-"`
 }
 
-type metadataInputService5TestShapeInputService5TestShapeInputService5TestCaseOperation1Output struct {
+type metadataInputService5TestShapeInputService5TestShapeInputService5TestCaseOperation6Output struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
@@ -669,7 +669,7 @@ type InputService5TestShapeInputService5TestShapeRecursiveStructType struct {
 
 	RecursiveStruct *InputService5TestShapeInputService5TestShapeRecursiveStructType `type:"structure"`
 
-	metadataInputService5TestShapeInputService5TestShapeRecursiveStructType `json:"-", xml:"-"`
+	metadataInputService5TestShapeInputService5TestShapeRecursiveStructType `json:"-" xml:"-"`
 }
 
 type metadataInputService5TestShapeInputService5TestShapeRecursiveStructType struct {
@@ -679,7 +679,7 @@ type metadataInputService5TestShapeInputService5TestShapeRecursiveStructType str
 type InputService5TestShapeInputShape struct {
 	RecursiveStruct *InputService5TestShapeInputService5TestShapeRecursiveStructType `type:"structure"`
 
-	metadataInputService5TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService5TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService5TestShapeInputShape struct {

--- a/internal/protocol/jsonrpc/build_test.go
+++ b/internal/protocol/jsonrpc/build_test.go
@@ -473,7 +473,7 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation1(input *Input
 var opInputService5TestCaseOperation1 *aws.Operation
 
 // InputService5TestCaseOperation2Request generates a request for the InputService5TestCaseOperation2 operation.
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation2Request(input *InputService5TestShapeInputShape) (req *aws.Request, output *InputService5TestShapeInputService5TestShapeInputService5TestCaseOperation2Output) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation2Request(input *InputService5TestShapeInputShape) (req *aws.Request, output *InputService5TestShapeInputService5TestCaseOperation2Output) {
 
 	if opInputService5TestCaseOperation2 == nil {
 		opInputService5TestCaseOperation2 = &aws.Operation{
@@ -486,12 +486,12 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation2Request(input
 	}
 
 	req = c.newRequest(opInputService5TestCaseOperation2, input, output)
-	output = &InputService5TestShapeInputService5TestShapeInputService5TestCaseOperation2Output{}
+	output = &InputService5TestShapeInputService5TestCaseOperation2Output{}
 	req.Data = output
 	return
 }
 
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation2(input *InputService5TestShapeInputShape) (output *InputService5TestShapeInputService5TestShapeInputService5TestCaseOperation2Output, err error) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation2(input *InputService5TestShapeInputShape) (output *InputService5TestShapeInputService5TestCaseOperation2Output, err error) {
 	req, out := c.InputService5TestCaseOperation2Request(input)
 	output = out
 	err = req.Send()
@@ -585,7 +585,7 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation5(input *Input
 var opInputService5TestCaseOperation5 *aws.Operation
 
 // InputService5TestCaseOperation6Request generates a request for the InputService5TestCaseOperation6 operation.
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation6Request(input *InputService5TestShapeInputShape) (req *aws.Request, output *InputService5TestShapeInputService5TestShapeInputService5TestCaseOperation6Output) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation6Request(input *InputService5TestShapeInputShape) (req *aws.Request, output *InputService5TestShapeInputService5TestCaseOperation6Output) {
 
 	if opInputService5TestCaseOperation6 == nil {
 		opInputService5TestCaseOperation6 = &aws.Operation{
@@ -598,12 +598,12 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation6Request(input
 	}
 
 	req = c.newRequest(opInputService5TestCaseOperation6, input, output)
-	output = &InputService5TestShapeInputService5TestShapeInputService5TestCaseOperation6Output{}
+	output = &InputService5TestShapeInputService5TestCaseOperation6Output{}
 	req.Data = output
 	return
 }
 
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation6(input *InputService5TestShapeInputShape) (output *InputService5TestShapeInputService5TestShapeInputService5TestCaseOperation6Output, err error) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation6(input *InputService5TestShapeInputShape) (output *InputService5TestShapeInputService5TestCaseOperation6Output, err error) {
 	req, out := c.InputService5TestCaseOperation6Request(input)
 	output = out
 	err = req.Send()
@@ -617,6 +617,14 @@ type InputService5TestShapeInputService5TestCaseOperation1Output struct {
 }
 
 type metadataInputService5TestShapeInputService5TestCaseOperation1Output struct {
+	SDKShapeTraits bool `type:"structure"`
+}
+
+type InputService5TestShapeInputService5TestCaseOperation2Output struct {
+	metadataInputService5TestShapeInputService5TestCaseOperation2Output `json:"-" xml:"-"`
+}
+
+type metadataInputService5TestShapeInputService5TestCaseOperation2Output struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
@@ -644,45 +652,37 @@ type metadataInputService5TestShapeInputService5TestCaseOperation5Output struct 
 	SDKShapeTraits bool `type:"structure"`
 }
 
-type InputService5TestShapeInputService5TestShapeInputService5TestCaseOperation2Output struct {
-	metadataInputService5TestShapeInputService5TestShapeInputService5TestCaseOperation2Output `json:"-" xml:"-"`
+type InputService5TestShapeInputService5TestCaseOperation6Output struct {
+	metadataInputService5TestShapeInputService5TestCaseOperation6Output `json:"-" xml:"-"`
 }
 
-type metadataInputService5TestShapeInputService5TestShapeInputService5TestCaseOperation2Output struct {
-	SDKShapeTraits bool `type:"structure"`
-}
-
-type InputService5TestShapeInputService5TestShapeInputService5TestCaseOperation6Output struct {
-	metadataInputService5TestShapeInputService5TestShapeInputService5TestCaseOperation6Output `json:"-" xml:"-"`
-}
-
-type metadataInputService5TestShapeInputService5TestShapeInputService5TestCaseOperation6Output struct {
-	SDKShapeTraits bool `type:"structure"`
-}
-
-type InputService5TestShapeInputService5TestShapeRecursiveStructType struct {
-	NoRecurse *string `type:"string"`
-
-	RecursiveList []*InputService5TestShapeInputService5TestShapeRecursiveStructType `type:"list"`
-
-	RecursiveMap *map[string]*InputService5TestShapeInputService5TestShapeRecursiveStructType `type:"map"`
-
-	RecursiveStruct *InputService5TestShapeInputService5TestShapeRecursiveStructType `type:"structure"`
-
-	metadataInputService5TestShapeInputService5TestShapeRecursiveStructType `json:"-" xml:"-"`
-}
-
-type metadataInputService5TestShapeInputService5TestShapeRecursiveStructType struct {
+type metadataInputService5TestShapeInputService5TestCaseOperation6Output struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
 type InputService5TestShapeInputShape struct {
-	RecursiveStruct *InputService5TestShapeInputService5TestShapeRecursiveStructType `type:"structure"`
+	RecursiveStruct *InputService5TestShapeRecursiveStructType `type:"structure"`
 
 	metadataInputService5TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService5TestShapeInputShape struct {
+	SDKShapeTraits bool `type:"structure"`
+}
+
+type InputService5TestShapeRecursiveStructType struct {
+	NoRecurse *string `type:"string"`
+
+	RecursiveList []*InputService5TestShapeRecursiveStructType `type:"list"`
+
+	RecursiveMap *map[string]*InputService5TestShapeRecursiveStructType `type:"map"`
+
+	RecursiveStruct *InputService5TestShapeRecursiveStructType `type:"structure"`
+
+	metadataInputService5TestShapeRecursiveStructType `json:"-" xml:"-"`
+}
+
+type metadataInputService5TestShapeRecursiveStructType struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
@@ -841,7 +841,7 @@ func TestInputService5ProtocolTestRecursiveShapesCase1(t *testing.T) {
 	svc.Endpoint = "https://test"
 
 	input := &InputService5TestShapeInputShape{
-		RecursiveStruct: &InputService5TestShapeInputService5TestShapeRecursiveStructType{
+		RecursiveStruct: &InputService5TestShapeRecursiveStructType{
 			NoRecurse: aws.String("foo"),
 		},
 	}
@@ -871,8 +871,8 @@ func TestInputService5ProtocolTestRecursiveShapesCase2(t *testing.T) {
 	svc.Endpoint = "https://test"
 
 	input := &InputService5TestShapeInputShape{
-		RecursiveStruct: &InputService5TestShapeInputService5TestShapeRecursiveStructType{
-			RecursiveStruct: &InputService5TestShapeInputService5TestShapeRecursiveStructType{
+		RecursiveStruct: &InputService5TestShapeRecursiveStructType{
+			RecursiveStruct: &InputService5TestShapeRecursiveStructType{
 				NoRecurse: aws.String("foo"),
 			},
 		},
@@ -903,10 +903,10 @@ func TestInputService5ProtocolTestRecursiveShapesCase3(t *testing.T) {
 	svc.Endpoint = "https://test"
 
 	input := &InputService5TestShapeInputShape{
-		RecursiveStruct: &InputService5TestShapeInputService5TestShapeRecursiveStructType{
-			RecursiveStruct: &InputService5TestShapeInputService5TestShapeRecursiveStructType{
-				RecursiveStruct: &InputService5TestShapeInputService5TestShapeRecursiveStructType{
-					RecursiveStruct: &InputService5TestShapeInputService5TestShapeRecursiveStructType{
+		RecursiveStruct: &InputService5TestShapeRecursiveStructType{
+			RecursiveStruct: &InputService5TestShapeRecursiveStructType{
+				RecursiveStruct: &InputService5TestShapeRecursiveStructType{
+					RecursiveStruct: &InputService5TestShapeRecursiveStructType{
 						NoRecurse: aws.String("foo"),
 					},
 				},
@@ -939,12 +939,12 @@ func TestInputService5ProtocolTestRecursiveShapesCase4(t *testing.T) {
 	svc.Endpoint = "https://test"
 
 	input := &InputService5TestShapeInputShape{
-		RecursiveStruct: &InputService5TestShapeInputService5TestShapeRecursiveStructType{
-			RecursiveList: []*InputService5TestShapeInputService5TestShapeRecursiveStructType{
-				&InputService5TestShapeInputService5TestShapeRecursiveStructType{
+		RecursiveStruct: &InputService5TestShapeRecursiveStructType{
+			RecursiveList: []*InputService5TestShapeRecursiveStructType{
+				&InputService5TestShapeRecursiveStructType{
 					NoRecurse: aws.String("foo"),
 				},
-				&InputService5TestShapeInputService5TestShapeRecursiveStructType{
+				&InputService5TestShapeRecursiveStructType{
 					NoRecurse: aws.String("bar"),
 				},
 			},
@@ -976,13 +976,13 @@ func TestInputService5ProtocolTestRecursiveShapesCase5(t *testing.T) {
 	svc.Endpoint = "https://test"
 
 	input := &InputService5TestShapeInputShape{
-		RecursiveStruct: &InputService5TestShapeInputService5TestShapeRecursiveStructType{
-			RecursiveList: []*InputService5TestShapeInputService5TestShapeRecursiveStructType{
-				&InputService5TestShapeInputService5TestShapeRecursiveStructType{
+		RecursiveStruct: &InputService5TestShapeRecursiveStructType{
+			RecursiveList: []*InputService5TestShapeRecursiveStructType{
+				&InputService5TestShapeRecursiveStructType{
 					NoRecurse: aws.String("foo"),
 				},
-				&InputService5TestShapeInputService5TestShapeRecursiveStructType{
-					RecursiveStruct: &InputService5TestShapeInputService5TestShapeRecursiveStructType{
+				&InputService5TestShapeRecursiveStructType{
+					RecursiveStruct: &InputService5TestShapeRecursiveStructType{
 						NoRecurse: aws.String("bar"),
 					},
 				},
@@ -1015,12 +1015,12 @@ func TestInputService5ProtocolTestRecursiveShapesCase6(t *testing.T) {
 	svc.Endpoint = "https://test"
 
 	input := &InputService5TestShapeInputShape{
-		RecursiveStruct: &InputService5TestShapeInputService5TestShapeRecursiveStructType{
-			RecursiveMap: &map[string]*InputService5TestShapeInputService5TestShapeRecursiveStructType{
-				"bar": &InputService5TestShapeInputService5TestShapeRecursiveStructType{
+		RecursiveStruct: &InputService5TestShapeRecursiveStructType{
+			RecursiveMap: &map[string]*InputService5TestShapeRecursiveStructType{
+				"bar": &InputService5TestShapeRecursiveStructType{
 					NoRecurse: aws.String("bar"),
 				},
-				"foo": &InputService5TestShapeInputService5TestShapeRecursiveStructType{
+				"foo": &InputService5TestShapeRecursiveStructType{
 					NoRecurse: aws.String("foo"),
 				},
 			},

--- a/internal/protocol/jsonrpc/unmarshal_test.go
+++ b/internal/protocol/jsonrpc/unmarshal_test.go
@@ -97,7 +97,7 @@ func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1(input *Out
 var opOutputService1TestCaseOperation1 *aws.Operation
 
 type OutputService1TestShapeOutputService1TestCaseOperation1Input struct {
-	metadataOutputService1TestShapeOutputService1TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService1TestShapeOutputService1TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService1TestShapeOutputService1TestCaseOperation1Input struct {
@@ -105,7 +105,7 @@ type metadataOutputService1TestShapeOutputService1TestCaseOperation1Input struct
 }
 
 type OutputService1TestShapeOutputShape struct {
-	metadataOutputService1TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService1TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService1TestShapeOutputShape struct {
@@ -179,7 +179,7 @@ func (c *OutputService2ProtocolTest) OutputService2TestCaseOperation1(input *Out
 var opOutputService2TestCaseOperation1 *aws.Operation
 
 type OutputService2TestShapeOutputService2TestCaseOperation1Input struct {
-	metadataOutputService2TestShapeOutputService2TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService2TestShapeOutputService2TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService2TestShapeOutputService2TestCaseOperation1Input struct {
@@ -203,7 +203,7 @@ type OutputService2TestShapeOutputShape struct {
 
 	TrueBool *bool `type:"boolean"`
 
-	metadataOutputService2TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService2TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService2TestShapeOutputShape struct {
@@ -279,7 +279,7 @@ var opOutputService3TestCaseOperation1 *aws.Operation
 type OutputService3TestShapeBlobContainer struct {
 	Foo []byte `locationName:"foo" type:"blob"`
 
-	metadataOutputService3TestShapeBlobContainer `json:"-", xml:"-"`
+	metadataOutputService3TestShapeBlobContainer `json:"-" xml:"-"`
 }
 
 type metadataOutputService3TestShapeBlobContainer struct {
@@ -287,7 +287,7 @@ type metadataOutputService3TestShapeBlobContainer struct {
 }
 
 type OutputService3TestShapeOutputService3TestCaseOperation1Input struct {
-	metadataOutputService3TestShapeOutputService3TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService3TestShapeOutputService3TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService3TestShapeOutputService3TestCaseOperation1Input struct {
@@ -299,7 +299,7 @@ type OutputService3TestShapeOutputShape struct {
 
 	StructMember *OutputService3TestShapeBlobContainer `type:"structure"`
 
-	metadataOutputService3TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService3TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService3TestShapeOutputShape struct {
@@ -373,7 +373,7 @@ func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation1(input *Out
 var opOutputService4TestCaseOperation1 *aws.Operation
 
 type OutputService4TestShapeOutputService4TestCaseOperation1Input struct {
-	metadataOutputService4TestShapeOutputService4TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService4TestShapeOutputService4TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService4TestShapeOutputService4TestCaseOperation1Input struct {
@@ -385,7 +385,7 @@ type OutputService4TestShapeOutputShape struct {
 
 	TimeMember *time.Time `type:"timestamp" timestampFormat:"unix"`
 
-	metadataOutputService4TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService4TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService4TestShapeOutputShape struct {
@@ -395,7 +395,7 @@ type metadataOutputService4TestShapeOutputShape struct {
 type OutputService4TestShapeTimeContainer struct {
 	Foo *time.Time `locationName:"foo" type:"timestamp" timestampFormat:"unix"`
 
-	metadataOutputService4TestShapeTimeContainer `json:"-", xml:"-"`
+	metadataOutputService4TestShapeTimeContainer `json:"-" xml:"-"`
 }
 
 type metadataOutputService4TestShapeTimeContainer struct {
@@ -469,7 +469,7 @@ func (c *OutputService5ProtocolTest) OutputService5TestCaseOperation1(input *Out
 var opOutputService5TestCaseOperation1 *aws.Operation
 
 type OutputService5TestShapeOutputService5TestCaseOperation1Input struct {
-	metadataOutputService5TestShapeOutputService5TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService5TestShapeOutputService5TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService5TestShapeOutputService5TestCaseOperation1Input struct {
@@ -479,7 +479,7 @@ type metadataOutputService5TestShapeOutputService5TestCaseOperation1Input struct
 type OutputService5TestShapeOutputShape struct {
 	ListMember []*string `type:"list"`
 
-	metadataOutputService5TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService5TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService5TestShapeOutputShape struct {
@@ -553,7 +553,7 @@ func (c *OutputService6ProtocolTest) OutputService6TestCaseOperation1(input *Out
 var opOutputService6TestCaseOperation1 *aws.Operation
 
 type OutputService6TestShapeOutputService6TestCaseOperation1Input struct {
-	metadataOutputService6TestShapeOutputService6TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService6TestShapeOutputService6TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService6TestShapeOutputService6TestCaseOperation1Input struct {
@@ -563,7 +563,7 @@ type metadataOutputService6TestShapeOutputService6TestCaseOperation1Input struct
 type OutputService6TestShapeOutputShape struct {
 	MapMember *map[string][]*int64 `type:"map"`
 
-	metadataOutputService6TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService6TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService6TestShapeOutputShape struct {
@@ -637,7 +637,7 @@ func (c *OutputService7ProtocolTest) OutputService7TestCaseOperation1(input *Out
 var opOutputService7TestCaseOperation1 *aws.Operation
 
 type OutputService7TestShapeOutputService7TestCaseOperation1Input struct {
-	metadataOutputService7TestShapeOutputService7TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService7TestShapeOutputService7TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService7TestShapeOutputService7TestCaseOperation1Input struct {
@@ -647,7 +647,7 @@ type metadataOutputService7TestShapeOutputService7TestCaseOperation1Input struct
 type OutputService7TestShapeOutputShape struct {
 	StrType *string `type:"string"`
 
-	metadataOutputService7TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService7TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService7TestShapeOutputShape struct {

--- a/internal/protocol/query/build_test.go
+++ b/internal/protocol/query/build_test.go
@@ -95,7 +95,7 @@ func (c *InputService1ProtocolTest) InputService1TestCaseOperation1(input *Input
 var opInputService1TestCaseOperation1 *aws.Operation
 
 type InputService1TestShapeInputService1TestCaseOperation1Output struct {
-	metadataInputService1TestShapeInputService1TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService1TestShapeInputService1TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService1TestShapeInputService1TestCaseOperation1Output struct {
@@ -107,7 +107,7 @@ type InputService1TestShapeInputShape struct {
 
 	Foo *string `type:"string"`
 
-	metadataInputService1TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService1TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService1TestShapeInputShape struct {
@@ -179,7 +179,7 @@ func (c *InputService2ProtocolTest) InputService2TestCaseOperation1(input *Input
 var opInputService2TestCaseOperation1 *aws.Operation
 
 type InputService2TestShapeInputService2TestCaseOperation1Output struct {
-	metadataInputService2TestShapeInputService2TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService2TestShapeInputService2TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService2TestShapeInputService2TestCaseOperation1Output struct {
@@ -189,7 +189,7 @@ type metadataInputService2TestShapeInputService2TestCaseOperation1Output struct 
 type InputService2TestShapeInputShape struct {
 	StructArg *InputService2TestShapeStructType `type:"structure"`
 
-	metadataInputService2TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService2TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService2TestShapeInputShape struct {
@@ -199,7 +199,7 @@ type metadataInputService2TestShapeInputShape struct {
 type InputService2TestShapeStructType struct {
 	ScalarArg *string `type:"string"`
 
-	metadataInputService2TestShapeStructType `json:"-", xml:"-"`
+	metadataInputService2TestShapeStructType `json:"-" xml:"-"`
 }
 
 type metadataInputService2TestShapeStructType struct {
@@ -299,7 +299,7 @@ func (c *InputService3ProtocolTest) InputService3TestCaseOperation2(input *Input
 var opInputService3TestCaseOperation2 *aws.Operation
 
 type InputService3TestShapeInputService3TestCaseOperation1Output struct {
-	metadataInputService3TestShapeInputService3TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService3TestShapeInputService3TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService3TestShapeInputService3TestCaseOperation1Output struct {
@@ -307,7 +307,7 @@ type metadataInputService3TestShapeInputService3TestCaseOperation1Output struct 
 }
 
 type InputService3TestShapeInputService3TestCaseOperation2Output struct {
-	metadataInputService3TestShapeInputService3TestCaseOperation2Output `json:"-", xml:"-"`
+	metadataInputService3TestShapeInputService3TestCaseOperation2Output `json:"-" xml:"-"`
 }
 
 type metadataInputService3TestShapeInputService3TestCaseOperation2Output struct {
@@ -317,7 +317,7 @@ type metadataInputService3TestShapeInputService3TestCaseOperation2Output struct 
 type InputService3TestShapeInputShape struct {
 	ListArg []*string `type:"list"`
 
-	metadataInputService3TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService3TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService3TestShapeInputShape struct {
@@ -417,7 +417,7 @@ func (c *InputService4ProtocolTest) InputService4TestCaseOperation2(input *Input
 var opInputService4TestCaseOperation2 *aws.Operation
 
 type InputService4TestShapeInputService4TestCaseOperation1Output struct {
-	metadataInputService4TestShapeInputService4TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService4TestShapeInputService4TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService4TestShapeInputService4TestCaseOperation1Output struct {
@@ -425,7 +425,7 @@ type metadataInputService4TestShapeInputService4TestCaseOperation1Output struct 
 }
 
 type InputService4TestShapeInputService4TestCaseOperation2Output struct {
-	metadataInputService4TestShapeInputService4TestCaseOperation2Output `json:"-", xml:"-"`
+	metadataInputService4TestShapeInputService4TestCaseOperation2Output `json:"-" xml:"-"`
 }
 
 type metadataInputService4TestShapeInputService4TestCaseOperation2Output struct {
@@ -437,7 +437,7 @@ type InputService4TestShapeInputShape struct {
 
 	ScalarArg *string `type:"string"`
 
-	metadataInputService4TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService4TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService4TestShapeInputShape struct {
@@ -537,7 +537,7 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation2(input *Input
 var opInputService5TestCaseOperation2 *aws.Operation
 
 type InputService5TestShapeInputService5TestCaseOperation1Output struct {
-	metadataInputService5TestShapeInputService5TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService5TestShapeInputService5TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService5TestShapeInputService5TestCaseOperation1Output struct {
@@ -545,7 +545,7 @@ type metadataInputService5TestShapeInputService5TestCaseOperation1Output struct 
 }
 
 type InputService5TestShapeInputService5TestCaseOperation2Output struct {
-	metadataInputService5TestShapeInputService5TestCaseOperation2Output `json:"-", xml:"-"`
+	metadataInputService5TestShapeInputService5TestCaseOperation2Output `json:"-" xml:"-"`
 }
 
 type metadataInputService5TestShapeInputService5TestCaseOperation2Output struct {
@@ -555,7 +555,7 @@ type metadataInputService5TestShapeInputService5TestCaseOperation2Output struct 
 type InputService5TestShapeInputShape struct {
 	MapArg *map[string]*string `type:"map"`
 
-	metadataInputService5TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService5TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService5TestShapeInputShape struct {
@@ -627,7 +627,7 @@ func (c *InputService6ProtocolTest) InputService6TestCaseOperation1(input *Input
 var opInputService6TestCaseOperation1 *aws.Operation
 
 type InputService6TestShapeInputService6TestCaseOperation1Output struct {
-	metadataInputService6TestShapeInputService6TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService6TestShapeInputService6TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService6TestShapeInputService6TestCaseOperation1Output struct {
@@ -637,7 +637,7 @@ type metadataInputService6TestShapeInputService6TestCaseOperation1Output struct 
 type InputService6TestShapeInputShape struct {
 	MapArg *map[string]*string `locationNameKey:"TheKey" locationNameValue:"TheValue" type:"map"`
 
-	metadataInputService6TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService6TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService6TestShapeInputShape struct {
@@ -709,7 +709,7 @@ func (c *InputService7ProtocolTest) InputService7TestCaseOperation1(input *Input
 var opInputService7TestCaseOperation1 *aws.Operation
 
 type InputService7TestShapeInputService7TestCaseOperation1Output struct {
-	metadataInputService7TestShapeInputService7TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService7TestShapeInputService7TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService7TestShapeInputService7TestCaseOperation1Output struct {
@@ -719,7 +719,7 @@ type metadataInputService7TestShapeInputService7TestCaseOperation1Output struct 
 type InputService7TestShapeInputShape struct {
 	BlobArg []byte `type:"blob"`
 
-	metadataInputService7TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService7TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService7TestShapeInputShape struct {
@@ -791,7 +791,7 @@ func (c *InputService8ProtocolTest) InputService8TestCaseOperation1(input *Input
 var opInputService8TestCaseOperation1 *aws.Operation
 
 type InputService8TestShapeInputService8TestCaseOperation1Output struct {
-	metadataInputService8TestShapeInputService8TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService8TestShapeInputService8TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService8TestShapeInputService8TestCaseOperation1Output struct {
@@ -801,7 +801,7 @@ type metadataInputService8TestShapeInputService8TestCaseOperation1Output struct 
 type InputService8TestShapeInputShape struct {
 	TimeArg *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataInputService8TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService8TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService8TestShapeInputShape struct {
@@ -957,7 +957,7 @@ func (c *InputService9ProtocolTest) InputService9TestCaseOperation4(input *Input
 var opInputService9TestCaseOperation4 *aws.Operation
 
 // InputService9TestCaseOperation5Request generates a request for the InputService9TestCaseOperation5 operation.
-func (c *InputService9ProtocolTest) InputService9TestCaseOperation5Request(input *InputService9TestShapeInputShape) (req *aws.Request, output *InputService9TestShapeInputService9TestCaseOperation5Output) {
+func (c *InputService9ProtocolTest) InputService9TestCaseOperation5Request(input *InputService9TestShapeInputShape) (req *aws.Request, output *InputService9TestShapeInputService9TestShapeInputService9TestCaseOperation5Output) {
 
 	if opInputService9TestCaseOperation5 == nil {
 		opInputService9TestCaseOperation5 = &aws.Operation{
@@ -970,12 +970,12 @@ func (c *InputService9ProtocolTest) InputService9TestCaseOperation5Request(input
 	}
 
 	req = c.newRequest(opInputService9TestCaseOperation5, input, output)
-	output = &InputService9TestShapeInputService9TestCaseOperation5Output{}
+	output = &InputService9TestShapeInputService9TestShapeInputService9TestCaseOperation5Output{}
 	req.Data = output
 	return
 }
 
-func (c *InputService9ProtocolTest) InputService9TestCaseOperation5(input *InputService9TestShapeInputShape) (output *InputService9TestShapeInputService9TestCaseOperation5Output, err error) {
+func (c *InputService9ProtocolTest) InputService9TestCaseOperation5(input *InputService9TestShapeInputShape) (output *InputService9TestShapeInputService9TestShapeInputService9TestCaseOperation5Output, err error) {
 	req, out := c.InputService9TestCaseOperation5Request(input)
 	output = out
 	err = req.Send()
@@ -985,7 +985,7 @@ func (c *InputService9ProtocolTest) InputService9TestCaseOperation5(input *Input
 var opInputService9TestCaseOperation5 *aws.Operation
 
 // InputService9TestCaseOperation6Request generates a request for the InputService9TestCaseOperation6 operation.
-func (c *InputService9ProtocolTest) InputService9TestCaseOperation6Request(input *InputService9TestShapeInputShape) (req *aws.Request, output *InputService9TestShapeInputService9TestCaseOperation6Output) {
+func (c *InputService9ProtocolTest) InputService9TestCaseOperation6Request(input *InputService9TestShapeInputShape) (req *aws.Request, output *InputService9TestShapeInputService9TestShapeInputService9TestCaseOperation6Output) {
 
 	if opInputService9TestCaseOperation6 == nil {
 		opInputService9TestCaseOperation6 = &aws.Operation{
@@ -998,12 +998,12 @@ func (c *InputService9ProtocolTest) InputService9TestCaseOperation6Request(input
 	}
 
 	req = c.newRequest(opInputService9TestCaseOperation6, input, output)
-	output = &InputService9TestShapeInputService9TestCaseOperation6Output{}
+	output = &InputService9TestShapeInputService9TestShapeInputService9TestCaseOperation6Output{}
 	req.Data = output
 	return
 }
 
-func (c *InputService9ProtocolTest) InputService9TestCaseOperation6(input *InputService9TestShapeInputShape) (output *InputService9TestShapeInputService9TestCaseOperation6Output, err error) {
+func (c *InputService9ProtocolTest) InputService9TestCaseOperation6(input *InputService9TestShapeInputShape) (output *InputService9TestShapeInputService9TestShapeInputService9TestCaseOperation6Output, err error) {
 	req, out := c.InputService9TestCaseOperation6Request(input)
 	output = out
 	err = req.Send()
@@ -1013,7 +1013,7 @@ func (c *InputService9ProtocolTest) InputService9TestCaseOperation6(input *Input
 var opInputService9TestCaseOperation6 *aws.Operation
 
 type InputService9TestShapeInputService9TestCaseOperation1Output struct {
-	metadataInputService9TestShapeInputService9TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService9TestShapeInputService9TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService9TestShapeInputService9TestCaseOperation1Output struct {
@@ -1021,7 +1021,7 @@ type metadataInputService9TestShapeInputService9TestCaseOperation1Output struct 
 }
 
 type InputService9TestShapeInputService9TestCaseOperation2Output struct {
-	metadataInputService9TestShapeInputService9TestCaseOperation2Output `json:"-", xml:"-"`
+	metadataInputService9TestShapeInputService9TestCaseOperation2Output `json:"-" xml:"-"`
 }
 
 type metadataInputService9TestShapeInputService9TestCaseOperation2Output struct {
@@ -1029,7 +1029,7 @@ type metadataInputService9TestShapeInputService9TestCaseOperation2Output struct 
 }
 
 type InputService9TestShapeInputService9TestCaseOperation3Output struct {
-	metadataInputService9TestShapeInputService9TestCaseOperation3Output `json:"-", xml:"-"`
+	metadataInputService9TestShapeInputService9TestCaseOperation3Output `json:"-" xml:"-"`
 }
 
 type metadataInputService9TestShapeInputService9TestCaseOperation3Output struct {
@@ -1037,52 +1037,52 @@ type metadataInputService9TestShapeInputService9TestCaseOperation3Output struct 
 }
 
 type InputService9TestShapeInputService9TestCaseOperation4Output struct {
-	metadataInputService9TestShapeInputService9TestCaseOperation4Output `json:"-", xml:"-"`
+	metadataInputService9TestShapeInputService9TestCaseOperation4Output `json:"-" xml:"-"`
 }
 
 type metadataInputService9TestShapeInputService9TestCaseOperation4Output struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
-type InputService9TestShapeInputService9TestCaseOperation5Output struct {
-	metadataInputService9TestShapeInputService9TestCaseOperation5Output `json:"-", xml:"-"`
+type InputService9TestShapeInputService9TestShapeInputService9TestCaseOperation5Output struct {
+	metadataInputService9TestShapeInputService9TestShapeInputService9TestCaseOperation5Output `json:"-" xml:"-"`
 }
 
-type metadataInputService9TestShapeInputService9TestCaseOperation5Output struct {
+type metadataInputService9TestShapeInputService9TestShapeInputService9TestCaseOperation5Output struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
-type InputService9TestShapeInputService9TestCaseOperation6Output struct {
-	metadataInputService9TestShapeInputService9TestCaseOperation6Output `json:"-", xml:"-"`
+type InputService9TestShapeInputService9TestShapeInputService9TestCaseOperation6Output struct {
+	metadataInputService9TestShapeInputService9TestShapeInputService9TestCaseOperation6Output `json:"-" xml:"-"`
 }
 
-type metadataInputService9TestShapeInputService9TestCaseOperation6Output struct {
-	SDKShapeTraits bool `type:"structure"`
-}
-
-type InputService9TestShapeInputService9TestShapeRecursiveStructType struct {
-	NoRecurse *string `type:"string"`
-
-	RecursiveList []*InputService9TestShapeInputService9TestShapeRecursiveStructType `type:"list"`
-
-	RecursiveMap *map[string]*InputService9TestShapeInputService9TestShapeRecursiveStructType `type:"map"`
-
-	RecursiveStruct *InputService9TestShapeInputService9TestShapeRecursiveStructType `type:"structure"`
-
-	metadataInputService9TestShapeInputService9TestShapeRecursiveStructType `json:"-", xml:"-"`
-}
-
-type metadataInputService9TestShapeInputService9TestShapeRecursiveStructType struct {
+type metadataInputService9TestShapeInputService9TestShapeInputService9TestCaseOperation6Output struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
 type InputService9TestShapeInputShape struct {
-	RecursiveStruct *InputService9TestShapeInputService9TestShapeRecursiveStructType `type:"structure"`
+	RecursiveStruct *InputService9TestShapeRecursiveStructType `type:"structure"`
 
-	metadataInputService9TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService9TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService9TestShapeInputShape struct {
+	SDKShapeTraits bool `type:"structure"`
+}
+
+type InputService9TestShapeRecursiveStructType struct {
+	NoRecurse *string `type:"string"`
+
+	RecursiveList []*InputService9TestShapeRecursiveStructType `type:"list"`
+
+	RecursiveMap *map[string]*InputService9TestShapeRecursiveStructType `type:"map"`
+
+	RecursiveStruct *InputService9TestShapeRecursiveStructType `type:"structure"`
+
+	metadataInputService9TestShapeRecursiveStructType `json:"-" xml:"-"`
+}
+
+type metadataInputService9TestShapeRecursiveStructType struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
@@ -1400,7 +1400,7 @@ func TestInputService9ProtocolTestRecursiveShapesCase1(t *testing.T) {
 	svc.Endpoint = "https://test"
 
 	input := &InputService9TestShapeInputShape{
-		RecursiveStruct: &InputService9TestShapeInputService9TestShapeRecursiveStructType{
+		RecursiveStruct: &InputService9TestShapeRecursiveStructType{
 			NoRecurse: aws.String("foo"),
 		},
 	}
@@ -1428,8 +1428,8 @@ func TestInputService9ProtocolTestRecursiveShapesCase2(t *testing.T) {
 	svc.Endpoint = "https://test"
 
 	input := &InputService9TestShapeInputShape{
-		RecursiveStruct: &InputService9TestShapeInputService9TestShapeRecursiveStructType{
-			RecursiveStruct: &InputService9TestShapeInputService9TestShapeRecursiveStructType{
+		RecursiveStruct: &InputService9TestShapeRecursiveStructType{
+			RecursiveStruct: &InputService9TestShapeRecursiveStructType{
 				NoRecurse: aws.String("foo"),
 			},
 		},
@@ -1458,10 +1458,10 @@ func TestInputService9ProtocolTestRecursiveShapesCase3(t *testing.T) {
 	svc.Endpoint = "https://test"
 
 	input := &InputService9TestShapeInputShape{
-		RecursiveStruct: &InputService9TestShapeInputService9TestShapeRecursiveStructType{
-			RecursiveStruct: &InputService9TestShapeInputService9TestShapeRecursiveStructType{
-				RecursiveStruct: &InputService9TestShapeInputService9TestShapeRecursiveStructType{
-					RecursiveStruct: &InputService9TestShapeInputService9TestShapeRecursiveStructType{
+		RecursiveStruct: &InputService9TestShapeRecursiveStructType{
+			RecursiveStruct: &InputService9TestShapeRecursiveStructType{
+				RecursiveStruct: &InputService9TestShapeRecursiveStructType{
+					RecursiveStruct: &InputService9TestShapeRecursiveStructType{
 						NoRecurse: aws.String("foo"),
 					},
 				},
@@ -1492,12 +1492,12 @@ func TestInputService9ProtocolTestRecursiveShapesCase4(t *testing.T) {
 	svc.Endpoint = "https://test"
 
 	input := &InputService9TestShapeInputShape{
-		RecursiveStruct: &InputService9TestShapeInputService9TestShapeRecursiveStructType{
-			RecursiveList: []*InputService9TestShapeInputService9TestShapeRecursiveStructType{
-				&InputService9TestShapeInputService9TestShapeRecursiveStructType{
+		RecursiveStruct: &InputService9TestShapeRecursiveStructType{
+			RecursiveList: []*InputService9TestShapeRecursiveStructType{
+				&InputService9TestShapeRecursiveStructType{
 					NoRecurse: aws.String("foo"),
 				},
-				&InputService9TestShapeInputService9TestShapeRecursiveStructType{
+				&InputService9TestShapeRecursiveStructType{
 					NoRecurse: aws.String("bar"),
 				},
 			},
@@ -1527,13 +1527,13 @@ func TestInputService9ProtocolTestRecursiveShapesCase5(t *testing.T) {
 	svc.Endpoint = "https://test"
 
 	input := &InputService9TestShapeInputShape{
-		RecursiveStruct: &InputService9TestShapeInputService9TestShapeRecursiveStructType{
-			RecursiveList: []*InputService9TestShapeInputService9TestShapeRecursiveStructType{
-				&InputService9TestShapeInputService9TestShapeRecursiveStructType{
+		RecursiveStruct: &InputService9TestShapeRecursiveStructType{
+			RecursiveList: []*InputService9TestShapeRecursiveStructType{
+				&InputService9TestShapeRecursiveStructType{
 					NoRecurse: aws.String("foo"),
 				},
-				&InputService9TestShapeInputService9TestShapeRecursiveStructType{
-					RecursiveStruct: &InputService9TestShapeInputService9TestShapeRecursiveStructType{
+				&InputService9TestShapeRecursiveStructType{
+					RecursiveStruct: &InputService9TestShapeRecursiveStructType{
 						NoRecurse: aws.String("bar"),
 					},
 				},
@@ -1564,12 +1564,12 @@ func TestInputService9ProtocolTestRecursiveShapesCase6(t *testing.T) {
 	svc.Endpoint = "https://test"
 
 	input := &InputService9TestShapeInputShape{
-		RecursiveStruct: &InputService9TestShapeInputService9TestShapeRecursiveStructType{
-			RecursiveMap: &map[string]*InputService9TestShapeInputService9TestShapeRecursiveStructType{
-				"bar": &InputService9TestShapeInputService9TestShapeRecursiveStructType{
+		RecursiveStruct: &InputService9TestShapeRecursiveStructType{
+			RecursiveMap: &map[string]*InputService9TestShapeRecursiveStructType{
+				"bar": &InputService9TestShapeRecursiveStructType{
 					NoRecurse: aws.String("bar"),
 				},
-				"foo": &InputService9TestShapeInputService9TestShapeRecursiveStructType{
+				"foo": &InputService9TestShapeRecursiveStructType{
 					NoRecurse: aws.String("foo"),
 				},
 			},

--- a/internal/protocol/query/build_test.go
+++ b/internal/protocol/query/build_test.go
@@ -957,7 +957,7 @@ func (c *InputService9ProtocolTest) InputService9TestCaseOperation4(input *Input
 var opInputService9TestCaseOperation4 *aws.Operation
 
 // InputService9TestCaseOperation5Request generates a request for the InputService9TestCaseOperation5 operation.
-func (c *InputService9ProtocolTest) InputService9TestCaseOperation5Request(input *InputService9TestShapeInputShape) (req *aws.Request, output *InputService9TestShapeInputService9TestShapeInputService9TestCaseOperation5Output) {
+func (c *InputService9ProtocolTest) InputService9TestCaseOperation5Request(input *InputService9TestShapeInputShape) (req *aws.Request, output *InputService9TestShapeInputService9TestCaseOperation5Output) {
 
 	if opInputService9TestCaseOperation5 == nil {
 		opInputService9TestCaseOperation5 = &aws.Operation{
@@ -970,12 +970,12 @@ func (c *InputService9ProtocolTest) InputService9TestCaseOperation5Request(input
 	}
 
 	req = c.newRequest(opInputService9TestCaseOperation5, input, output)
-	output = &InputService9TestShapeInputService9TestShapeInputService9TestCaseOperation5Output{}
+	output = &InputService9TestShapeInputService9TestCaseOperation5Output{}
 	req.Data = output
 	return
 }
 
-func (c *InputService9ProtocolTest) InputService9TestCaseOperation5(input *InputService9TestShapeInputShape) (output *InputService9TestShapeInputService9TestShapeInputService9TestCaseOperation5Output, err error) {
+func (c *InputService9ProtocolTest) InputService9TestCaseOperation5(input *InputService9TestShapeInputShape) (output *InputService9TestShapeInputService9TestCaseOperation5Output, err error) {
 	req, out := c.InputService9TestCaseOperation5Request(input)
 	output = out
 	err = req.Send()
@@ -985,7 +985,7 @@ func (c *InputService9ProtocolTest) InputService9TestCaseOperation5(input *Input
 var opInputService9TestCaseOperation5 *aws.Operation
 
 // InputService9TestCaseOperation6Request generates a request for the InputService9TestCaseOperation6 operation.
-func (c *InputService9ProtocolTest) InputService9TestCaseOperation6Request(input *InputService9TestShapeInputShape) (req *aws.Request, output *InputService9TestShapeInputService9TestShapeInputService9TestCaseOperation6Output) {
+func (c *InputService9ProtocolTest) InputService9TestCaseOperation6Request(input *InputService9TestShapeInputShape) (req *aws.Request, output *InputService9TestShapeInputService9TestCaseOperation6Output) {
 
 	if opInputService9TestCaseOperation6 == nil {
 		opInputService9TestCaseOperation6 = &aws.Operation{
@@ -998,12 +998,12 @@ func (c *InputService9ProtocolTest) InputService9TestCaseOperation6Request(input
 	}
 
 	req = c.newRequest(opInputService9TestCaseOperation6, input, output)
-	output = &InputService9TestShapeInputService9TestShapeInputService9TestCaseOperation6Output{}
+	output = &InputService9TestShapeInputService9TestCaseOperation6Output{}
 	req.Data = output
 	return
 }
 
-func (c *InputService9ProtocolTest) InputService9TestCaseOperation6(input *InputService9TestShapeInputShape) (output *InputService9TestShapeInputService9TestShapeInputService9TestCaseOperation6Output, err error) {
+func (c *InputService9ProtocolTest) InputService9TestCaseOperation6(input *InputService9TestShapeInputShape) (output *InputService9TestShapeInputService9TestCaseOperation6Output, err error) {
 	req, out := c.InputService9TestCaseOperation6Request(input)
 	output = out
 	err = req.Send()
@@ -1044,19 +1044,19 @@ type metadataInputService9TestShapeInputService9TestCaseOperation4Output struct 
 	SDKShapeTraits bool `type:"structure"`
 }
 
-type InputService9TestShapeInputService9TestShapeInputService9TestCaseOperation5Output struct {
-	metadataInputService9TestShapeInputService9TestShapeInputService9TestCaseOperation5Output `json:"-" xml:"-"`
+type InputService9TestShapeInputService9TestCaseOperation5Output struct {
+	metadataInputService9TestShapeInputService9TestCaseOperation5Output `json:"-" xml:"-"`
 }
 
-type metadataInputService9TestShapeInputService9TestShapeInputService9TestCaseOperation5Output struct {
+type metadataInputService9TestShapeInputService9TestCaseOperation5Output struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
-type InputService9TestShapeInputService9TestShapeInputService9TestCaseOperation6Output struct {
-	metadataInputService9TestShapeInputService9TestShapeInputService9TestCaseOperation6Output `json:"-" xml:"-"`
+type InputService9TestShapeInputService9TestCaseOperation6Output struct {
+	metadataInputService9TestShapeInputService9TestCaseOperation6Output `json:"-" xml:"-"`
 }
 
-type metadataInputService9TestShapeInputService9TestShapeInputService9TestCaseOperation6Output struct {
+type metadataInputService9TestShapeInputService9TestCaseOperation6Output struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 

--- a/internal/protocol/query/unmarshal_test.go
+++ b/internal/protocol/query/unmarshal_test.go
@@ -95,7 +95,7 @@ func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1(input *Out
 var opOutputService1TestCaseOperation1 *aws.Operation
 
 type OutputService1TestShapeOutputService1TestCaseOperation1Input struct {
-	metadataOutputService1TestShapeOutputService1TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService1TestShapeOutputService1TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService1TestShapeOutputService1TestCaseOperation1Input struct {
@@ -121,7 +121,7 @@ type OutputService1TestShapeOutputShape struct {
 
 	TrueBool *bool `type:"boolean"`
 
-	metadataOutputService1TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService1TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService1TestShapeOutputShape struct {
@@ -193,7 +193,7 @@ func (c *OutputService2ProtocolTest) OutputService2TestCaseOperation1(input *Out
 var opOutputService2TestCaseOperation1 *aws.Operation
 
 type OutputService2TestShapeOutputService2TestCaseOperation1Input struct {
-	metadataOutputService2TestShapeOutputService2TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService2TestShapeOutputService2TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService2TestShapeOutputService2TestCaseOperation1Input struct {
@@ -205,7 +205,7 @@ type OutputService2TestShapeOutputShape struct {
 
 	Str *string `type:"string"`
 
-	metadataOutputService2TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService2TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService2TestShapeOutputShape struct {
@@ -277,7 +277,7 @@ func (c *OutputService3ProtocolTest) OutputService3TestCaseOperation1(input *Out
 var opOutputService3TestCaseOperation1 *aws.Operation
 
 type OutputService3TestShapeOutputService3TestCaseOperation1Input struct {
-	metadataOutputService3TestShapeOutputService3TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService3TestShapeOutputService3TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService3TestShapeOutputService3TestCaseOperation1Input struct {
@@ -287,7 +287,7 @@ type metadataOutputService3TestShapeOutputService3TestCaseOperation1Input struct
 type OutputService3TestShapeOutputShape struct {
 	Blob []byte `type:"blob"`
 
-	metadataOutputService3TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService3TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService3TestShapeOutputShape struct {
@@ -359,7 +359,7 @@ func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation1(input *Out
 var opOutputService4TestCaseOperation1 *aws.Operation
 
 type OutputService4TestShapeOutputService4TestCaseOperation1Input struct {
-	metadataOutputService4TestShapeOutputService4TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService4TestShapeOutputService4TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService4TestShapeOutputService4TestCaseOperation1Input struct {
@@ -369,7 +369,7 @@ type metadataOutputService4TestShapeOutputService4TestCaseOperation1Input struct
 type OutputService4TestShapeOutputShape struct {
 	ListMember []*string `type:"list"`
 
-	metadataOutputService4TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService4TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService4TestShapeOutputShape struct {
@@ -441,7 +441,7 @@ func (c *OutputService5ProtocolTest) OutputService5TestCaseOperation1(input *Out
 var opOutputService5TestCaseOperation1 *aws.Operation
 
 type OutputService5TestShapeOutputService5TestCaseOperation1Input struct {
-	metadataOutputService5TestShapeOutputService5TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService5TestShapeOutputService5TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService5TestShapeOutputService5TestCaseOperation1Input struct {
@@ -451,7 +451,7 @@ type metadataOutputService5TestShapeOutputService5TestCaseOperation1Input struct
 type OutputService5TestShapeOutputShape struct {
 	ListMember []*string `locationNameList:"item" type:"list"`
 
-	metadataOutputService5TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService5TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService5TestShapeOutputShape struct {
@@ -523,7 +523,7 @@ func (c *OutputService6ProtocolTest) OutputService6TestCaseOperation1(input *Out
 var opOutputService6TestCaseOperation1 *aws.Operation
 
 type OutputService6TestShapeOutputService6TestCaseOperation1Input struct {
-	metadataOutputService6TestShapeOutputService6TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService6TestShapeOutputService6TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService6TestShapeOutputService6TestCaseOperation1Input struct {
@@ -533,7 +533,7 @@ type metadataOutputService6TestShapeOutputService6TestCaseOperation1Input struct
 type OutputService6TestShapeOutputShape struct {
 	ListMember []*string `type:"list" flattened:"true"`
 
-	metadataOutputService6TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService6TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService6TestShapeOutputShape struct {
@@ -605,7 +605,7 @@ func (c *OutputService7ProtocolTest) OutputService7TestCaseOperation1(input *Out
 var opOutputService7TestCaseOperation1 *aws.Operation
 
 type OutputService7TestShapeOutputService7TestCaseOperation1Input struct {
-	metadataOutputService7TestShapeOutputService7TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService7TestShapeOutputService7TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService7TestShapeOutputService7TestCaseOperation1Input struct {
@@ -615,7 +615,7 @@ type metadataOutputService7TestShapeOutputService7TestCaseOperation1Input struct
 type OutputService7TestShapeOutputShape struct {
 	ListMember []*string `type:"list" flattened:"true"`
 
-	metadataOutputService7TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService7TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService7TestShapeOutputShape struct {
@@ -687,7 +687,7 @@ func (c *OutputService8ProtocolTest) OutputService8TestCaseOperation1(input *Out
 var opOutputService8TestCaseOperation1 *aws.Operation
 
 type OutputService8TestShapeOutputService8TestCaseOperation1Input struct {
-	metadataOutputService8TestShapeOutputService8TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService8TestShapeOutputService8TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService8TestShapeOutputService8TestCaseOperation1Input struct {
@@ -697,7 +697,7 @@ type metadataOutputService8TestShapeOutputService8TestCaseOperation1Input struct
 type OutputService8TestShapeOutputShape struct {
 	List []*OutputService8TestShapeStructureShape `type:"list"`
 
-	metadataOutputService8TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService8TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService8TestShapeOutputShape struct {
@@ -711,7 +711,7 @@ type OutputService8TestShapeStructureShape struct {
 
 	Foo *string `type:"string"`
 
-	metadataOutputService8TestShapeStructureShape `json:"-", xml:"-"`
+	metadataOutputService8TestShapeStructureShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService8TestShapeStructureShape struct {
@@ -783,7 +783,7 @@ func (c *OutputService9ProtocolTest) OutputService9TestCaseOperation1(input *Out
 var opOutputService9TestCaseOperation1 *aws.Operation
 
 type OutputService9TestShapeOutputService9TestCaseOperation1Input struct {
-	metadataOutputService9TestShapeOutputService9TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService9TestShapeOutputService9TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService9TestShapeOutputService9TestCaseOperation1Input struct {
@@ -793,7 +793,7 @@ type metadataOutputService9TestShapeOutputService9TestCaseOperation1Input struct
 type OutputService9TestShapeOutputShape struct {
 	List []*OutputService9TestShapeStructureShape `type:"list" flattened:"true"`
 
-	metadataOutputService9TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService9TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService9TestShapeOutputShape struct {
@@ -807,7 +807,7 @@ type OutputService9TestShapeStructureShape struct {
 
 	Foo *string `type:"string"`
 
-	metadataOutputService9TestShapeStructureShape `json:"-", xml:"-"`
+	metadataOutputService9TestShapeStructureShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService9TestShapeStructureShape struct {
@@ -879,7 +879,7 @@ func (c *OutputService10ProtocolTest) OutputService10TestCaseOperation1(input *O
 var opOutputService10TestCaseOperation1 *aws.Operation
 
 type OutputService10TestShapeOutputService10TestCaseOperation1Input struct {
-	metadataOutputService10TestShapeOutputService10TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService10TestShapeOutputService10TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService10TestShapeOutputService10TestCaseOperation1Input struct {
@@ -889,7 +889,7 @@ type metadataOutputService10TestShapeOutputService10TestCaseOperation1Input stru
 type OutputService10TestShapeOutputShape struct {
 	List []*string `locationNameList:"NamedList" type:"list" flattened:"true"`
 
-	metadataOutputService10TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService10TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService10TestShapeOutputShape struct {
@@ -961,7 +961,7 @@ func (c *OutputService11ProtocolTest) OutputService11TestCaseOperation1(input *O
 var opOutputService11TestCaseOperation1 *aws.Operation
 
 type OutputService11TestShapeOutputService11TestCaseOperation1Input struct {
-	metadataOutputService11TestShapeOutputService11TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService11TestShapeOutputService11TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService11TestShapeOutputService11TestCaseOperation1Input struct {
@@ -971,7 +971,7 @@ type metadataOutputService11TestShapeOutputService11TestCaseOperation1Input stru
 type OutputService11TestShapeOutputShape struct {
 	Map *map[string]*OutputService11TestShapeStructType `type:"map"`
 
-	metadataOutputService11TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService11TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService11TestShapeOutputShape struct {
@@ -981,7 +981,7 @@ type metadataOutputService11TestShapeOutputShape struct {
 type OutputService11TestShapeStructType struct {
 	Foo *string `locationName:"foo" type:"string"`
 
-	metadataOutputService11TestShapeStructType `json:"-", xml:"-"`
+	metadataOutputService11TestShapeStructType `json:"-" xml:"-"`
 }
 
 type metadataOutputService11TestShapeStructType struct {
@@ -1053,7 +1053,7 @@ func (c *OutputService12ProtocolTest) OutputService12TestCaseOperation1(input *O
 var opOutputService12TestCaseOperation1 *aws.Operation
 
 type OutputService12TestShapeOutputService12TestCaseOperation1Input struct {
-	metadataOutputService12TestShapeOutputService12TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService12TestShapeOutputService12TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService12TestShapeOutputService12TestCaseOperation1Input struct {
@@ -1063,7 +1063,7 @@ type metadataOutputService12TestShapeOutputService12TestCaseOperation1Input stru
 type OutputService12TestShapeOutputShape struct {
 	Map *map[string]*string `type:"map" flattened:"true"`
 
-	metadataOutputService12TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService12TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService12TestShapeOutputShape struct {
@@ -1135,7 +1135,7 @@ func (c *OutputService13ProtocolTest) OutputService13TestCaseOperation1(input *O
 var opOutputService13TestCaseOperation1 *aws.Operation
 
 type OutputService13TestShapeOutputService13TestCaseOperation1Input struct {
-	metadataOutputService13TestShapeOutputService13TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService13TestShapeOutputService13TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService13TestShapeOutputService13TestCaseOperation1Input struct {
@@ -1145,7 +1145,7 @@ type metadataOutputService13TestShapeOutputService13TestCaseOperation1Input stru
 type OutputService13TestShapeOutputShape struct {
 	Map *map[string]*string `locationName:"Attribute" locationNameKey:"Name" locationNameValue:"Value" type:"map" flattened:"true"`
 
-	metadataOutputService13TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService13TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService13TestShapeOutputShape struct {
@@ -1217,7 +1217,7 @@ func (c *OutputService14ProtocolTest) OutputService14TestCaseOperation1(input *O
 var opOutputService14TestCaseOperation1 *aws.Operation
 
 type OutputService14TestShapeOutputService14TestCaseOperation1Input struct {
-	metadataOutputService14TestShapeOutputService14TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService14TestShapeOutputService14TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService14TestShapeOutputService14TestCaseOperation1Input struct {
@@ -1227,7 +1227,7 @@ type metadataOutputService14TestShapeOutputService14TestCaseOperation1Input stru
 type OutputService14TestShapeOutputShape struct {
 	Map *map[string]*string `locationNameKey:"foo" locationNameValue:"bar" type:"map" flattened:"true"`
 
-	metadataOutputService14TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService14TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService14TestShapeOutputShape struct {

--- a/internal/protocol/restjson/build_test.go
+++ b/internal/protocol/restjson/build_test.go
@@ -97,7 +97,7 @@ func (c *InputService1ProtocolTest) InputService1TestCaseOperation1(input *Input
 var opInputService1TestCaseOperation1 *aws.Operation
 
 type InputService1TestShapeInputService1TestCaseOperation1Output struct {
-	metadataInputService1TestShapeInputService1TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService1TestShapeInputService1TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService1TestShapeInputService1TestCaseOperation1Output struct {
@@ -107,7 +107,7 @@ type metadataInputService1TestShapeInputService1TestCaseOperation1Output struct 
 type InputService1TestShapeInputShape struct {
 	PipelineId *string `location:"uri" type:"string"`
 
-	metadataInputService1TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService1TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService1TestShapeInputShape struct {
@@ -181,7 +181,7 @@ func (c *InputService2ProtocolTest) InputService2TestCaseOperation1(input *Input
 var opInputService2TestCaseOperation1 *aws.Operation
 
 type InputService2TestShapeInputService2TestCaseOperation1Output struct {
-	metadataInputService2TestShapeInputService2TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService2TestShapeInputService2TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService2TestShapeInputService2TestCaseOperation1Output struct {
@@ -191,7 +191,7 @@ type metadataInputService2TestShapeInputService2TestCaseOperation1Output struct 
 type InputService2TestShapeInputShape struct {
 	Foo *string `location:"uri" locationName:"PipelineId" type:"string"`
 
-	metadataInputService2TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService2TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService2TestShapeInputShape struct {
@@ -265,7 +265,7 @@ func (c *InputService3ProtocolTest) InputService3TestCaseOperation1(input *Input
 var opInputService3TestCaseOperation1 *aws.Operation
 
 type InputService3TestShapeInputService3TestCaseOperation1Output struct {
-	metadataInputService3TestShapeInputService3TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService3TestShapeInputService3TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService3TestShapeInputService3TestCaseOperation1Output struct {
@@ -279,7 +279,7 @@ type InputService3TestShapeInputShape struct {
 
 	PipelineId *string `location:"uri" locationName:"PipelineId" type:"string"`
 
-	metadataInputService3TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService3TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService3TestShapeInputShape struct {
@@ -353,7 +353,7 @@ func (c *InputService4ProtocolTest) InputService4TestCaseOperation1(input *Input
 var opInputService4TestCaseOperation1 *aws.Operation
 
 type InputService4TestShapeInputService4TestCaseOperation1Output struct {
-	metadataInputService4TestShapeInputService4TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService4TestShapeInputService4TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService4TestShapeInputService4TestCaseOperation1Output struct {
@@ -369,7 +369,7 @@ type InputService4TestShapeInputShape struct {
 
 	PipelineId *string `location:"uri" locationName:"PipelineId" type:"string"`
 
-	metadataInputService4TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService4TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService4TestShapeInputShape struct {
@@ -381,7 +381,7 @@ type InputService4TestShapeStructType struct {
 
 	B *string `type:"string"`
 
-	metadataInputService4TestShapeStructType `json:"-", xml:"-"`
+	metadataInputService4TestShapeStructType `json:"-" xml:"-"`
 }
 
 type metadataInputService4TestShapeStructType struct {
@@ -455,7 +455,7 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation1(input *Input
 var opInputService5TestCaseOperation1 *aws.Operation
 
 type InputService5TestShapeInputService5TestCaseOperation1Output struct {
-	metadataInputService5TestShapeInputService5TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService5TestShapeInputService5TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService5TestShapeInputService5TestCaseOperation1Output struct {
@@ -473,7 +473,7 @@ type InputService5TestShapeInputShape struct {
 
 	PipelineId *string `location:"uri" locationName:"PipelineId" type:"string"`
 
-	metadataInputService5TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService5TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService5TestShapeInputShape struct {
@@ -485,7 +485,7 @@ type InputService5TestShapeStructType struct {
 
 	B *string `type:"string"`
 
-	metadataInputService5TestShapeStructType `json:"-", xml:"-"`
+	metadataInputService5TestShapeStructType `json:"-" xml:"-"`
 }
 
 type metadataInputService5TestShapeStructType struct {
@@ -559,7 +559,7 @@ func (c *InputService6ProtocolTest) InputService6TestCaseOperation1(input *Input
 var opInputService6TestCaseOperation1 *aws.Operation
 
 type InputService6TestShapeInputService6TestCaseOperation1Output struct {
-	metadataInputService6TestShapeInputService6TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService6TestShapeInputService6TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService6TestShapeInputService6TestCaseOperation1Output struct {
@@ -573,7 +573,7 @@ type InputService6TestShapeInputShape struct {
 
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataInputService6TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService6TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService6TestShapeInputShape struct {
@@ -677,7 +677,7 @@ func (c *InputService7ProtocolTest) InputService7TestCaseOperation2(input *Input
 var opInputService7TestCaseOperation2 *aws.Operation
 
 type InputService7TestShapeInputService7TestCaseOperation1Output struct {
-	metadataInputService7TestShapeInputService7TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService7TestShapeInputService7TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService7TestShapeInputService7TestCaseOperation1Output struct {
@@ -685,7 +685,7 @@ type metadataInputService7TestShapeInputService7TestCaseOperation1Output struct 
 }
 
 type InputService7TestShapeInputService7TestCaseOperation2Output struct {
-	metadataInputService7TestShapeInputService7TestCaseOperation2Output `json:"-", xml:"-"`
+	metadataInputService7TestShapeInputService7TestCaseOperation2Output `json:"-" xml:"-"`
 }
 
 type metadataInputService7TestShapeInputService7TestCaseOperation2Output struct {
@@ -695,7 +695,7 @@ type metadataInputService7TestShapeInputService7TestCaseOperation2Output struct 
 type InputService7TestShapeInputShape struct {
 	Foo *string `location:"querystring" locationName:"param-name" type:"string"`
 
-	metadataInputService7TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService7TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService7TestShapeInputShape struct {
@@ -739,7 +739,7 @@ func (c *InputService8ProtocolTest) newRequest(op *aws.Operation, params, data i
 }
 
 // InputService8TestCaseOperation1Request generates a request for the InputService8TestCaseOperation1 operation.
-func (c *InputService8ProtocolTest) InputService8TestCaseOperation1Request(input *InputService8TestShapeInputShape) (req *aws.Request, output *InputService8TestShapeInputService8TestShapeInputService8TestCaseOperation1Output) {
+func (c *InputService8ProtocolTest) InputService8TestCaseOperation1Request(input *InputService8TestShapeInputShape) (req *aws.Request, output *InputService8TestShapeInputService8TestCaseOperation1Output) {
 
 	if opInputService8TestCaseOperation1 == nil {
 		opInputService8TestCaseOperation1 = &aws.Operation{
@@ -754,12 +754,12 @@ func (c *InputService8ProtocolTest) InputService8TestCaseOperation1Request(input
 	}
 
 	req = c.newRequest(opInputService8TestCaseOperation1, input, output)
-	output = &InputService8TestShapeInputService8TestShapeInputService8TestCaseOperation1Output{}
+	output = &InputService8TestShapeInputService8TestCaseOperation1Output{}
 	req.Data = output
 	return
 }
 
-func (c *InputService8ProtocolTest) InputService8TestCaseOperation1(input *InputService8TestShapeInputShape) (output *InputService8TestShapeInputService8TestShapeInputService8TestCaseOperation1Output, err error) {
+func (c *InputService8ProtocolTest) InputService8TestCaseOperation1(input *InputService8TestShapeInputShape) (output *InputService8TestShapeInputService8TestCaseOperation1Output, err error) {
 	req, out := c.InputService8TestCaseOperation1Request(input)
 	output = out
 	err = req.Send()
@@ -769,7 +769,7 @@ func (c *InputService8ProtocolTest) InputService8TestCaseOperation1(input *Input
 var opInputService8TestCaseOperation1 *aws.Operation
 
 // InputService8TestCaseOperation2Request generates a request for the InputService8TestCaseOperation2 operation.
-func (c *InputService8ProtocolTest) InputService8TestCaseOperation2Request(input *InputService8TestShapeInputShape) (req *aws.Request, output *InputService8TestShapeInputService8TestShapeInputService8TestCaseOperation2Output) {
+func (c *InputService8ProtocolTest) InputService8TestCaseOperation2Request(input *InputService8TestShapeInputShape) (req *aws.Request, output *InputService8TestShapeInputService8TestCaseOperation2Output) {
 
 	if opInputService8TestCaseOperation2 == nil {
 		opInputService8TestCaseOperation2 = &aws.Operation{
@@ -784,12 +784,12 @@ func (c *InputService8ProtocolTest) InputService8TestCaseOperation2Request(input
 	}
 
 	req = c.newRequest(opInputService8TestCaseOperation2, input, output)
-	output = &InputService8TestShapeInputService8TestShapeInputService8TestCaseOperation2Output{}
+	output = &InputService8TestShapeInputService8TestCaseOperation2Output{}
 	req.Data = output
 	return
 }
 
-func (c *InputService8ProtocolTest) InputService8TestCaseOperation2(input *InputService8TestShapeInputShape) (output *InputService8TestShapeInputService8TestShapeInputService8TestCaseOperation2Output, err error) {
+func (c *InputService8ProtocolTest) InputService8TestCaseOperation2(input *InputService8TestShapeInputShape) (output *InputService8TestShapeInputService8TestCaseOperation2Output, err error) {
 	req, out := c.InputService8TestCaseOperation2Request(input)
 	output = out
 	err = req.Send()
@@ -799,7 +799,7 @@ func (c *InputService8ProtocolTest) InputService8TestCaseOperation2(input *Input
 var opInputService8TestCaseOperation2 *aws.Operation
 
 // InputService8TestCaseOperation3Request generates a request for the InputService8TestCaseOperation3 operation.
-func (c *InputService8ProtocolTest) InputService8TestCaseOperation3Request(input *InputService8TestShapeInputShape) (req *aws.Request, output *InputService8TestShapeInputService8TestCaseOperation3Output) {
+func (c *InputService8ProtocolTest) InputService8TestCaseOperation3Request(input *InputService8TestShapeInputShape) (req *aws.Request, output *InputService8TestShapeInputService8TestShapeInputService8TestCaseOperation3Output) {
 
 	if opInputService8TestCaseOperation3 == nil {
 		opInputService8TestCaseOperation3 = &aws.Operation{
@@ -814,12 +814,12 @@ func (c *InputService8ProtocolTest) InputService8TestCaseOperation3Request(input
 	}
 
 	req = c.newRequest(opInputService8TestCaseOperation3, input, output)
-	output = &InputService8TestShapeInputService8TestCaseOperation3Output{}
+	output = &InputService8TestShapeInputService8TestShapeInputService8TestCaseOperation3Output{}
 	req.Data = output
 	return
 }
 
-func (c *InputService8ProtocolTest) InputService8TestCaseOperation3(input *InputService8TestShapeInputShape) (output *InputService8TestShapeInputService8TestCaseOperation3Output, err error) {
+func (c *InputService8ProtocolTest) InputService8TestCaseOperation3(input *InputService8TestShapeInputShape) (output *InputService8TestShapeInputService8TestShapeInputService8TestCaseOperation3Output, err error) {
 	req, out := c.InputService8TestCaseOperation3Request(input)
 	output = out
 	err = req.Send()
@@ -829,7 +829,7 @@ func (c *InputService8ProtocolTest) InputService8TestCaseOperation3(input *Input
 var opInputService8TestCaseOperation3 *aws.Operation
 
 // InputService8TestCaseOperation4Request generates a request for the InputService8TestCaseOperation4 operation.
-func (c *InputService8ProtocolTest) InputService8TestCaseOperation4Request(input *InputService8TestShapeInputShape) (req *aws.Request, output *InputService8TestShapeInputService8TestShapeInputService8TestCaseOperation4Output) {
+func (c *InputService8ProtocolTest) InputService8TestCaseOperation4Request(input *InputService8TestShapeInputShape) (req *aws.Request, output *InputService8TestShapeInputService8TestCaseOperation4Output) {
 
 	if opInputService8TestCaseOperation4 == nil {
 		opInputService8TestCaseOperation4 = &aws.Operation{
@@ -844,12 +844,12 @@ func (c *InputService8ProtocolTest) InputService8TestCaseOperation4Request(input
 	}
 
 	req = c.newRequest(opInputService8TestCaseOperation4, input, output)
-	output = &InputService8TestShapeInputService8TestShapeInputService8TestCaseOperation4Output{}
+	output = &InputService8TestShapeInputService8TestCaseOperation4Output{}
 	req.Data = output
 	return
 }
 
-func (c *InputService8ProtocolTest) InputService8TestCaseOperation4(input *InputService8TestShapeInputShape) (output *InputService8TestShapeInputService8TestShapeInputService8TestCaseOperation4Output, err error) {
+func (c *InputService8ProtocolTest) InputService8TestCaseOperation4(input *InputService8TestShapeInputShape) (output *InputService8TestShapeInputService8TestCaseOperation4Output, err error) {
 	req, out := c.InputService8TestCaseOperation4Request(input)
 	output = out
 	err = req.Send()
@@ -918,16 +918,32 @@ func (c *InputService8ProtocolTest) InputService8TestCaseOperation6(input *Input
 
 var opInputService8TestCaseOperation6 *aws.Operation
 
-type InputService8TestShapeInputService8TestCaseOperation3Output struct {
-	metadataInputService8TestShapeInputService8TestCaseOperation3Output `json:"-", xml:"-"`
+type InputService8TestShapeInputService8TestCaseOperation1Output struct {
+	metadataInputService8TestShapeInputService8TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
-type metadataInputService8TestShapeInputService8TestCaseOperation3Output struct {
+type metadataInputService8TestShapeInputService8TestCaseOperation1Output struct {
+	SDKShapeTraits bool `type:"structure"`
+}
+
+type InputService8TestShapeInputService8TestCaseOperation2Output struct {
+	metadataInputService8TestShapeInputService8TestCaseOperation2Output `json:"-" xml:"-"`
+}
+
+type metadataInputService8TestShapeInputService8TestCaseOperation2Output struct {
+	SDKShapeTraits bool `type:"structure"`
+}
+
+type InputService8TestShapeInputService8TestCaseOperation4Output struct {
+	metadataInputService8TestShapeInputService8TestCaseOperation4Output `json:"-" xml:"-"`
+}
+
+type metadataInputService8TestShapeInputService8TestCaseOperation4Output struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
 type InputService8TestShapeInputService8TestCaseOperation5Output struct {
-	metadataInputService8TestShapeInputService8TestCaseOperation5Output `json:"-", xml:"-"`
+	metadataInputService8TestShapeInputService8TestCaseOperation5Output `json:"-" xml:"-"`
 }
 
 type metadataInputService8TestShapeInputService8TestCaseOperation5Output struct {
@@ -935,60 +951,44 @@ type metadataInputService8TestShapeInputService8TestCaseOperation5Output struct 
 }
 
 type InputService8TestShapeInputService8TestCaseOperation6Output struct {
-	metadataInputService8TestShapeInputService8TestCaseOperation6Output `json:"-", xml:"-"`
+	metadataInputService8TestShapeInputService8TestCaseOperation6Output `json:"-" xml:"-"`
 }
 
 type metadataInputService8TestShapeInputService8TestCaseOperation6Output struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
-type InputService8TestShapeInputService8TestShapeInputService8TestCaseOperation1Output struct {
-	metadataInputService8TestShapeInputService8TestShapeInputService8TestCaseOperation1Output `json:"-", xml:"-"`
+type InputService8TestShapeInputService8TestShapeInputService8TestCaseOperation3Output struct {
+	metadataInputService8TestShapeInputService8TestShapeInputService8TestCaseOperation3Output `json:"-" xml:"-"`
 }
 
-type metadataInputService8TestShapeInputService8TestShapeInputService8TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
-}
-
-type InputService8TestShapeInputService8TestShapeInputService8TestCaseOperation2Output struct {
-	metadataInputService8TestShapeInputService8TestShapeInputService8TestCaseOperation2Output `json:"-", xml:"-"`
-}
-
-type metadataInputService8TestShapeInputService8TestShapeInputService8TestCaseOperation2Output struct {
-	SDKShapeTraits bool `type:"structure"`
-}
-
-type InputService8TestShapeInputService8TestShapeInputService8TestCaseOperation4Output struct {
-	metadataInputService8TestShapeInputService8TestShapeInputService8TestCaseOperation4Output `json:"-", xml:"-"`
-}
-
-type metadataInputService8TestShapeInputService8TestShapeInputService8TestCaseOperation4Output struct {
-	SDKShapeTraits bool `type:"structure"`
-}
-
-type InputService8TestShapeInputService8TestShapeRecursiveStructType struct {
-	NoRecurse *string `type:"string"`
-
-	RecursiveList []*InputService8TestShapeInputService8TestShapeRecursiveStructType `type:"list"`
-
-	RecursiveMap *map[string]*InputService8TestShapeInputService8TestShapeRecursiveStructType `type:"map"`
-
-	RecursiveStruct *InputService8TestShapeInputService8TestShapeRecursiveStructType `type:"structure"`
-
-	metadataInputService8TestShapeInputService8TestShapeRecursiveStructType `json:"-", xml:"-"`
-}
-
-type metadataInputService8TestShapeInputService8TestShapeRecursiveStructType struct {
+type metadataInputService8TestShapeInputService8TestShapeInputService8TestCaseOperation3Output struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
 type InputService8TestShapeInputShape struct {
-	RecursiveStruct *InputService8TestShapeInputService8TestShapeRecursiveStructType `type:"structure"`
+	RecursiveStruct *InputService8TestShapeRecursiveStructType `type:"structure"`
 
-	metadataInputService8TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService8TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService8TestShapeInputShape struct {
+	SDKShapeTraits bool `type:"structure"`
+}
+
+type InputService8TestShapeRecursiveStructType struct {
+	NoRecurse *string `type:"string"`
+
+	RecursiveList []*InputService8TestShapeRecursiveStructType `type:"list"`
+
+	RecursiveMap *map[string]*InputService8TestShapeRecursiveStructType `type:"map"`
+
+	RecursiveStruct *InputService8TestShapeRecursiveStructType `type:"structure"`
+
+	metadataInputService8TestShapeRecursiveStructType `json:"-" xml:"-"`
+}
+
+type metadataInputService8TestShapeRecursiveStructType struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
@@ -1089,7 +1089,7 @@ func (c *InputService9ProtocolTest) InputService9TestCaseOperation2(input *Input
 var opInputService9TestCaseOperation2 *aws.Operation
 
 type InputService9TestShapeInputService9TestCaseOperation1Output struct {
-	metadataInputService9TestShapeInputService9TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService9TestShapeInputService9TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService9TestShapeInputService9TestCaseOperation1Output struct {
@@ -1097,7 +1097,7 @@ type metadataInputService9TestShapeInputService9TestCaseOperation1Output struct 
 }
 
 type InputService9TestShapeInputService9TestCaseOperation2Output struct {
-	metadataInputService9TestShapeInputService9TestCaseOperation2Output `json:"-", xml:"-"`
+	metadataInputService9TestShapeInputService9TestCaseOperation2Output `json:"-" xml:"-"`
 }
 
 type metadataInputService9TestShapeInputService9TestCaseOperation2Output struct {
@@ -1109,7 +1109,7 @@ type InputService9TestShapeInputShape struct {
 
 	TimeArgInHeader *time.Time `location:"header" locationName:"x-amz-timearg" type:"timestamp" timestampFormat:"rfc822"`
 
-	metadataInputService9TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService9TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService9TestShapeInputShape struct {
@@ -1256,7 +1256,7 @@ func TestInputService6ProtocolTestStreamingPayloadCase1(t *testing.T) {
 	svc.Endpoint = "https://test"
 
 	input := &InputService6TestShapeInputShape{
-		Body:      bytes.NewReader([]byte("contents")),
+		Body:      []byte("contents"),
 		Checksum:  aws.String("foo"),
 		VaultName: aws.String("name"),
 	}
@@ -1325,7 +1325,7 @@ func TestInputService8ProtocolTestRecursiveShapesCase1(t *testing.T) {
 	svc.Endpoint = "https://test"
 
 	input := &InputService8TestShapeInputShape{
-		RecursiveStruct: &InputService8TestShapeInputService8TestShapeRecursiveStructType{
+		RecursiveStruct: &InputService8TestShapeRecursiveStructType{
 			NoRecurse: aws.String("foo"),
 		},
 	}
@@ -1353,8 +1353,8 @@ func TestInputService8ProtocolTestRecursiveShapesCase2(t *testing.T) {
 	svc.Endpoint = "https://test"
 
 	input := &InputService8TestShapeInputShape{
-		RecursiveStruct: &InputService8TestShapeInputService8TestShapeRecursiveStructType{
-			RecursiveStruct: &InputService8TestShapeInputService8TestShapeRecursiveStructType{
+		RecursiveStruct: &InputService8TestShapeRecursiveStructType{
+			RecursiveStruct: &InputService8TestShapeRecursiveStructType{
 				NoRecurse: aws.String("foo"),
 			},
 		},
@@ -1383,10 +1383,10 @@ func TestInputService8ProtocolTestRecursiveShapesCase3(t *testing.T) {
 	svc.Endpoint = "https://test"
 
 	input := &InputService8TestShapeInputShape{
-		RecursiveStruct: &InputService8TestShapeInputService8TestShapeRecursiveStructType{
-			RecursiveStruct: &InputService8TestShapeInputService8TestShapeRecursiveStructType{
-				RecursiveStruct: &InputService8TestShapeInputService8TestShapeRecursiveStructType{
-					RecursiveStruct: &InputService8TestShapeInputService8TestShapeRecursiveStructType{
+		RecursiveStruct: &InputService8TestShapeRecursiveStructType{
+			RecursiveStruct: &InputService8TestShapeRecursiveStructType{
+				RecursiveStruct: &InputService8TestShapeRecursiveStructType{
+					RecursiveStruct: &InputService8TestShapeRecursiveStructType{
 						NoRecurse: aws.String("foo"),
 					},
 				},
@@ -1417,12 +1417,12 @@ func TestInputService8ProtocolTestRecursiveShapesCase4(t *testing.T) {
 	svc.Endpoint = "https://test"
 
 	input := &InputService8TestShapeInputShape{
-		RecursiveStruct: &InputService8TestShapeInputService8TestShapeRecursiveStructType{
-			RecursiveList: []*InputService8TestShapeInputService8TestShapeRecursiveStructType{
-				&InputService8TestShapeInputService8TestShapeRecursiveStructType{
+		RecursiveStruct: &InputService8TestShapeRecursiveStructType{
+			RecursiveList: []*InputService8TestShapeRecursiveStructType{
+				&InputService8TestShapeRecursiveStructType{
 					NoRecurse: aws.String("foo"),
 				},
-				&InputService8TestShapeInputService8TestShapeRecursiveStructType{
+				&InputService8TestShapeRecursiveStructType{
 					NoRecurse: aws.String("bar"),
 				},
 			},
@@ -1452,13 +1452,13 @@ func TestInputService8ProtocolTestRecursiveShapesCase5(t *testing.T) {
 	svc.Endpoint = "https://test"
 
 	input := &InputService8TestShapeInputShape{
-		RecursiveStruct: &InputService8TestShapeInputService8TestShapeRecursiveStructType{
-			RecursiveList: []*InputService8TestShapeInputService8TestShapeRecursiveStructType{
-				&InputService8TestShapeInputService8TestShapeRecursiveStructType{
+		RecursiveStruct: &InputService8TestShapeRecursiveStructType{
+			RecursiveList: []*InputService8TestShapeRecursiveStructType{
+				&InputService8TestShapeRecursiveStructType{
 					NoRecurse: aws.String("foo"),
 				},
-				&InputService8TestShapeInputService8TestShapeRecursiveStructType{
-					RecursiveStruct: &InputService8TestShapeInputService8TestShapeRecursiveStructType{
+				&InputService8TestShapeRecursiveStructType{
+					RecursiveStruct: &InputService8TestShapeRecursiveStructType{
 						NoRecurse: aws.String("bar"),
 					},
 				},
@@ -1489,12 +1489,12 @@ func TestInputService8ProtocolTestRecursiveShapesCase6(t *testing.T) {
 	svc.Endpoint = "https://test"
 
 	input := &InputService8TestShapeInputShape{
-		RecursiveStruct: &InputService8TestShapeInputService8TestShapeRecursiveStructType{
-			RecursiveMap: &map[string]*InputService8TestShapeInputService8TestShapeRecursiveStructType{
-				"bar": &InputService8TestShapeInputService8TestShapeRecursiveStructType{
+		RecursiveStruct: &InputService8TestShapeRecursiveStructType{
+			RecursiveMap: &map[string]*InputService8TestShapeRecursiveStructType{
+				"bar": &InputService8TestShapeRecursiveStructType{
 					NoRecurse: aws.String("bar"),
 				},
-				"foo": &InputService8TestShapeInputService8TestShapeRecursiveStructType{
+				"foo": &InputService8TestShapeRecursiveStructType{
 					NoRecurse: aws.String("foo"),
 				},
 			},
@@ -1566,3 +1566,4 @@ func TestInputService9ProtocolTestTimestampValuesCase2(t *testing.T) {
 	assert.Equal(t, "Sun, 25 Jan 2015 08:00:00 GMT", r.Header.Get("x-amz-timearg"))
 
 }
+

--- a/internal/protocol/restjson/build_test.go
+++ b/internal/protocol/restjson/build_test.go
@@ -799,7 +799,7 @@ func (c *InputService8ProtocolTest) InputService8TestCaseOperation2(input *Input
 var opInputService8TestCaseOperation2 *aws.Operation
 
 // InputService8TestCaseOperation3Request generates a request for the InputService8TestCaseOperation3 operation.
-func (c *InputService8ProtocolTest) InputService8TestCaseOperation3Request(input *InputService8TestShapeInputShape) (req *aws.Request, output *InputService8TestShapeInputService8TestShapeInputService8TestCaseOperation3Output) {
+func (c *InputService8ProtocolTest) InputService8TestCaseOperation3Request(input *InputService8TestShapeInputShape) (req *aws.Request, output *InputService8TestShapeInputService8TestCaseOperation3Output) {
 
 	if opInputService8TestCaseOperation3 == nil {
 		opInputService8TestCaseOperation3 = &aws.Operation{
@@ -814,12 +814,12 @@ func (c *InputService8ProtocolTest) InputService8TestCaseOperation3Request(input
 	}
 
 	req = c.newRequest(opInputService8TestCaseOperation3, input, output)
-	output = &InputService8TestShapeInputService8TestShapeInputService8TestCaseOperation3Output{}
+	output = &InputService8TestShapeInputService8TestCaseOperation3Output{}
 	req.Data = output
 	return
 }
 
-func (c *InputService8ProtocolTest) InputService8TestCaseOperation3(input *InputService8TestShapeInputShape) (output *InputService8TestShapeInputService8TestShapeInputService8TestCaseOperation3Output, err error) {
+func (c *InputService8ProtocolTest) InputService8TestCaseOperation3(input *InputService8TestShapeInputShape) (output *InputService8TestShapeInputService8TestCaseOperation3Output, err error) {
 	req, out := c.InputService8TestCaseOperation3Request(input)
 	output = out
 	err = req.Send()
@@ -934,6 +934,14 @@ type metadataInputService8TestShapeInputService8TestCaseOperation2Output struct 
 	SDKShapeTraits bool `type:"structure"`
 }
 
+type InputService8TestShapeInputService8TestCaseOperation3Output struct {
+	metadataInputService8TestShapeInputService8TestCaseOperation3Output `json:"-" xml:"-"`
+}
+
+type metadataInputService8TestShapeInputService8TestCaseOperation3Output struct {
+	SDKShapeTraits bool `type:"structure"`
+}
+
 type InputService8TestShapeInputService8TestCaseOperation4Output struct {
 	metadataInputService8TestShapeInputService8TestCaseOperation4Output `json:"-" xml:"-"`
 }
@@ -955,14 +963,6 @@ type InputService8TestShapeInputService8TestCaseOperation6Output struct {
 }
 
 type metadataInputService8TestShapeInputService8TestCaseOperation6Output struct {
-	SDKShapeTraits bool `type:"structure"`
-}
-
-type InputService8TestShapeInputService8TestShapeInputService8TestCaseOperation3Output struct {
-	metadataInputService8TestShapeInputService8TestShapeInputService8TestCaseOperation3Output `json:"-" xml:"-"`
-}
-
-type metadataInputService8TestShapeInputService8TestShapeInputService8TestCaseOperation3Output struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
@@ -1256,7 +1256,7 @@ func TestInputService6ProtocolTestStreamingPayloadCase1(t *testing.T) {
 	svc.Endpoint = "https://test"
 
 	input := &InputService6TestShapeInputShape{
-		Body:      []byte("contents"),
+		Body:      aws.ReadSeekCloser(bytes.NewBufferString("contents")),
 		Checksum:  aws.String("foo"),
 		VaultName: aws.String("name"),
 	}

--- a/internal/protocol/restjson/unmarshal_test.go
+++ b/internal/protocol/restjson/unmarshal_test.go
@@ -67,7 +67,7 @@ func (c *OutputService1ProtocolTest) newRequest(op *aws.Operation, params, data 
 }
 
 // OutputService1TestCaseOperation1Request generates a request for the OutputService1TestCaseOperation1 operation.
-func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1Request(input *OutputService1TestShapeOutputService1TestCaseOperation1Input) (req *aws.Request, output *OutputService1TestShapeOutputService1TestShapeOutputShape) {
+func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1Request(input *OutputService1TestShapeOutputService1TestCaseOperation1Input) (req *aws.Request, output *OutputService1TestShapeOutputShape) {
 
 	if opOutputService1TestCaseOperation1 == nil {
 		opOutputService1TestCaseOperation1 = &aws.Operation{
@@ -80,12 +80,12 @@ func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1Request(inp
 	}
 
 	req = c.newRequest(opOutputService1TestCaseOperation1, input, output)
-	output = &OutputService1TestShapeOutputService1TestShapeOutputShape{}
+	output = &OutputService1TestShapeOutputShape{}
 	req.Data = output
 	return
 }
 
-func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1(input *OutputService1TestShapeOutputService1TestCaseOperation1Input) (output *OutputService1TestShapeOutputService1TestShapeOutputShape, err error) {
+func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1(input *OutputService1TestShapeOutputService1TestCaseOperation1Input) (output *OutputService1TestShapeOutputShape, err error) {
 	req, out := c.OutputService1TestCaseOperation1Request(input)
 	output = out
 	err = req.Send()
@@ -95,14 +95,14 @@ func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1(input *Out
 var opOutputService1TestCaseOperation1 *aws.Operation
 
 type OutputService1TestShapeOutputService1TestCaseOperation1Input struct {
-	metadataOutputService1TestShapeOutputService1TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService1TestShapeOutputService1TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService1TestShapeOutputService1TestCaseOperation1Input struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
-type OutputService1TestShapeOutputService1TestShapeOutputShape struct {
+type OutputService1TestShapeOutputShape struct {
 	Char *string `type:"character"`
 
 	Double *float64 `type:"double"`
@@ -125,10 +125,10 @@ type OutputService1TestShapeOutputService1TestShapeOutputShape struct {
 
 	TrueBool *bool `type:"boolean"`
 
-	metadataOutputService1TestShapeOutputService1TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService1TestShapeOutputShape `json:"-" xml:"-"`
 }
 
-type metadataOutputService1TestShapeOutputService1TestShapeOutputShape struct {
+type metadataOutputService1TestShapeOutputShape struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
@@ -199,7 +199,7 @@ var opOutputService2TestCaseOperation1 *aws.Operation
 type OutputService2TestShapeBlobContainer struct {
 	Foo []byte `locationName:"foo" type:"blob"`
 
-	metadataOutputService2TestShapeBlobContainer `json:"-", xml:"-"`
+	metadataOutputService2TestShapeBlobContainer `json:"-" xml:"-"`
 }
 
 type metadataOutputService2TestShapeBlobContainer struct {
@@ -207,7 +207,7 @@ type metadataOutputService2TestShapeBlobContainer struct {
 }
 
 type OutputService2TestShapeOutputService2TestCaseOperation1Input struct {
-	metadataOutputService2TestShapeOutputService2TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService2TestShapeOutputService2TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService2TestShapeOutputService2TestCaseOperation1Input struct {
@@ -219,7 +219,7 @@ type OutputService2TestShapeOutputShape struct {
 
 	StructMember *OutputService2TestShapeBlobContainer `type:"structure"`
 
-	metadataOutputService2TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService2TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService2TestShapeOutputShape struct {
@@ -291,7 +291,7 @@ func (c *OutputService3ProtocolTest) OutputService3TestCaseOperation1(input *Out
 var opOutputService3TestCaseOperation1 *aws.Operation
 
 type OutputService3TestShapeOutputService3TestCaseOperation1Input struct {
-	metadataOutputService3TestShapeOutputService3TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService3TestShapeOutputService3TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService3TestShapeOutputService3TestCaseOperation1Input struct {
@@ -303,7 +303,7 @@ type OutputService3TestShapeOutputShape struct {
 
 	TimeMember *time.Time `type:"timestamp" timestampFormat:"unix"`
 
-	metadataOutputService3TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService3TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService3TestShapeOutputShape struct {
@@ -313,7 +313,7 @@ type metadataOutputService3TestShapeOutputShape struct {
 type OutputService3TestShapeTimeContainer struct {
 	Foo *time.Time `locationName:"foo" type:"timestamp" timestampFormat:"unix"`
 
-	metadataOutputService3TestShapeTimeContainer `json:"-", xml:"-"`
+	metadataOutputService3TestShapeTimeContainer `json:"-" xml:"-"`
 }
 
 type metadataOutputService3TestShapeTimeContainer struct {
@@ -385,7 +385,7 @@ func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation1(input *Out
 var opOutputService4TestCaseOperation1 *aws.Operation
 
 type OutputService4TestShapeOutputService4TestCaseOperation1Input struct {
-	metadataOutputService4TestShapeOutputService4TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService4TestShapeOutputService4TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService4TestShapeOutputService4TestCaseOperation1Input struct {
@@ -395,7 +395,7 @@ type metadataOutputService4TestShapeOutputService4TestCaseOperation1Input struct
 type OutputService4TestShapeOutputShape struct {
 	ListMember []*string `type:"list"`
 
-	metadataOutputService4TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService4TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService4TestShapeOutputShape struct {
@@ -467,7 +467,7 @@ func (c *OutputService5ProtocolTest) OutputService5TestCaseOperation1(input *Out
 var opOutputService5TestCaseOperation1 *aws.Operation
 
 type OutputService5TestShapeOutputService5TestCaseOperation1Input struct {
-	metadataOutputService5TestShapeOutputService5TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService5TestShapeOutputService5TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService5TestShapeOutputService5TestCaseOperation1Input struct {
@@ -477,7 +477,7 @@ type metadataOutputService5TestShapeOutputService5TestCaseOperation1Input struct
 type OutputService5TestShapeOutputShape struct {
 	ListMember []*OutputService5TestShapeSingleStruct `type:"list"`
 
-	metadataOutputService5TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService5TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService5TestShapeOutputShape struct {
@@ -487,7 +487,7 @@ type metadataOutputService5TestShapeOutputShape struct {
 type OutputService5TestShapeSingleStruct struct {
 	Foo *string `type:"string"`
 
-	metadataOutputService5TestShapeSingleStruct `json:"-", xml:"-"`
+	metadataOutputService5TestShapeSingleStruct `json:"-" xml:"-"`
 }
 
 type metadataOutputService5TestShapeSingleStruct struct {
@@ -559,7 +559,7 @@ func (c *OutputService6ProtocolTest) OutputService6TestCaseOperation1(input *Out
 var opOutputService6TestCaseOperation1 *aws.Operation
 
 type OutputService6TestShapeOutputService6TestCaseOperation1Input struct {
-	metadataOutputService6TestShapeOutputService6TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService6TestShapeOutputService6TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService6TestShapeOutputService6TestCaseOperation1Input struct {
@@ -569,7 +569,7 @@ type metadataOutputService6TestShapeOutputService6TestCaseOperation1Input struct
 type OutputService6TestShapeOutputShape struct {
 	MapMember *map[string][]*int64 `type:"map"`
 
-	metadataOutputService6TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService6TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService6TestShapeOutputShape struct {
@@ -641,7 +641,7 @@ func (c *OutputService7ProtocolTest) OutputService7TestCaseOperation1(input *Out
 var opOutputService7TestCaseOperation1 *aws.Operation
 
 type OutputService7TestShapeOutputService7TestCaseOperation1Input struct {
-	metadataOutputService7TestShapeOutputService7TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService7TestShapeOutputService7TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService7TestShapeOutputService7TestCaseOperation1Input struct {
@@ -651,7 +651,7 @@ type metadataOutputService7TestShapeOutputService7TestCaseOperation1Input struct
 type OutputService7TestShapeOutputShape struct {
 	MapMember *map[string]*time.Time `type:"map"`
 
-	metadataOutputService7TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService7TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService7TestShapeOutputShape struct {
@@ -723,7 +723,7 @@ func (c *OutputService8ProtocolTest) OutputService8TestCaseOperation1(input *Out
 var opOutputService8TestCaseOperation1 *aws.Operation
 
 type OutputService8TestShapeOutputService8TestCaseOperation1Input struct {
-	metadataOutputService8TestShapeOutputService8TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService8TestShapeOutputService8TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService8TestShapeOutputService8TestCaseOperation1Input struct {
@@ -733,7 +733,7 @@ type metadataOutputService8TestShapeOutputService8TestCaseOperation1Input struct
 type OutputService8TestShapeOutputShape struct {
 	StrType *string `type:"string"`
 
-	metadataOutputService8TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService8TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService8TestShapeOutputShape struct {
@@ -805,7 +805,7 @@ func (c *OutputService9ProtocolTest) OutputService9TestCaseOperation1(input *Out
 var opOutputService9TestCaseOperation1 *aws.Operation
 
 type OutputService9TestShapeOutputService9TestCaseOperation1Input struct {
-	metadataOutputService9TestShapeOutputService9TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService9TestShapeOutputService9TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService9TestShapeOutputService9TestCaseOperation1Input struct {
@@ -817,7 +817,7 @@ type OutputService9TestShapeOutputShape struct {
 
 	PrefixedHeaders *map[string]*string `location:"headers" locationName:"X-" type:"map"`
 
-	metadataOutputService9TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService9TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService9TestShapeOutputShape struct {
@@ -891,7 +891,7 @@ var opOutputService10TestCaseOperation1 *aws.Operation
 type OutputService10TestShapeBodyStructure struct {
 	Foo *string `type:"string"`
 
-	metadataOutputService10TestShapeBodyStructure `json:"-", xml:"-"`
+	metadataOutputService10TestShapeBodyStructure `json:"-" xml:"-"`
 }
 
 type metadataOutputService10TestShapeBodyStructure struct {
@@ -899,7 +899,7 @@ type metadataOutputService10TestShapeBodyStructure struct {
 }
 
 type OutputService10TestShapeOutputService10TestCaseOperation1Input struct {
-	metadataOutputService10TestShapeOutputService10TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService10TestShapeOutputService10TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService10TestShapeOutputService10TestCaseOperation1Input struct {
@@ -911,7 +911,7 @@ type OutputService10TestShapeOutputShape struct {
 
 	Header *string `location:"header" locationName:"X-Foo" type:"string"`
 
-	metadataOutputService10TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService10TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService10TestShapeOutputShape struct {
@@ -983,7 +983,7 @@ func (c *OutputService11ProtocolTest) OutputService11TestCaseOperation1(input *O
 var opOutputService11TestCaseOperation1 *aws.Operation
 
 type OutputService11TestShapeOutputService11TestCaseOperation1Input struct {
-	metadataOutputService11TestShapeOutputService11TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService11TestShapeOutputService11TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService11TestShapeOutputService11TestCaseOperation1Input struct {
@@ -993,7 +993,7 @@ type metadataOutputService11TestShapeOutputService11TestCaseOperation1Input stru
 type OutputService11TestShapeOutputShape struct {
 	Stream []byte `type:"blob"`
 
-	metadataOutputService11TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService11TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService11TestShapeOutputShape struct {

--- a/internal/protocol/restxml/build_test.go
+++ b/internal/protocol/restxml/build_test.go
@@ -127,7 +127,7 @@ func (c *InputService1ProtocolTest) InputService1TestCaseOperation2(input *Input
 var opInputService1TestCaseOperation2 *aws.Operation
 
 type InputService1TestShapeInputService1TestCaseOperation1Output struct {
-	metadataInputService1TestShapeInputService1TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService1TestShapeInputService1TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService1TestShapeInputService1TestCaseOperation1Output struct {
@@ -135,7 +135,7 @@ type metadataInputService1TestShapeInputService1TestCaseOperation1Output struct 
 }
 
 type InputService1TestShapeInputService1TestCaseOperation2Output struct {
-	metadataInputService1TestShapeInputService1TestCaseOperation2Output `json:"-", xml:"-"`
+	metadataInputService1TestShapeInputService1TestCaseOperation2Output `json:"-" xml:"-"`
 }
 
 type metadataInputService1TestShapeInputService1TestCaseOperation2Output struct {
@@ -147,7 +147,7 @@ type InputService1TestShapeInputShape struct {
 
 	Name *string `type:"string"`
 
-	metadataInputService1TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService1TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService1TestShapeInputShape struct {
@@ -221,7 +221,7 @@ func (c *InputService2ProtocolTest) InputService2TestCaseOperation1(input *Input
 var opInputService2TestCaseOperation1 *aws.Operation
 
 type InputService2TestShapeInputService2TestCaseOperation1Output struct {
-	metadataInputService2TestShapeInputService2TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService2TestShapeInputService2TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService2TestShapeInputService2TestCaseOperation1Output struct {
@@ -237,7 +237,7 @@ type InputService2TestShapeInputShape struct {
 
 	Third *float64 `type:"float"`
 
-	metadataInputService2TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService2TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService2TestShapeInputShape struct {
@@ -311,7 +311,7 @@ func (c *InputService3ProtocolTest) InputService3TestCaseOperation1(input *Input
 var opInputService3TestCaseOperation1 *aws.Operation
 
 type InputService3TestShapeInputService3TestCaseOperation1Output struct {
-	metadataInputService3TestShapeInputService3TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService3TestShapeInputService3TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService3TestShapeInputService3TestCaseOperation1Output struct {
@@ -323,7 +323,7 @@ type InputService3TestShapeInputShape struct {
 
 	SubStructure *InputService3TestShapeSubStructure `type:"structure"`
 
-	metadataInputService3TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService3TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService3TestShapeInputShape struct {
@@ -335,7 +335,7 @@ type InputService3TestShapeSubStructure struct {
 
 	Foo *string `type:"string"`
 
-	metadataInputService3TestShapeSubStructure `json:"-", xml:"-"`
+	metadataInputService3TestShapeSubStructure `json:"-" xml:"-"`
 }
 
 type metadataInputService3TestShapeSubStructure struct {
@@ -409,7 +409,7 @@ func (c *InputService4ProtocolTest) InputService4TestCaseOperation1(input *Input
 var opInputService4TestCaseOperation1 *aws.Operation
 
 type InputService4TestShapeInputService4TestCaseOperation1Output struct {
-	metadataInputService4TestShapeInputService4TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService4TestShapeInputService4TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService4TestShapeInputService4TestCaseOperation1Output struct {
@@ -421,7 +421,7 @@ type InputService4TestShapeInputShape struct {
 
 	SubStructure *InputService4TestShapeSubStructure `type:"structure"`
 
-	metadataInputService4TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService4TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService4TestShapeInputShape struct {
@@ -433,7 +433,7 @@ type InputService4TestShapeSubStructure struct {
 
 	Foo *string `type:"string"`
 
-	metadataInputService4TestShapeSubStructure `json:"-", xml:"-"`
+	metadataInputService4TestShapeSubStructure `json:"-" xml:"-"`
 }
 
 type metadataInputService4TestShapeSubStructure struct {
@@ -507,7 +507,7 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation1(input *Input
 var opInputService5TestCaseOperation1 *aws.Operation
 
 type InputService5TestShapeInputService5TestCaseOperation1Output struct {
-	metadataInputService5TestShapeInputService5TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService5TestShapeInputService5TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService5TestShapeInputService5TestCaseOperation1Output struct {
@@ -517,7 +517,7 @@ type metadataInputService5TestShapeInputService5TestCaseOperation1Output struct 
 type InputService5TestShapeInputShape struct {
 	ListParam []*string `type:"list"`
 
-	metadataInputService5TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService5TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService5TestShapeInputShape struct {
@@ -591,7 +591,7 @@ func (c *InputService6ProtocolTest) InputService6TestCaseOperation1(input *Input
 var opInputService6TestCaseOperation1 *aws.Operation
 
 type InputService6TestShapeInputService6TestCaseOperation1Output struct {
-	metadataInputService6TestShapeInputService6TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService6TestShapeInputService6TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService6TestShapeInputService6TestCaseOperation1Output struct {
@@ -601,7 +601,7 @@ type metadataInputService6TestShapeInputService6TestCaseOperation1Output struct 
 type InputService6TestShapeInputShape struct {
 	ListParam []*string `locationName:"AlternateName" locationNameList:"NotMember" type:"list"`
 
-	metadataInputService6TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService6TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService6TestShapeInputShape struct {
@@ -675,7 +675,7 @@ func (c *InputService7ProtocolTest) InputService7TestCaseOperation1(input *Input
 var opInputService7TestCaseOperation1 *aws.Operation
 
 type InputService7TestShapeInputService7TestCaseOperation1Output struct {
-	metadataInputService7TestShapeInputService7TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService7TestShapeInputService7TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService7TestShapeInputService7TestCaseOperation1Output struct {
@@ -685,7 +685,7 @@ type metadataInputService7TestShapeInputService7TestCaseOperation1Output struct 
 type InputService7TestShapeInputShape struct {
 	ListParam []*string `type:"list" flattened:"true"`
 
-	metadataInputService7TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService7TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService7TestShapeInputShape struct {
@@ -759,7 +759,7 @@ func (c *InputService8ProtocolTest) InputService8TestCaseOperation1(input *Input
 var opInputService8TestCaseOperation1 *aws.Operation
 
 type InputService8TestShapeInputService8TestCaseOperation1Output struct {
-	metadataInputService8TestShapeInputService8TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService8TestShapeInputService8TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService8TestShapeInputService8TestCaseOperation1Output struct {
@@ -769,7 +769,7 @@ type metadataInputService8TestShapeInputService8TestCaseOperation1Output struct 
 type InputService8TestShapeInputShape struct {
 	ListParam []*string `locationName:"item" type:"list" flattened:"true"`
 
-	metadataInputService8TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService8TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService8TestShapeInputShape struct {
@@ -843,7 +843,7 @@ func (c *InputService9ProtocolTest) InputService9TestCaseOperation1(input *Input
 var opInputService9TestCaseOperation1 *aws.Operation
 
 type InputService9TestShapeInputService9TestCaseOperation1Output struct {
-	metadataInputService9TestShapeInputService9TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService9TestShapeInputService9TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService9TestShapeInputService9TestCaseOperation1Output struct {
@@ -853,7 +853,7 @@ type metadataInputService9TestShapeInputService9TestCaseOperation1Output struct 
 type InputService9TestShapeInputShape struct {
 	ListParam []*InputService9TestShapeSingleFieldStruct `locationName:"item" type:"list" flattened:"true"`
 
-	metadataInputService9TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService9TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService9TestShapeInputShape struct {
@@ -863,7 +863,7 @@ type metadataInputService9TestShapeInputShape struct {
 type InputService9TestShapeSingleFieldStruct struct {
 	Element *string `locationName:"value" type:"string"`
 
-	metadataInputService9TestShapeSingleFieldStruct `json:"-", xml:"-"`
+	metadataInputService9TestShapeSingleFieldStruct `json:"-" xml:"-"`
 }
 
 type metadataInputService9TestShapeSingleFieldStruct struct {
@@ -937,7 +937,7 @@ func (c *InputService10ProtocolTest) InputService10TestCaseOperation1(input *Inp
 var opInputService10TestCaseOperation1 *aws.Operation
 
 type InputService10TestShapeInputService10TestCaseOperation1Output struct {
-	metadataInputService10TestShapeInputService10TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService10TestShapeInputService10TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService10TestShapeInputService10TestCaseOperation1Output struct {
@@ -947,7 +947,7 @@ type metadataInputService10TestShapeInputService10TestCaseOperation1Output struc
 type InputService10TestShapeInputShape struct {
 	StructureParam *InputService10TestShapeStructureShape `type:"structure"`
 
-	metadataInputService10TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService10TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService10TestShapeInputShape struct {
@@ -959,7 +959,7 @@ type InputService10TestShapeStructureShape struct {
 
 	T *time.Time `locationName:"t" type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataInputService10TestShapeStructureShape `json:"-", xml:"-"`
+	metadataInputService10TestShapeStructureShape `json:"-" xml:"-"`
 }
 
 type metadataInputService10TestShapeStructureShape struct {
@@ -1033,7 +1033,7 @@ func (c *InputService11ProtocolTest) InputService11TestCaseOperation1(input *Inp
 var opInputService11TestCaseOperation1 *aws.Operation
 
 type InputService11TestShapeInputService11TestCaseOperation1Output struct {
-	metadataInputService11TestShapeInputService11TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService11TestShapeInputService11TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService11TestShapeInputService11TestCaseOperation1Output struct {
@@ -1043,7 +1043,7 @@ type metadataInputService11TestShapeInputService11TestCaseOperation1Output struc
 type InputService11TestShapeInputShape struct {
 	Foo *map[string]*string `location:"headers" locationName:"x-foo-" type:"map"`
 
-	metadataInputService11TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService11TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService11TestShapeInputShape struct {
@@ -1117,7 +1117,7 @@ func (c *InputService12ProtocolTest) InputService12TestCaseOperation1(input *Inp
 var opInputService12TestCaseOperation1 *aws.Operation
 
 type InputService12TestShapeInputService12TestCaseOperation1Output struct {
-	metadataInputService12TestShapeInputService12TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService12TestShapeInputService12TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService12TestShapeInputService12TestCaseOperation1Output struct {
@@ -1127,7 +1127,7 @@ type metadataInputService12TestShapeInputService12TestCaseOperation1Output struc
 type InputService12TestShapeInputShape struct {
 	Foo *string `locationName:"foo" type:"string"`
 
-	metadataInputService12TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService12TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService12TestShapeInputShape struct {
@@ -1231,7 +1231,7 @@ func (c *InputService13ProtocolTest) InputService13TestCaseOperation2(input *Inp
 var opInputService13TestCaseOperation2 *aws.Operation
 
 type InputService13TestShapeInputService13TestCaseOperation1Output struct {
-	metadataInputService13TestShapeInputService13TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService13TestShapeInputService13TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService13TestShapeInputService13TestCaseOperation1Output struct {
@@ -1239,7 +1239,7 @@ type metadataInputService13TestShapeInputService13TestCaseOperation1Output struc
 }
 
 type InputService13TestShapeInputService13TestCaseOperation2Output struct {
-	metadataInputService13TestShapeInputService13TestCaseOperation2Output `json:"-", xml:"-"`
+	metadataInputService13TestShapeInputService13TestCaseOperation2Output `json:"-" xml:"-"`
 }
 
 type metadataInputService13TestShapeInputService13TestCaseOperation2Output struct {
@@ -1249,7 +1249,7 @@ type metadataInputService13TestShapeInputService13TestCaseOperation2Output struc
 type InputService13TestShapeInputShape struct {
 	Foo []byte `locationName:"foo" type:"blob"`
 
-	metadataInputService13TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService13TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService13TestShapeInputShape struct {
@@ -1355,7 +1355,7 @@ var opInputService14TestCaseOperation2 *aws.Operation
 type InputService14TestShapeFooShape struct {
 	Baz *string `locationName:"baz" type:"string"`
 
-	metadataInputService14TestShapeFooShape `json:"-", xml:"-"`
+	metadataInputService14TestShapeFooShape `json:"-" xml:"-"`
 }
 
 type metadataInputService14TestShapeFooShape struct {
@@ -1363,7 +1363,7 @@ type metadataInputService14TestShapeFooShape struct {
 }
 
 type InputService14TestShapeInputService14TestCaseOperation1Output struct {
-	metadataInputService14TestShapeInputService14TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService14TestShapeInputService14TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService14TestShapeInputService14TestCaseOperation1Output struct {
@@ -1371,7 +1371,7 @@ type metadataInputService14TestShapeInputService14TestCaseOperation1Output struc
 }
 
 type InputService14TestShapeInputService14TestCaseOperation2Output struct {
-	metadataInputService14TestShapeInputService14TestCaseOperation2Output `json:"-", xml:"-"`
+	metadataInputService14TestShapeInputService14TestCaseOperation2Output `json:"-" xml:"-"`
 }
 
 type metadataInputService14TestShapeInputService14TestCaseOperation2Output struct {
@@ -1381,7 +1381,7 @@ type metadataInputService14TestShapeInputService14TestCaseOperation2Output struc
 type InputService14TestShapeInputShape struct {
 	Foo *InputService14TestShapeFooShape `locationName:"foo" type:"structure"`
 
-	metadataInputService14TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService14TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService14TestShapeInputShape struct {
@@ -1457,7 +1457,7 @@ var opInputService15TestCaseOperation1 *aws.Operation
 type InputService15TestShapeGrant struct {
 	Grantee *InputService15TestShapeGrantee `type:"structure"`
 
-	metadataInputService15TestShapeGrant `json:"-", xml:"-"`
+	metadataInputService15TestShapeGrant `json:"-" xml:"-"`
 }
 
 type metadataInputService15TestShapeGrant struct {
@@ -1469,7 +1469,7 @@ type InputService15TestShapeGrantee struct {
 
 	Type *string `locationName:"xsi:type" type:"string" xmlAttribute:"true"`
 
-	metadataInputService15TestShapeGrantee `json:"-", xml:"-"`
+	metadataInputService15TestShapeGrantee `json:"-" xml:"-"`
 }
 
 type metadataInputService15TestShapeGrantee struct {
@@ -1477,7 +1477,7 @@ type metadataInputService15TestShapeGrantee struct {
 }
 
 type InputService15TestShapeInputService15TestCaseOperation1Output struct {
-	metadataInputService15TestShapeInputService15TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService15TestShapeInputService15TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService15TestShapeInputService15TestCaseOperation1Output struct {
@@ -1487,7 +1487,7 @@ type metadataInputService15TestShapeInputService15TestCaseOperation1Output struc
 type InputService15TestShapeInputShape struct {
 	Grant *InputService15TestShapeGrant `locationName:"Grant" type:"structure"`
 
-	metadataInputService15TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService15TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService15TestShapeInputShape struct {
@@ -1561,7 +1561,7 @@ func (c *InputService16ProtocolTest) InputService16TestCaseOperation1(input *Inp
 var opInputService16TestCaseOperation1 *aws.Operation
 
 type InputService16TestShapeInputService16TestCaseOperation1Output struct {
-	metadataInputService16TestShapeInputService16TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService16TestShapeInputService16TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService16TestShapeInputService16TestCaseOperation1Output struct {
@@ -1573,7 +1573,7 @@ type InputService16TestShapeInputShape struct {
 
 	Key *string `location:"uri" type:"string"`
 
-	metadataInputService16TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService16TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService16TestShapeInputShape struct {
@@ -1677,7 +1677,7 @@ func (c *InputService17ProtocolTest) InputService17TestCaseOperation2(input *Inp
 var opInputService17TestCaseOperation2 *aws.Operation
 
 type InputService17TestShapeInputService17TestCaseOperation1Output struct {
-	metadataInputService17TestShapeInputService17TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService17TestShapeInputService17TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService17TestShapeInputService17TestCaseOperation1Output struct {
@@ -1685,7 +1685,7 @@ type metadataInputService17TestShapeInputService17TestCaseOperation1Output struc
 }
 
 type InputService17TestShapeInputService17TestCaseOperation2Output struct {
-	metadataInputService17TestShapeInputService17TestCaseOperation2Output `json:"-", xml:"-"`
+	metadataInputService17TestShapeInputService17TestCaseOperation2Output `json:"-" xml:"-"`
 }
 
 type metadataInputService17TestShapeInputService17TestCaseOperation2Output struct {
@@ -1695,7 +1695,7 @@ type metadataInputService17TestShapeInputService17TestCaseOperation2Output struc
 type InputService17TestShapeInputShape struct {
 	Foo *string `location:"querystring" locationName:"param-name" type:"string"`
 
-	metadataInputService17TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService17TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService17TestShapeInputShape struct {
@@ -1829,7 +1829,7 @@ func (c *InputService18ProtocolTest) InputService18TestCaseOperation3(input *Inp
 var opInputService18TestCaseOperation3 *aws.Operation
 
 // InputService18TestCaseOperation4Request generates a request for the InputService18TestCaseOperation4 operation.
-func (c *InputService18ProtocolTest) InputService18TestCaseOperation4Request(input *InputService18TestShapeInputShape) (req *aws.Request, output *InputService18TestShapeInputService18TestShapeInputService18TestCaseOperation4Output) {
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation4Request(input *InputService18TestShapeInputShape) (req *aws.Request, output *InputService18TestShapeInputService18TestCaseOperation4Output) {
 
 	if opInputService18TestCaseOperation4 == nil {
 		opInputService18TestCaseOperation4 = &aws.Operation{
@@ -1844,12 +1844,12 @@ func (c *InputService18ProtocolTest) InputService18TestCaseOperation4Request(inp
 	}
 
 	req = c.newRequest(opInputService18TestCaseOperation4, input, output)
-	output = &InputService18TestShapeInputService18TestShapeInputService18TestCaseOperation4Output{}
+	output = &InputService18TestShapeInputService18TestCaseOperation4Output{}
 	req.Data = output
 	return
 }
 
-func (c *InputService18ProtocolTest) InputService18TestCaseOperation4(input *InputService18TestShapeInputShape) (output *InputService18TestShapeInputService18TestShapeInputService18TestCaseOperation4Output, err error) {
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation4(input *InputService18TestShapeInputShape) (output *InputService18TestShapeInputService18TestCaseOperation4Output, err error) {
 	req, out := c.InputService18TestCaseOperation4Request(input)
 	output = out
 	err = req.Send()
@@ -1859,7 +1859,7 @@ func (c *InputService18ProtocolTest) InputService18TestCaseOperation4(input *Inp
 var opInputService18TestCaseOperation4 *aws.Operation
 
 // InputService18TestCaseOperation5Request generates a request for the InputService18TestCaseOperation5 operation.
-func (c *InputService18ProtocolTest) InputService18TestCaseOperation5Request(input *InputService18TestShapeInputShape) (req *aws.Request, output *InputService18TestShapeInputService18TestCaseOperation5Output) {
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation5Request(input *InputService18TestShapeInputShape) (req *aws.Request, output *InputService18TestShapeInputService18TestShapeInputService18TestCaseOperation5Output) {
 
 	if opInputService18TestCaseOperation5 == nil {
 		opInputService18TestCaseOperation5 = &aws.Operation{
@@ -1874,12 +1874,12 @@ func (c *InputService18ProtocolTest) InputService18TestCaseOperation5Request(inp
 	}
 
 	req = c.newRequest(opInputService18TestCaseOperation5, input, output)
-	output = &InputService18TestShapeInputService18TestCaseOperation5Output{}
+	output = &InputService18TestShapeInputService18TestShapeInputService18TestCaseOperation5Output{}
 	req.Data = output
 	return
 }
 
-func (c *InputService18ProtocolTest) InputService18TestCaseOperation5(input *InputService18TestShapeInputShape) (output *InputService18TestShapeInputService18TestCaseOperation5Output, err error) {
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation5(input *InputService18TestShapeInputShape) (output *InputService18TestShapeInputService18TestShapeInputService18TestCaseOperation5Output, err error) {
 	req, out := c.InputService18TestCaseOperation5Request(input)
 	output = out
 	err = req.Send()
@@ -1919,7 +1919,7 @@ func (c *InputService18ProtocolTest) InputService18TestCaseOperation6(input *Inp
 var opInputService18TestCaseOperation6 *aws.Operation
 
 type InputService18TestShapeInputService18TestCaseOperation1Output struct {
-	metadataInputService18TestShapeInputService18TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService18TestShapeInputService18TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService18TestShapeInputService18TestCaseOperation1Output struct {
@@ -1927,23 +1927,23 @@ type metadataInputService18TestShapeInputService18TestCaseOperation1Output struc
 }
 
 type InputService18TestShapeInputService18TestCaseOperation2Output struct {
-	metadataInputService18TestShapeInputService18TestCaseOperation2Output `json:"-", xml:"-"`
+	metadataInputService18TestShapeInputService18TestCaseOperation2Output `json:"-" xml:"-"`
 }
 
 type metadataInputService18TestShapeInputService18TestCaseOperation2Output struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
-type InputService18TestShapeInputService18TestCaseOperation5Output struct {
-	metadataInputService18TestShapeInputService18TestCaseOperation5Output `json:"-", xml:"-"`
+type InputService18TestShapeInputService18TestCaseOperation4Output struct {
+	metadataInputService18TestShapeInputService18TestCaseOperation4Output `json:"-" xml:"-"`
 }
 
-type metadataInputService18TestShapeInputService18TestCaseOperation5Output struct {
+type metadataInputService18TestShapeInputService18TestCaseOperation4Output struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
 type InputService18TestShapeInputService18TestCaseOperation6Output struct {
-	metadataInputService18TestShapeInputService18TestCaseOperation6Output `json:"-", xml:"-"`
+	metadataInputService18TestShapeInputService18TestCaseOperation6Output `json:"-" xml:"-"`
 }
 
 type metadataInputService18TestShapeInputService18TestCaseOperation6Output struct {
@@ -1951,25 +1951,25 @@ type metadataInputService18TestShapeInputService18TestCaseOperation6Output struc
 }
 
 type InputService18TestShapeInputService18TestShapeInputService18TestCaseOperation3Output struct {
-	metadataInputService18TestShapeInputService18TestShapeInputService18TestCaseOperation3Output `json:"-", xml:"-"`
+	metadataInputService18TestShapeInputService18TestShapeInputService18TestCaseOperation3Output `json:"-" xml:"-"`
 }
 
 type metadataInputService18TestShapeInputService18TestShapeInputService18TestCaseOperation3Output struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
-type InputService18TestShapeInputService18TestShapeInputService18TestCaseOperation4Output struct {
-	metadataInputService18TestShapeInputService18TestShapeInputService18TestCaseOperation4Output `json:"-", xml:"-"`
+type InputService18TestShapeInputService18TestShapeInputService18TestCaseOperation5Output struct {
+	metadataInputService18TestShapeInputService18TestShapeInputService18TestCaseOperation5Output `json:"-" xml:"-"`
 }
 
-type metadataInputService18TestShapeInputService18TestShapeInputService18TestCaseOperation4Output struct {
+type metadataInputService18TestShapeInputService18TestShapeInputService18TestCaseOperation5Output struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
 type InputService18TestShapeInputShape struct {
 	RecursiveStruct *InputService18TestShapeRecursiveStructType `type:"structure"`
 
-	metadataInputService18TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService18TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService18TestShapeInputShape struct {
@@ -1985,7 +1985,7 @@ type InputService18TestShapeRecursiveStructType struct {
 
 	RecursiveStruct *InputService18TestShapeRecursiveStructType `type:"structure"`
 
-	metadataInputService18TestShapeRecursiveStructType `json:"-", xml:"-"`
+	metadataInputService18TestShapeRecursiveStructType `json:"-" xml:"-"`
 }
 
 type metadataInputService18TestShapeRecursiveStructType struct {
@@ -2059,7 +2059,7 @@ func (c *InputService19ProtocolTest) InputService19TestCaseOperation1(input *Inp
 var opInputService19TestCaseOperation1 *aws.Operation
 
 type InputService19TestShapeInputService19TestCaseOperation1Output struct {
-	metadataInputService19TestShapeInputService19TestCaseOperation1Output `json:"-", xml:"-"`
+	metadataInputService19TestShapeInputService19TestCaseOperation1Output `json:"-" xml:"-"`
 }
 
 type metadataInputService19TestShapeInputService19TestCaseOperation1Output struct {
@@ -2069,7 +2069,7 @@ type metadataInputService19TestShapeInputService19TestCaseOperation1Output struc
 type InputService19TestShapeInputShape struct {
 	TimeArgInHeader *time.Time `location:"header" locationName:"x-amz-timearg" type:"timestamp" timestampFormat:"rfc822"`
 
-	metadataInputService19TestShapeInputShape `json:"-", xml:"-"`
+	metadataInputService19TestShapeInputShape `json:"-" xml:"-"`
 }
 
 type metadataInputService19TestShapeInputShape struct {

--- a/internal/protocol/restxml/build_test.go
+++ b/internal/protocol/restxml/build_test.go
@@ -1799,7 +1799,7 @@ func (c *InputService18ProtocolTest) InputService18TestCaseOperation2(input *Inp
 var opInputService18TestCaseOperation2 *aws.Operation
 
 // InputService18TestCaseOperation3Request generates a request for the InputService18TestCaseOperation3 operation.
-func (c *InputService18ProtocolTest) InputService18TestCaseOperation3Request(input *InputService18TestShapeInputShape) (req *aws.Request, output *InputService18TestShapeInputService18TestShapeInputService18TestCaseOperation3Output) {
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation3Request(input *InputService18TestShapeInputShape) (req *aws.Request, output *InputService18TestShapeInputService18TestCaseOperation3Output) {
 
 	if opInputService18TestCaseOperation3 == nil {
 		opInputService18TestCaseOperation3 = &aws.Operation{
@@ -1814,12 +1814,12 @@ func (c *InputService18ProtocolTest) InputService18TestCaseOperation3Request(inp
 	}
 
 	req = c.newRequest(opInputService18TestCaseOperation3, input, output)
-	output = &InputService18TestShapeInputService18TestShapeInputService18TestCaseOperation3Output{}
+	output = &InputService18TestShapeInputService18TestCaseOperation3Output{}
 	req.Data = output
 	return
 }
 
-func (c *InputService18ProtocolTest) InputService18TestCaseOperation3(input *InputService18TestShapeInputShape) (output *InputService18TestShapeInputService18TestShapeInputService18TestCaseOperation3Output, err error) {
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation3(input *InputService18TestShapeInputShape) (output *InputService18TestShapeInputService18TestCaseOperation3Output, err error) {
 	req, out := c.InputService18TestCaseOperation3Request(input)
 	output = out
 	err = req.Send()
@@ -1859,7 +1859,7 @@ func (c *InputService18ProtocolTest) InputService18TestCaseOperation4(input *Inp
 var opInputService18TestCaseOperation4 *aws.Operation
 
 // InputService18TestCaseOperation5Request generates a request for the InputService18TestCaseOperation5 operation.
-func (c *InputService18ProtocolTest) InputService18TestCaseOperation5Request(input *InputService18TestShapeInputShape) (req *aws.Request, output *InputService18TestShapeInputService18TestShapeInputService18TestCaseOperation5Output) {
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation5Request(input *InputService18TestShapeInputShape) (req *aws.Request, output *InputService18TestShapeInputService18TestCaseOperation5Output) {
 
 	if opInputService18TestCaseOperation5 == nil {
 		opInputService18TestCaseOperation5 = &aws.Operation{
@@ -1874,12 +1874,12 @@ func (c *InputService18ProtocolTest) InputService18TestCaseOperation5Request(inp
 	}
 
 	req = c.newRequest(opInputService18TestCaseOperation5, input, output)
-	output = &InputService18TestShapeInputService18TestShapeInputService18TestCaseOperation5Output{}
+	output = &InputService18TestShapeInputService18TestCaseOperation5Output{}
 	req.Data = output
 	return
 }
 
-func (c *InputService18ProtocolTest) InputService18TestCaseOperation5(input *InputService18TestShapeInputShape) (output *InputService18TestShapeInputService18TestShapeInputService18TestCaseOperation5Output, err error) {
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation5(input *InputService18TestShapeInputShape) (output *InputService18TestShapeInputService18TestCaseOperation5Output, err error) {
 	req, out := c.InputService18TestCaseOperation5Request(input)
 	output = out
 	err = req.Send()
@@ -1934,6 +1934,14 @@ type metadataInputService18TestShapeInputService18TestCaseOperation2Output struc
 	SDKShapeTraits bool `type:"structure"`
 }
 
+type InputService18TestShapeInputService18TestCaseOperation3Output struct {
+	metadataInputService18TestShapeInputService18TestCaseOperation3Output `json:"-" xml:"-"`
+}
+
+type metadataInputService18TestShapeInputService18TestCaseOperation3Output struct {
+	SDKShapeTraits bool `type:"structure"`
+}
+
 type InputService18TestShapeInputService18TestCaseOperation4Output struct {
 	metadataInputService18TestShapeInputService18TestCaseOperation4Output `json:"-" xml:"-"`
 }
@@ -1942,27 +1950,19 @@ type metadataInputService18TestShapeInputService18TestCaseOperation4Output struc
 	SDKShapeTraits bool `type:"structure"`
 }
 
+type InputService18TestShapeInputService18TestCaseOperation5Output struct {
+	metadataInputService18TestShapeInputService18TestCaseOperation5Output `json:"-" xml:"-"`
+}
+
+type metadataInputService18TestShapeInputService18TestCaseOperation5Output struct {
+	SDKShapeTraits bool `type:"structure"`
+}
+
 type InputService18TestShapeInputService18TestCaseOperation6Output struct {
 	metadataInputService18TestShapeInputService18TestCaseOperation6Output `json:"-" xml:"-"`
 }
 
 type metadataInputService18TestShapeInputService18TestCaseOperation6Output struct {
-	SDKShapeTraits bool `type:"structure"`
-}
-
-type InputService18TestShapeInputService18TestShapeInputService18TestCaseOperation3Output struct {
-	metadataInputService18TestShapeInputService18TestShapeInputService18TestCaseOperation3Output `json:"-" xml:"-"`
-}
-
-type metadataInputService18TestShapeInputService18TestShapeInputService18TestCaseOperation3Output struct {
-	SDKShapeTraits bool `type:"structure"`
-}
-
-type InputService18TestShapeInputService18TestShapeInputService18TestCaseOperation5Output struct {
-	metadataInputService18TestShapeInputService18TestShapeInputService18TestCaseOperation5Output `json:"-" xml:"-"`
-}
-
-type metadataInputService18TestShapeInputService18TestShapeInputService18TestCaseOperation5Output struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 

--- a/internal/protocol/restxml/unmarshal_test.go
+++ b/internal/protocol/restxml/unmarshal_test.go
@@ -965,7 +965,7 @@ func (c *OutputService11ProtocolTest) newRequest(op *aws.Operation, params, data
 }
 
 // OutputService11TestCaseOperation1Request generates a request for the OutputService11TestCaseOperation1 operation.
-func (c *OutputService11ProtocolTest) OutputService11TestCaseOperation1Request(input *OutputService11TestShapeOutputService11TestShapeOutputService11TestCaseOperation1Input) (req *aws.Request, output *OutputService11TestShapeOutputShape) {
+func (c *OutputService11ProtocolTest) OutputService11TestCaseOperation1Request(input *OutputService11TestShapeOutputService11TestCaseOperation1Input) (req *aws.Request, output *OutputService11TestShapeOutputShape) {
 
 	if opOutputService11TestCaseOperation1 == nil {
 		opOutputService11TestCaseOperation1 = &aws.Operation{
@@ -974,7 +974,7 @@ func (c *OutputService11ProtocolTest) OutputService11TestCaseOperation1Request(i
 	}
 
 	if input == nil {
-		input = &OutputService11TestShapeOutputService11TestShapeOutputService11TestCaseOperation1Input{}
+		input = &OutputService11TestShapeOutputService11TestCaseOperation1Input{}
 	}
 
 	req = c.newRequest(opOutputService11TestCaseOperation1, input, output)
@@ -983,7 +983,7 @@ func (c *OutputService11ProtocolTest) OutputService11TestCaseOperation1Request(i
 	return
 }
 
-func (c *OutputService11ProtocolTest) OutputService11TestCaseOperation1(input *OutputService11TestShapeOutputService11TestShapeOutputService11TestCaseOperation1Input) (output *OutputService11TestShapeOutputShape, err error) {
+func (c *OutputService11ProtocolTest) OutputService11TestCaseOperation1(input *OutputService11TestShapeOutputService11TestCaseOperation1Input) (output *OutputService11TestShapeOutputShape, err error) {
 	req, out := c.OutputService11TestCaseOperation1Request(input)
 	output = out
 	err = req.Send()
@@ -992,11 +992,11 @@ func (c *OutputService11ProtocolTest) OutputService11TestCaseOperation1(input *O
 
 var opOutputService11TestCaseOperation1 *aws.Operation
 
-type OutputService11TestShapeOutputService11TestShapeOutputService11TestCaseOperation1Input struct {
-	metadataOutputService11TestShapeOutputService11TestShapeOutputService11TestCaseOperation1Input `json:"-" xml:"-"`
+type OutputService11TestShapeOutputService11TestCaseOperation1Input struct {
+	metadataOutputService11TestShapeOutputService11TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
-type metadataOutputService11TestShapeOutputService11TestShapeOutputService11TestCaseOperation1Input struct {
+type metadataOutputService11TestShapeOutputService11TestCaseOperation1Input struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 

--- a/internal/protocol/restxml/unmarshal_test.go
+++ b/internal/protocol/restxml/unmarshal_test.go
@@ -67,7 +67,7 @@ func (c *OutputService1ProtocolTest) newRequest(op *aws.Operation, params, data 
 }
 
 // OutputService1TestCaseOperation1Request generates a request for the OutputService1TestCaseOperation1 operation.
-func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1Request(input *OutputService1TestShapeOutputService1TestShapeOutputService1TestCaseOperation1Input) (req *aws.Request, output *OutputService1TestShapeOutputShape) {
+func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1Request(input *OutputService1TestShapeOutputService1TestCaseOperation1Input) (req *aws.Request, output *OutputService1TestShapeOutputShape) {
 
 	if opOutputService1TestCaseOperation1 == nil {
 		opOutputService1TestCaseOperation1 = &aws.Operation{
@@ -76,7 +76,7 @@ func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1Request(inp
 	}
 
 	if input == nil {
-		input = &OutputService1TestShapeOutputService1TestShapeOutputService1TestCaseOperation1Input{}
+		input = &OutputService1TestShapeOutputService1TestCaseOperation1Input{}
 	}
 
 	req = c.newRequest(opOutputService1TestCaseOperation1, input, output)
@@ -85,7 +85,7 @@ func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1Request(inp
 	return
 }
 
-func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1(input *OutputService1TestShapeOutputService1TestShapeOutputService1TestCaseOperation1Input) (output *OutputService1TestShapeOutputShape, err error) {
+func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1(input *OutputService1TestShapeOutputService1TestCaseOperation1Input) (output *OutputService1TestShapeOutputShape, err error) {
 	req, out := c.OutputService1TestCaseOperation1Request(input)
 	output = out
 	err = req.Send()
@@ -122,19 +122,19 @@ func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation2(input *Out
 
 var opOutputService1TestCaseOperation2 *aws.Operation
 
-type OutputService1TestShapeOutputService1TestCaseOperation2Input struct {
-	metadataOutputService1TestShapeOutputService1TestCaseOperation2Input `json:"-", xml:"-"`
+type OutputService1TestShapeOutputService1TestCaseOperation1Input struct {
+	metadataOutputService1TestShapeOutputService1TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
-type metadataOutputService1TestShapeOutputService1TestCaseOperation2Input struct {
+type metadataOutputService1TestShapeOutputService1TestCaseOperation1Input struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
-type OutputService1TestShapeOutputService1TestShapeOutputService1TestCaseOperation1Input struct {
-	metadataOutputService1TestShapeOutputService1TestShapeOutputService1TestCaseOperation1Input `json:"-", xml:"-"`
+type OutputService1TestShapeOutputService1TestCaseOperation2Input struct {
+	metadataOutputService1TestShapeOutputService1TestCaseOperation2Input `json:"-" xml:"-"`
 }
 
-type metadataOutputService1TestShapeOutputService1TestShapeOutputService1TestCaseOperation1Input struct {
+type metadataOutputService1TestShapeOutputService1TestCaseOperation2Input struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
@@ -161,7 +161,7 @@ type OutputService1TestShapeOutputShape struct {
 
 	TrueBool *bool `type:"boolean"`
 
-	metadataOutputService1TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService1TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService1TestShapeOutputShape struct {
@@ -233,7 +233,7 @@ func (c *OutputService2ProtocolTest) OutputService2TestCaseOperation1(input *Out
 var opOutputService2TestCaseOperation1 *aws.Operation
 
 type OutputService2TestShapeOutputService2TestCaseOperation1Input struct {
-	metadataOutputService2TestShapeOutputService2TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService2TestShapeOutputService2TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService2TestShapeOutputService2TestCaseOperation1Input struct {
@@ -243,7 +243,7 @@ type metadataOutputService2TestShapeOutputService2TestCaseOperation1Input struct
 type OutputService2TestShapeOutputShape struct {
 	Blob []byte `type:"blob"`
 
-	metadataOutputService2TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService2TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService2TestShapeOutputShape struct {
@@ -315,7 +315,7 @@ func (c *OutputService3ProtocolTest) OutputService3TestCaseOperation1(input *Out
 var opOutputService3TestCaseOperation1 *aws.Operation
 
 type OutputService3TestShapeOutputService3TestCaseOperation1Input struct {
-	metadataOutputService3TestShapeOutputService3TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService3TestShapeOutputService3TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService3TestShapeOutputService3TestCaseOperation1Input struct {
@@ -325,7 +325,7 @@ type metadataOutputService3TestShapeOutputService3TestCaseOperation1Input struct
 type OutputService3TestShapeOutputShape struct {
 	ListMember []*string `type:"list"`
 
-	metadataOutputService3TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService3TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService3TestShapeOutputShape struct {
@@ -397,7 +397,7 @@ func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation1(input *Out
 var opOutputService4TestCaseOperation1 *aws.Operation
 
 type OutputService4TestShapeOutputService4TestCaseOperation1Input struct {
-	metadataOutputService4TestShapeOutputService4TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService4TestShapeOutputService4TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService4TestShapeOutputService4TestCaseOperation1Input struct {
@@ -407,7 +407,7 @@ type metadataOutputService4TestShapeOutputService4TestCaseOperation1Input struct
 type OutputService4TestShapeOutputShape struct {
 	ListMember []*string `locationNameList:"item" type:"list"`
 
-	metadataOutputService4TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService4TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService4TestShapeOutputShape struct {
@@ -479,7 +479,7 @@ func (c *OutputService5ProtocolTest) OutputService5TestCaseOperation1(input *Out
 var opOutputService5TestCaseOperation1 *aws.Operation
 
 type OutputService5TestShapeOutputService5TestCaseOperation1Input struct {
-	metadataOutputService5TestShapeOutputService5TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService5TestShapeOutputService5TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService5TestShapeOutputService5TestCaseOperation1Input struct {
@@ -489,7 +489,7 @@ type metadataOutputService5TestShapeOutputService5TestCaseOperation1Input struct
 type OutputService5TestShapeOutputShape struct {
 	ListMember []*string `type:"list" flattened:"true"`
 
-	metadataOutputService5TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService5TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService5TestShapeOutputShape struct {
@@ -561,7 +561,7 @@ func (c *OutputService6ProtocolTest) OutputService6TestCaseOperation1(input *Out
 var opOutputService6TestCaseOperation1 *aws.Operation
 
 type OutputService6TestShapeOutputService6TestCaseOperation1Input struct {
-	metadataOutputService6TestShapeOutputService6TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService6TestShapeOutputService6TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService6TestShapeOutputService6TestCaseOperation1Input struct {
@@ -571,7 +571,7 @@ type metadataOutputService6TestShapeOutputService6TestCaseOperation1Input struct
 type OutputService6TestShapeOutputShape struct {
 	Map *map[string]*OutputService6TestShapeSingleStructure `type:"map"`
 
-	metadataOutputService6TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService6TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService6TestShapeOutputShape struct {
@@ -581,7 +581,7 @@ type metadataOutputService6TestShapeOutputShape struct {
 type OutputService6TestShapeSingleStructure struct {
 	Foo *string `locationName:"foo" type:"string"`
 
-	metadataOutputService6TestShapeSingleStructure `json:"-", xml:"-"`
+	metadataOutputService6TestShapeSingleStructure `json:"-" xml:"-"`
 }
 
 type metadataOutputService6TestShapeSingleStructure struct {
@@ -653,7 +653,7 @@ func (c *OutputService7ProtocolTest) OutputService7TestCaseOperation1(input *Out
 var opOutputService7TestCaseOperation1 *aws.Operation
 
 type OutputService7TestShapeOutputService7TestCaseOperation1Input struct {
-	metadataOutputService7TestShapeOutputService7TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService7TestShapeOutputService7TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService7TestShapeOutputService7TestCaseOperation1Input struct {
@@ -663,7 +663,7 @@ type metadataOutputService7TestShapeOutputService7TestCaseOperation1Input struct
 type OutputService7TestShapeOutputShape struct {
 	Map *map[string]*string `type:"map" flattened:"true"`
 
-	metadataOutputService7TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService7TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService7TestShapeOutputShape struct {
@@ -735,7 +735,7 @@ func (c *OutputService8ProtocolTest) OutputService8TestCaseOperation1(input *Out
 var opOutputService8TestCaseOperation1 *aws.Operation
 
 type OutputService8TestShapeOutputService8TestCaseOperation1Input struct {
-	metadataOutputService8TestShapeOutputService8TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService8TestShapeOutputService8TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService8TestShapeOutputService8TestCaseOperation1Input struct {
@@ -745,7 +745,7 @@ type metadataOutputService8TestShapeOutputService8TestCaseOperation1Input struct
 type OutputService8TestShapeOutputShape struct {
 	Map *map[string]*string `locationNameKey:"foo" locationNameValue:"bar" type:"map"`
 
-	metadataOutputService8TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService8TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService8TestShapeOutputShape struct {
@@ -817,7 +817,7 @@ func (c *OutputService9ProtocolTest) OutputService9TestCaseOperation1(input *Out
 var opOutputService9TestCaseOperation1 *aws.Operation
 
 type OutputService9TestShapeOutputService9TestCaseOperation1Input struct {
-	metadataOutputService9TestShapeOutputService9TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService9TestShapeOutputService9TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService9TestShapeOutputService9TestCaseOperation1Input struct {
@@ -829,7 +829,7 @@ type OutputService9TestShapeOutputShape struct {
 
 	Header *string `location:"header" locationName:"X-Foo" type:"string"`
 
-	metadataOutputService9TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService9TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService9TestShapeOutputShape struct {
@@ -839,7 +839,7 @@ type metadataOutputService9TestShapeOutputShape struct {
 type OutputService9TestShapeSingleStructure struct {
 	Foo *string `type:"string"`
 
-	metadataOutputService9TestShapeSingleStructure `json:"-", xml:"-"`
+	metadataOutputService9TestShapeSingleStructure `json:"-" xml:"-"`
 }
 
 type metadataOutputService9TestShapeSingleStructure struct {
@@ -911,7 +911,7 @@ func (c *OutputService10ProtocolTest) OutputService10TestCaseOperation1(input *O
 var opOutputService10TestCaseOperation1 *aws.Operation
 
 type OutputService10TestShapeOutputService10TestCaseOperation1Input struct {
-	metadataOutputService10TestShapeOutputService10TestCaseOperation1Input `json:"-", xml:"-"`
+	metadataOutputService10TestShapeOutputService10TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
 type metadataOutputService10TestShapeOutputService10TestCaseOperation1Input struct {
@@ -921,7 +921,7 @@ type metadataOutputService10TestShapeOutputService10TestCaseOperation1Input stru
 type OutputService10TestShapeOutputShape struct {
 	Stream []byte `type:"blob"`
 
-	metadataOutputService10TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService10TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService10TestShapeOutputShape struct {
@@ -965,7 +965,7 @@ func (c *OutputService11ProtocolTest) newRequest(op *aws.Operation, params, data
 }
 
 // OutputService11TestCaseOperation1Request generates a request for the OutputService11TestCaseOperation1 operation.
-func (c *OutputService11ProtocolTest) OutputService11TestCaseOperation1Request(input *OutputService11TestShapeOutputService11TestCaseOperation1Input) (req *aws.Request, output *OutputService11TestShapeOutputShape) {
+func (c *OutputService11ProtocolTest) OutputService11TestCaseOperation1Request(input *OutputService11TestShapeOutputService11TestShapeOutputService11TestCaseOperation1Input) (req *aws.Request, output *OutputService11TestShapeOutputShape) {
 
 	if opOutputService11TestCaseOperation1 == nil {
 		opOutputService11TestCaseOperation1 = &aws.Operation{
@@ -974,7 +974,7 @@ func (c *OutputService11ProtocolTest) OutputService11TestCaseOperation1Request(i
 	}
 
 	if input == nil {
-		input = &OutputService11TestShapeOutputService11TestCaseOperation1Input{}
+		input = &OutputService11TestShapeOutputService11TestShapeOutputService11TestCaseOperation1Input{}
 	}
 
 	req = c.newRequest(opOutputService11TestCaseOperation1, input, output)
@@ -983,7 +983,7 @@ func (c *OutputService11ProtocolTest) OutputService11TestCaseOperation1Request(i
 	return
 }
 
-func (c *OutputService11ProtocolTest) OutputService11TestCaseOperation1(input *OutputService11TestShapeOutputService11TestCaseOperation1Input) (output *OutputService11TestShapeOutputShape, err error) {
+func (c *OutputService11ProtocolTest) OutputService11TestCaseOperation1(input *OutputService11TestShapeOutputService11TestShapeOutputService11TestCaseOperation1Input) (output *OutputService11TestShapeOutputShape, err error) {
 	req, out := c.OutputService11TestCaseOperation1Request(input)
 	output = out
 	err = req.Send()
@@ -992,11 +992,11 @@ func (c *OutputService11ProtocolTest) OutputService11TestCaseOperation1(input *O
 
 var opOutputService11TestCaseOperation1 *aws.Operation
 
-type OutputService11TestShapeOutputService11TestCaseOperation1Input struct {
-	metadataOutputService11TestShapeOutputService11TestCaseOperation1Input `json:"-", xml:"-"`
+type OutputService11TestShapeOutputService11TestShapeOutputService11TestCaseOperation1Input struct {
+	metadataOutputService11TestShapeOutputService11TestShapeOutputService11TestCaseOperation1Input `json:"-" xml:"-"`
 }
 
-type metadataOutputService11TestShapeOutputService11TestCaseOperation1Input struct {
+type metadataOutputService11TestShapeOutputService11TestShapeOutputService11TestCaseOperation1Input struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
@@ -1019,7 +1019,7 @@ type OutputService11TestShapeOutputShape struct {
 
 	TrueBool *bool `location:"header" locationName:"x-true-bool" type:"boolean"`
 
-	metadataOutputService11TestShapeOutputShape `json:"-", xml:"-"`
+	metadataOutputService11TestShapeOutputShape `json:"-" xml:"-"`
 }
 
 type metadataOutputService11TestShapeOutputShape struct {

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -84,7 +84,6 @@ func PrettyPrint(v interface{}) string {
 	default:
 		return fmt.Sprintf("%#v", v)
 	}
-	return ""
 }
 
 func pkgName(t reflect.Type) string {

--- a/service/autoscaling/api.go
+++ b/service/autoscaling/api.go
@@ -1734,7 +1734,7 @@ type Activity struct {
 	// A friendly, more verbose description of the activity status.
 	StatusMessage *string `type:"string"`
 
-	metadataActivity `json:"-", xml:"-"`
+	metadataActivity `json:"-" xml:"-"`
 }
 
 type metadataActivity struct {
@@ -1750,7 +1750,7 @@ type AdjustmentType struct {
 	// in the Auto Scaling Developer Guide.
 	AdjustmentType *string `type:"string"`
 
-	metadataAdjustmentType `json:"-", xml:"-"`
+	metadataAdjustmentType `json:"-" xml:"-"`
 }
 
 type metadataAdjustmentType struct {
@@ -1765,7 +1765,7 @@ type Alarm struct {
 	// The name of the alarm.
 	AlarmName *string `type:"string"`
 
-	metadataAlarm `json:"-", xml:"-"`
+	metadataAlarm `json:"-" xml:"-"`
 }
 
 type metadataAlarm struct {
@@ -1779,7 +1779,7 @@ type AttachInstancesInput struct {
 	// One or more EC2 instance IDs. You must specify at least one ID.
 	InstanceIDs []*string `locationName:"InstanceIds" type:"list"`
 
-	metadataAttachInstancesInput `json:"-", xml:"-"`
+	metadataAttachInstancesInput `json:"-" xml:"-"`
 }
 
 type metadataAttachInstancesInput struct {
@@ -1787,7 +1787,7 @@ type metadataAttachInstancesInput struct {
 }
 
 type AttachInstancesOutput struct {
-	metadataAttachInstancesOutput `json:"-", xml:"-"`
+	metadataAttachInstancesOutput `json:"-" xml:"-"`
 }
 
 type metadataAttachInstancesOutput struct {
@@ -1864,7 +1864,7 @@ type AutoScalingGroup struct {
 	// Availability Zones of the subnets match the values for AvailabilityZones.
 	VPCZoneIdentifier *string `type:"string"`
 
-	metadataAutoScalingGroup `json:"-", xml:"-"`
+	metadataAutoScalingGroup `json:"-" xml:"-"`
 }
 
 type metadataAutoScalingGroup struct {
@@ -1895,7 +1895,7 @@ type AutoScalingInstanceDetails struct {
 	// in the Auto Scaling Developer Guide.
 	LifecycleState *string `type:"string" required:"true"`
 
-	metadataAutoScalingInstanceDetails `json:"-", xml:"-"`
+	metadataAutoScalingInstanceDetails `json:"-" xml:"-"`
 }
 
 type metadataAutoScalingInstanceDetails struct {
@@ -1920,7 +1920,7 @@ type BlockDeviceMapping struct {
 	// The name of the virtual device, ephemeral0 to ephemeral3.
 	VirtualName *string `type:"string"`
 
-	metadataBlockDeviceMapping `json:"-", xml:"-"`
+	metadataBlockDeviceMapping `json:"-" xml:"-"`
 }
 
 type metadataBlockDeviceMapping struct {
@@ -1943,7 +1943,7 @@ type CompleteLifecycleActionInput struct {
 	// The name of the lifecycle hook.
 	LifecycleHookName *string `type:"string" required:"true"`
 
-	metadataCompleteLifecycleActionInput `json:"-", xml:"-"`
+	metadataCompleteLifecycleActionInput `json:"-" xml:"-"`
 }
 
 type metadataCompleteLifecycleActionInput struct {
@@ -1951,7 +1951,7 @@ type metadataCompleteLifecycleActionInput struct {
 }
 
 type CompleteLifecycleActionOutput struct {
-	metadataCompleteLifecycleActionOutput `json:"-", xml:"-"`
+	metadataCompleteLifecycleActionOutput `json:"-" xml:"-"`
 }
 
 type metadataCompleteLifecycleActionOutput struct {
@@ -2061,7 +2061,7 @@ type CreateAutoScalingGroupInput struct {
 	// in the Auto Scaling Developer Guide.
 	VPCZoneIdentifier *string `type:"string"`
 
-	metadataCreateAutoScalingGroupInput `json:"-", xml:"-"`
+	metadataCreateAutoScalingGroupInput `json:"-" xml:"-"`
 }
 
 type metadataCreateAutoScalingGroupInput struct {
@@ -2069,7 +2069,7 @@ type metadataCreateAutoScalingGroupInput struct {
 }
 
 type CreateAutoScalingGroupOutput struct {
-	metadataCreateAutoScalingGroupOutput `json:"-", xml:"-"`
+	metadataCreateAutoScalingGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateAutoScalingGroupOutput struct {
@@ -2219,7 +2219,7 @@ type CreateLaunchConfigurationInput struct {
 	// data files.
 	UserData *string `type:"string"`
 
-	metadataCreateLaunchConfigurationInput `json:"-", xml:"-"`
+	metadataCreateLaunchConfigurationInput `json:"-" xml:"-"`
 }
 
 type metadataCreateLaunchConfigurationInput struct {
@@ -2227,7 +2227,7 @@ type metadataCreateLaunchConfigurationInput struct {
 }
 
 type CreateLaunchConfigurationOutput struct {
-	metadataCreateLaunchConfigurationOutput `json:"-", xml:"-"`
+	metadataCreateLaunchConfigurationOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateLaunchConfigurationOutput struct {
@@ -2252,7 +2252,7 @@ type CreateOrUpdateTagsInput struct {
 	// overwrites the previous tag definition, but you will not get an error message.
 	Tags []*Tag `type:"list" required:"true"`
 
-	metadataCreateOrUpdateTagsInput `json:"-", xml:"-"`
+	metadataCreateOrUpdateTagsInput `json:"-" xml:"-"`
 }
 
 type metadataCreateOrUpdateTagsInput struct {
@@ -2260,7 +2260,7 @@ type metadataCreateOrUpdateTagsInput struct {
 }
 
 type CreateOrUpdateTagsOutput struct {
-	metadataCreateOrUpdateTagsOutput `json:"-", xml:"-"`
+	metadataCreateOrUpdateTagsOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateOrUpdateTagsOutput struct {
@@ -2276,7 +2276,7 @@ type DeleteAutoScalingGroupInput struct {
 	// parameter also deletes any lifecycle actions associated with the group.
 	ForceDelete *bool `type:"boolean"`
 
-	metadataDeleteAutoScalingGroupInput `json:"-", xml:"-"`
+	metadataDeleteAutoScalingGroupInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteAutoScalingGroupInput struct {
@@ -2284,7 +2284,7 @@ type metadataDeleteAutoScalingGroupInput struct {
 }
 
 type DeleteAutoScalingGroupOutput struct {
-	metadataDeleteAutoScalingGroupOutput `json:"-", xml:"-"`
+	metadataDeleteAutoScalingGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteAutoScalingGroupOutput struct {
@@ -2295,7 +2295,7 @@ type DeleteLaunchConfigurationInput struct {
 	// The name of the launch configuration.
 	LaunchConfigurationName *string `type:"string" required:"true"`
 
-	metadataDeleteLaunchConfigurationInput `json:"-", xml:"-"`
+	metadataDeleteLaunchConfigurationInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteLaunchConfigurationInput struct {
@@ -2303,7 +2303,7 @@ type metadataDeleteLaunchConfigurationInput struct {
 }
 
 type DeleteLaunchConfigurationOutput struct {
-	metadataDeleteLaunchConfigurationOutput `json:"-", xml:"-"`
+	metadataDeleteLaunchConfigurationOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteLaunchConfigurationOutput struct {
@@ -2317,7 +2317,7 @@ type DeleteLifecycleHookInput struct {
 	// The name of the lifecycle hook.
 	LifecycleHookName *string `type:"string" required:"true"`
 
-	metadataDeleteLifecycleHookInput `json:"-", xml:"-"`
+	metadataDeleteLifecycleHookInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteLifecycleHookInput struct {
@@ -2325,7 +2325,7 @@ type metadataDeleteLifecycleHookInput struct {
 }
 
 type DeleteLifecycleHookOutput struct {
-	metadataDeleteLifecycleHookOutput `json:"-", xml:"-"`
+	metadataDeleteLifecycleHookOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteLifecycleHookOutput struct {
@@ -2340,7 +2340,7 @@ type DeleteNotificationConfigurationInput struct {
 	// (SNS) topic.
 	TopicARN *string `type:"string" required:"true"`
 
-	metadataDeleteNotificationConfigurationInput `json:"-", xml:"-"`
+	metadataDeleteNotificationConfigurationInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteNotificationConfigurationInput struct {
@@ -2348,7 +2348,7 @@ type metadataDeleteNotificationConfigurationInput struct {
 }
 
 type DeleteNotificationConfigurationOutput struct {
-	metadataDeleteNotificationConfigurationOutput `json:"-", xml:"-"`
+	metadataDeleteNotificationConfigurationOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteNotificationConfigurationOutput struct {
@@ -2362,7 +2362,7 @@ type DeletePolicyInput struct {
 	// The name or Amazon Resource Name (ARN) of the policy.
 	PolicyName *string `type:"string" required:"true"`
 
-	metadataDeletePolicyInput `json:"-", xml:"-"`
+	metadataDeletePolicyInput `json:"-" xml:"-"`
 }
 
 type metadataDeletePolicyInput struct {
@@ -2370,7 +2370,7 @@ type metadataDeletePolicyInput struct {
 }
 
 type DeletePolicyOutput struct {
-	metadataDeletePolicyOutput `json:"-", xml:"-"`
+	metadataDeletePolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataDeletePolicyOutput struct {
@@ -2384,7 +2384,7 @@ type DeleteScheduledActionInput struct {
 	// The name of the action to delete.
 	ScheduledActionName *string `type:"string" required:"true"`
 
-	metadataDeleteScheduledActionInput `json:"-", xml:"-"`
+	metadataDeleteScheduledActionInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteScheduledActionInput struct {
@@ -2392,7 +2392,7 @@ type metadataDeleteScheduledActionInput struct {
 }
 
 type DeleteScheduledActionOutput struct {
-	metadataDeleteScheduledActionOutput `json:"-", xml:"-"`
+	metadataDeleteScheduledActionOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteScheduledActionOutput struct {
@@ -2406,7 +2406,7 @@ type DeleteTagsInput struct {
 	// or false.
 	Tags []*Tag `type:"list" required:"true"`
 
-	metadataDeleteTagsInput `json:"-", xml:"-"`
+	metadataDeleteTagsInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteTagsInput struct {
@@ -2414,7 +2414,7 @@ type metadataDeleteTagsInput struct {
 }
 
 type DeleteTagsOutput struct {
-	metadataDeleteTagsOutput `json:"-", xml:"-"`
+	metadataDeleteTagsOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteTagsOutput struct {
@@ -2422,7 +2422,7 @@ type metadataDeleteTagsOutput struct {
 }
 
 type DescribeAccountLimitsInput struct {
-	metadataDescribeAccountLimitsInput `json:"-", xml:"-"`
+	metadataDescribeAccountLimitsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeAccountLimitsInput struct {
@@ -2438,7 +2438,7 @@ type DescribeAccountLimitsOutput struct {
 	// The default limit is 100 per region.
 	MaxNumberOfLaunchConfigurations *int64 `type:"integer"`
 
-	metadataDescribeAccountLimitsOutput `json:"-", xml:"-"`
+	metadataDescribeAccountLimitsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeAccountLimitsOutput struct {
@@ -2446,7 +2446,7 @@ type metadataDescribeAccountLimitsOutput struct {
 }
 
 type DescribeAdjustmentTypesInput struct {
-	metadataDescribeAdjustmentTypesInput `json:"-", xml:"-"`
+	metadataDescribeAdjustmentTypesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeAdjustmentTypesInput struct {
@@ -2457,7 +2457,7 @@ type DescribeAdjustmentTypesOutput struct {
 	// The policy adjustment types.
 	AdjustmentTypes []*AdjustmentType `type:"list"`
 
-	metadataDescribeAdjustmentTypesOutput `json:"-", xml:"-"`
+	metadataDescribeAdjustmentTypesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeAdjustmentTypesOutput struct {
@@ -2475,7 +2475,7 @@ type DescribeAutoScalingGroupsInput struct {
 	// a previous call.)
 	NextToken *string `type:"string"`
 
-	metadataDescribeAutoScalingGroupsInput `json:"-", xml:"-"`
+	metadataDescribeAutoScalingGroupsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeAutoScalingGroupsInput struct {
@@ -2490,7 +2490,7 @@ type DescribeAutoScalingGroupsOutput struct {
 	// items to return, the string is empty.
 	NextToken *string `type:"string"`
 
-	metadataDescribeAutoScalingGroupsOutput `json:"-", xml:"-"`
+	metadataDescribeAutoScalingGroupsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeAutoScalingGroupsOutput struct {
@@ -2510,7 +2510,7 @@ type DescribeAutoScalingInstancesInput struct {
 	// a previous call.)
 	NextToken *string `type:"string"`
 
-	metadataDescribeAutoScalingInstancesInput `json:"-", xml:"-"`
+	metadataDescribeAutoScalingInstancesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeAutoScalingInstancesInput struct {
@@ -2525,7 +2525,7 @@ type DescribeAutoScalingInstancesOutput struct {
 	// items to return, the string is empty.
 	NextToken *string `type:"string"`
 
-	metadataDescribeAutoScalingInstancesOutput `json:"-", xml:"-"`
+	metadataDescribeAutoScalingInstancesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeAutoScalingInstancesOutput struct {
@@ -2533,7 +2533,7 @@ type metadataDescribeAutoScalingInstancesOutput struct {
 }
 
 type DescribeAutoScalingNotificationTypesInput struct {
-	metadataDescribeAutoScalingNotificationTypesInput `json:"-", xml:"-"`
+	metadataDescribeAutoScalingNotificationTypesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeAutoScalingNotificationTypesInput struct {
@@ -2554,7 +2554,7 @@ type DescribeAutoScalingNotificationTypesOutput struct {
 	// autoscaling:TEST_NOTIFICATION
 	AutoScalingNotificationTypes []*string `type:"list"`
 
-	metadataDescribeAutoScalingNotificationTypesOutput `json:"-", xml:"-"`
+	metadataDescribeAutoScalingNotificationTypesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeAutoScalingNotificationTypesOutput struct {
@@ -2572,7 +2572,7 @@ type DescribeLaunchConfigurationsInput struct {
 	// a previous call.)
 	NextToken *string `type:"string"`
 
-	metadataDescribeLaunchConfigurationsInput `json:"-", xml:"-"`
+	metadataDescribeLaunchConfigurationsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeLaunchConfigurationsInput struct {
@@ -2587,7 +2587,7 @@ type DescribeLaunchConfigurationsOutput struct {
 	// items to return, the string is empty.
 	NextToken *string `type:"string"`
 
-	metadataDescribeLaunchConfigurationsOutput `json:"-", xml:"-"`
+	metadataDescribeLaunchConfigurationsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeLaunchConfigurationsOutput struct {
@@ -2595,7 +2595,7 @@ type metadataDescribeLaunchConfigurationsOutput struct {
 }
 
 type DescribeLifecycleHookTypesInput struct {
-	metadataDescribeLifecycleHookTypesInput `json:"-", xml:"-"`
+	metadataDescribeLifecycleHookTypesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeLifecycleHookTypesInput struct {
@@ -2610,7 +2610,7 @@ type DescribeLifecycleHookTypesOutput struct {
 	// autoscaling:EC2_INSTANCE_TERMINATING
 	LifecycleHookTypes []*string `type:"list"`
 
-	metadataDescribeLifecycleHookTypesOutput `json:"-", xml:"-"`
+	metadataDescribeLifecycleHookTypesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeLifecycleHookTypesOutput struct {
@@ -2624,7 +2624,7 @@ type DescribeLifecycleHooksInput struct {
 	// The names of one or more lifecycle hooks.
 	LifecycleHookNames []*string `type:"list"`
 
-	metadataDescribeLifecycleHooksInput `json:"-", xml:"-"`
+	metadataDescribeLifecycleHooksInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeLifecycleHooksInput struct {
@@ -2635,7 +2635,7 @@ type DescribeLifecycleHooksOutput struct {
 	// The lifecycle hooks for the specified group.
 	LifecycleHooks []*LifecycleHook `type:"list"`
 
-	metadataDescribeLifecycleHooksOutput `json:"-", xml:"-"`
+	metadataDescribeLifecycleHooksOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeLifecycleHooksOutput struct {
@@ -2643,7 +2643,7 @@ type metadataDescribeLifecycleHooksOutput struct {
 }
 
 type DescribeMetricCollectionTypesInput struct {
-	metadataDescribeMetricCollectionTypesInput `json:"-", xml:"-"`
+	metadataDescribeMetricCollectionTypesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeMetricCollectionTypesInput struct {
@@ -2676,7 +2676,7 @@ type DescribeMetricCollectionTypesOutput struct {
 	// explicitly request it when calling EnableMetricsCollection.
 	Metrics []*MetricCollectionType `type:"list"`
 
-	metadataDescribeMetricCollectionTypesOutput `json:"-", xml:"-"`
+	metadataDescribeMetricCollectionTypesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeMetricCollectionTypesOutput struct {
@@ -2694,7 +2694,7 @@ type DescribeNotificationConfigurationsInput struct {
 	// a previous call.)
 	NextToken *string `type:"string"`
 
-	metadataDescribeNotificationConfigurationsInput `json:"-", xml:"-"`
+	metadataDescribeNotificationConfigurationsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeNotificationConfigurationsInput struct {
@@ -2709,7 +2709,7 @@ type DescribeNotificationConfigurationsOutput struct {
 	// The notification configurations.
 	NotificationConfigurations []*NotificationConfiguration `type:"list" required:"true"`
 
-	metadataDescribeNotificationConfigurationsOutput `json:"-", xml:"-"`
+	metadataDescribeNotificationConfigurationsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeNotificationConfigurationsOutput struct {
@@ -2733,7 +2733,7 @@ type DescribePoliciesInput struct {
 	// an unknown policy name, it is ignored with no error.
 	PolicyNames []*string `type:"list"`
 
-	metadataDescribePoliciesInput `json:"-", xml:"-"`
+	metadataDescribePoliciesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribePoliciesInput struct {
@@ -2748,7 +2748,7 @@ type DescribePoliciesOutput struct {
 	// The scaling policies.
 	ScalingPolicies []*ScalingPolicy `type:"list"`
 
-	metadataDescribePoliciesOutput `json:"-", xml:"-"`
+	metadataDescribePoliciesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribePoliciesOutput struct {
@@ -2773,7 +2773,7 @@ type DescribeScalingActivitiesInput struct {
 	// a previous call.)
 	NextToken *string `type:"string"`
 
-	metadataDescribeScalingActivitiesInput `json:"-", xml:"-"`
+	metadataDescribeScalingActivitiesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeScalingActivitiesInput struct {
@@ -2788,7 +2788,7 @@ type DescribeScalingActivitiesOutput struct {
 	// items to return, the string is empty.
 	NextToken *string `type:"string"`
 
-	metadataDescribeScalingActivitiesOutput `json:"-", xml:"-"`
+	metadataDescribeScalingActivitiesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeScalingActivitiesOutput struct {
@@ -2796,7 +2796,7 @@ type metadataDescribeScalingActivitiesOutput struct {
 }
 
 type DescribeScalingProcessTypesInput struct {
-	metadataDescribeScalingProcessTypesInput `json:"-", xml:"-"`
+	metadataDescribeScalingProcessTypesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeScalingProcessTypesInput struct {
@@ -2807,7 +2807,7 @@ type DescribeScalingProcessTypesOutput struct {
 	// The names of the process types.
 	Processes []*ProcessType `type:"list"`
 
-	metadataDescribeScalingProcessTypesOutput `json:"-", xml:"-"`
+	metadataDescribeScalingProcessTypesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeScalingProcessTypesOutput struct {
@@ -2842,7 +2842,7 @@ type DescribeScheduledActionsInput struct {
 	// provided, this parameter is ignored.
 	StartTime *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataDescribeScheduledActionsInput `json:"-", xml:"-"`
+	metadataDescribeScheduledActionsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeScheduledActionsInput struct {
@@ -2857,7 +2857,7 @@ type DescribeScheduledActionsOutput struct {
 	// The scheduled actions.
 	ScheduledUpdateGroupActions []*ScheduledUpdateGroupAction `type:"list"`
 
-	metadataDescribeScheduledActionsOutput `json:"-", xml:"-"`
+	metadataDescribeScheduledActionsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeScheduledActionsOutput struct {
@@ -2878,7 +2878,7 @@ type DescribeTagsInput struct {
 	// a previous call.)
 	NextToken *string `type:"string"`
 
-	metadataDescribeTagsInput `json:"-", xml:"-"`
+	metadataDescribeTagsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeTagsInput struct {
@@ -2893,7 +2893,7 @@ type DescribeTagsOutput struct {
 	// The tags.
 	Tags []*TagDescription `type:"list"`
 
-	metadataDescribeTagsOutput `json:"-", xml:"-"`
+	metadataDescribeTagsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeTagsOutput struct {
@@ -2901,7 +2901,7 @@ type metadataDescribeTagsOutput struct {
 }
 
 type DescribeTerminationPolicyTypesInput struct {
-	metadataDescribeTerminationPolicyTypesInput `json:"-", xml:"-"`
+	metadataDescribeTerminationPolicyTypesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeTerminationPolicyTypesInput struct {
@@ -2914,7 +2914,7 @@ type DescribeTerminationPolicyTypesOutput struct {
 	// Default.
 	TerminationPolicyTypes []*string `type:"list"`
 
-	metadataDescribeTerminationPolicyTypesOutput `json:"-", xml:"-"`
+	metadataDescribeTerminationPolicyTypesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeTerminationPolicyTypesOutput struct {
@@ -2932,7 +2932,7 @@ type DetachInstancesInput struct {
 	// the number of instances detached.
 	ShouldDecrementDesiredCapacity *bool `type:"boolean" required:"true"`
 
-	metadataDetachInstancesInput `json:"-", xml:"-"`
+	metadataDetachInstancesInput `json:"-" xml:"-"`
 }
 
 type metadataDetachInstancesInput struct {
@@ -2943,7 +2943,7 @@ type DetachInstancesOutput struct {
 	// The activities related to detaching the instances from the Auto Scaling group.
 	Activities []*Activity `type:"list"`
 
-	metadataDetachInstancesOutput `json:"-", xml:"-"`
+	metadataDetachInstancesOutput `json:"-" xml:"-"`
 }
 
 type metadataDetachInstancesOutput struct {
@@ -2975,7 +2975,7 @@ type DisableMetricsCollectionInput struct {
 	//  If you omit this parameter, all metrics are disabled.
 	Metrics []*string `type:"list"`
 
-	metadataDisableMetricsCollectionInput `json:"-", xml:"-"`
+	metadataDisableMetricsCollectionInput `json:"-" xml:"-"`
 }
 
 type metadataDisableMetricsCollectionInput struct {
@@ -2983,7 +2983,7 @@ type metadataDisableMetricsCollectionInput struct {
 }
 
 type DisableMetricsCollectionOutput struct {
-	metadataDisableMetricsCollectionOutput `json:"-", xml:"-"`
+	metadataDisableMetricsCollectionOutput `json:"-" xml:"-"`
 }
 
 type metadataDisableMetricsCollectionOutput struct {
@@ -3027,7 +3027,7 @@ type EBS struct {
 	// Default: standard
 	VolumeType *string `type:"string"`
 
-	metadataEBS `json:"-", xml:"-"`
+	metadataEBS `json:"-" xml:"-"`
 }
 
 type metadataEBS struct {
@@ -3066,7 +3066,7 @@ type EnableMetricsCollectionInput struct {
 	// request it when calling EnableMetricsCollection.
 	Metrics []*string `type:"list"`
 
-	metadataEnableMetricsCollectionInput `json:"-", xml:"-"`
+	metadataEnableMetricsCollectionInput `json:"-" xml:"-"`
 }
 
 type metadataEnableMetricsCollectionInput struct {
@@ -3074,7 +3074,7 @@ type metadataEnableMetricsCollectionInput struct {
 }
 
 type EnableMetricsCollectionOutput struct {
-	metadataEnableMetricsCollectionOutput `json:"-", xml:"-"`
+	metadataEnableMetricsCollectionOutput `json:"-" xml:"-"`
 }
 
 type metadataEnableMetricsCollectionOutput struct {
@@ -3089,7 +3089,7 @@ type EnabledMetric struct {
 	// The name of the metric.
 	Metric *string `type:"string"`
 
-	metadataEnabledMetric `json:"-", xml:"-"`
+	metadataEnabledMetric `json:"-" xml:"-"`
 }
 
 type metadataEnabledMetric struct {
@@ -3110,7 +3110,7 @@ type EnterStandbyInput struct {
 	// mode.
 	ShouldDecrementDesiredCapacity *bool `type:"boolean" required:"true"`
 
-	metadataEnterStandbyInput `json:"-", xml:"-"`
+	metadataEnterStandbyInput `json:"-" xml:"-"`
 }
 
 type metadataEnterStandbyInput struct {
@@ -3121,7 +3121,7 @@ type EnterStandbyOutput struct {
 	// The activities related to moving instances into Standby mode.
 	Activities []*Activity `type:"list"`
 
-	metadataEnterStandbyOutput `json:"-", xml:"-"`
+	metadataEnterStandbyOutput `json:"-" xml:"-"`
 }
 
 type metadataEnterStandbyOutput struct {
@@ -3146,7 +3146,7 @@ type ExecutePolicyInput struct {
 	// The name or ARN of the policy.
 	PolicyName *string `type:"string" required:"true"`
 
-	metadataExecutePolicyInput `json:"-", xml:"-"`
+	metadataExecutePolicyInput `json:"-" xml:"-"`
 }
 
 type metadataExecutePolicyInput struct {
@@ -3154,7 +3154,7 @@ type metadataExecutePolicyInput struct {
 }
 
 type ExecutePolicyOutput struct {
-	metadataExecutePolicyOutput `json:"-", xml:"-"`
+	metadataExecutePolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataExecutePolicyOutput struct {
@@ -3168,7 +3168,7 @@ type ExitStandbyInput struct {
 	// One or more instance IDs. You must specify at least one instance ID.
 	InstanceIDs []*string `locationName:"InstanceIds" type:"list"`
 
-	metadataExitStandbyInput `json:"-", xml:"-"`
+	metadataExitStandbyInput `json:"-" xml:"-"`
 }
 
 type metadataExitStandbyInput struct {
@@ -3179,7 +3179,7 @@ type ExitStandbyOutput struct {
 	// The activities related to moving instances out of Standby mode.
 	Activities []*Activity `type:"list"`
 
-	metadataExitStandbyOutput `json:"-", xml:"-"`
+	metadataExitStandbyOutput `json:"-" xml:"-"`
 }
 
 type metadataExitStandbyOutput struct {
@@ -3195,7 +3195,7 @@ type Filter struct {
 	// The value of the filter.
 	Values []*string `type:"list"`
 
-	metadataFilter `json:"-", xml:"-"`
+	metadataFilter `json:"-" xml:"-"`
 }
 
 type metadataFilter struct {
@@ -3221,7 +3221,7 @@ type Instance struct {
 	//  The Quarantined lifecycle state is not used.
 	LifecycleState *string `type:"string" required:"true"`
 
-	metadataInstance `json:"-", xml:"-"`
+	metadataInstance `json:"-" xml:"-"`
 }
 
 type metadataInstance struct {
@@ -3233,7 +3233,7 @@ type InstanceMonitoring struct {
 	// If True, instance monitoring is enabled.
 	Enabled *bool `type:"boolean"`
 
-	metadataInstanceMonitoring `json:"-", xml:"-"`
+	metadataInstanceMonitoring `json:"-" xml:"-"`
 }
 
 type metadataInstanceMonitoring struct {
@@ -3310,7 +3310,7 @@ type LaunchConfiguration struct {
 	// The user data available to the EC2 instances.
 	UserData *string `type:"string"`
 
-	metadataLaunchConfiguration `json:"-", xml:"-"`
+	metadataLaunchConfiguration `json:"-" xml:"-"`
 }
 
 type metadataLaunchConfiguration struct {
@@ -3369,7 +3369,7 @@ type LifecycleHook struct {
 	// the specified notification target.
 	RoleARN *string `type:"string"`
 
-	metadataLifecycleHook `json:"-", xml:"-"`
+	metadataLifecycleHook `json:"-" xml:"-"`
 }
 
 type metadataLifecycleHook struct {
@@ -3381,7 +3381,7 @@ type MetricCollectionType struct {
 	// The metric.
 	Metric *string `type:"string"`
 
-	metadataMetricCollectionType `json:"-", xml:"-"`
+	metadataMetricCollectionType `json:"-" xml:"-"`
 }
 
 type metadataMetricCollectionType struct {
@@ -3393,7 +3393,7 @@ type MetricGranularityType struct {
 	// The granularity.
 	Granularity *string `type:"string"`
 
-	metadataMetricGranularityType `json:"-", xml:"-"`
+	metadataMetricGranularityType `json:"-" xml:"-"`
 }
 
 type metadataMetricGranularityType struct {
@@ -3412,7 +3412,7 @@ type NotificationConfiguration struct {
 	// (SNS) topic.
 	TopicARN *string `type:"string"`
 
-	metadataNotificationConfiguration `json:"-", xml:"-"`
+	metadataNotificationConfiguration `json:"-" xml:"-"`
 }
 
 type metadataNotificationConfiguration struct {
@@ -3495,7 +3495,7 @@ type ProcessType struct {
 	// The name of the process.
 	ProcessName *string `type:"string" required:"true"`
 
-	metadataProcessType `json:"-", xml:"-"`
+	metadataProcessType `json:"-" xml:"-"`
 }
 
 type metadataProcessType struct {
@@ -3562,7 +3562,7 @@ type PutLifecycleHookInput struct {
 	// existing hooks.
 	RoleARN *string `type:"string"`
 
-	metadataPutLifecycleHookInput `json:"-", xml:"-"`
+	metadataPutLifecycleHookInput `json:"-" xml:"-"`
 }
 
 type metadataPutLifecycleHookInput struct {
@@ -3570,7 +3570,7 @@ type metadataPutLifecycleHookInput struct {
 }
 
 type PutLifecycleHookOutput struct {
-	metadataPutLifecycleHookOutput `json:"-", xml:"-"`
+	metadataPutLifecycleHookOutput `json:"-" xml:"-"`
 }
 
 type metadataPutLifecycleHookOutput struct {
@@ -3589,7 +3589,7 @@ type PutNotificationConfigurationInput struct {
 	// (SNS) topic.
 	TopicARN *string `type:"string" required:"true"`
 
-	metadataPutNotificationConfigurationInput `json:"-", xml:"-"`
+	metadataPutNotificationConfigurationInput `json:"-" xml:"-"`
 }
 
 type metadataPutNotificationConfigurationInput struct {
@@ -3597,7 +3597,7 @@ type metadataPutNotificationConfigurationInput struct {
 }
 
 type PutNotificationConfigurationOutput struct {
-	metadataPutNotificationConfigurationOutput `json:"-", xml:"-"`
+	metadataPutNotificationConfigurationOutput `json:"-" xml:"-"`
 }
 
 type metadataPutNotificationConfigurationOutput struct {
@@ -3640,7 +3640,7 @@ type PutScalingPolicyInput struct {
 	// current capacity and a negative value removes from the current capacity.
 	ScalingAdjustment *int64 `type:"integer" required:"true"`
 
-	metadataPutScalingPolicyInput `json:"-", xml:"-"`
+	metadataPutScalingPolicyInput `json:"-" xml:"-"`
 }
 
 type metadataPutScalingPolicyInput struct {
@@ -3651,7 +3651,7 @@ type PutScalingPolicyOutput struct {
 	// The Amazon Resource Name (ARN) of the policy.
 	PolicyARN *string `type:"string"`
 
-	metadataPutScalingPolicyOutput `json:"-", xml:"-"`
+	metadataPutScalingPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataPutScalingPolicyOutput struct {
@@ -3702,7 +3702,7 @@ type PutScheduledUpdateGroupActionInput struct {
 	// will return an error.
 	Time *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataPutScheduledUpdateGroupActionInput `json:"-", xml:"-"`
+	metadataPutScheduledUpdateGroupActionInput `json:"-" xml:"-"`
 }
 
 type metadataPutScheduledUpdateGroupActionInput struct {
@@ -3710,7 +3710,7 @@ type metadataPutScheduledUpdateGroupActionInput struct {
 }
 
 type PutScheduledUpdateGroupActionOutput struct {
-	metadataPutScheduledUpdateGroupActionOutput `json:"-", xml:"-"`
+	metadataPutScheduledUpdateGroupActionOutput `json:"-" xml:"-"`
 }
 
 type metadataPutScheduledUpdateGroupActionOutput struct {
@@ -3729,7 +3729,7 @@ type RecordLifecycleActionHeartbeatInput struct {
 	// The name of the lifecycle hook.
 	LifecycleHookName *string `type:"string" required:"true"`
 
-	metadataRecordLifecycleActionHeartbeatInput `json:"-", xml:"-"`
+	metadataRecordLifecycleActionHeartbeatInput `json:"-" xml:"-"`
 }
 
 type metadataRecordLifecycleActionHeartbeatInput struct {
@@ -3737,7 +3737,7 @@ type metadataRecordLifecycleActionHeartbeatInput struct {
 }
 
 type RecordLifecycleActionHeartbeatOutput struct {
-	metadataRecordLifecycleActionHeartbeatOutput `json:"-", xml:"-"`
+	metadataRecordLifecycleActionHeartbeatOutput `json:"-" xml:"-"`
 }
 
 type metadataRecordLifecycleActionHeartbeatOutput struct {
@@ -3745,7 +3745,7 @@ type metadataRecordLifecycleActionHeartbeatOutput struct {
 }
 
 type ResumeProcessesOutput struct {
-	metadataResumeProcessesOutput `json:"-", xml:"-"`
+	metadataResumeProcessesOutput `json:"-" xml:"-"`
 }
 
 type metadataResumeProcessesOutput struct {
@@ -3784,7 +3784,7 @@ type ScalingPolicy struct {
 	// capacity.
 	ScalingAdjustment *int64 `type:"integer"`
 
-	metadataScalingPolicy `json:"-", xml:"-"`
+	metadataScalingPolicy `json:"-" xml:"-"`
 }
 
 type metadataScalingPolicy struct {
@@ -3801,7 +3801,7 @@ type ScalingProcessQuery struct {
 	// ScheduledActions AddToLoadBalancer
 	ScalingProcesses []*string `type:"list"`
 
-	metadataScalingProcessQuery `json:"-", xml:"-"`
+	metadataScalingProcessQuery `json:"-" xml:"-"`
 }
 
 type metadataScalingProcessQuery struct {
@@ -3847,7 +3847,7 @@ type ScheduledUpdateGroupAction struct {
 	// The time that the action is scheduled to begin. Time is an alias for StartTime.
 	Time *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataScheduledUpdateGroupAction `json:"-", xml:"-"`
+	metadataScheduledUpdateGroupAction `json:"-" xml:"-"`
 }
 
 type metadataScheduledUpdateGroupAction struct {
@@ -3867,7 +3867,7 @@ type SetDesiredCapacityInput struct {
 	// initiating a scaling activity to set your Auto Scaling group to its new capacity.
 	HonorCooldown *bool `type:"boolean"`
 
-	metadataSetDesiredCapacityInput `json:"-", xml:"-"`
+	metadataSetDesiredCapacityInput `json:"-" xml:"-"`
 }
 
 type metadataSetDesiredCapacityInput struct {
@@ -3875,7 +3875,7 @@ type metadataSetDesiredCapacityInput struct {
 }
 
 type SetDesiredCapacityOutput struct {
-	metadataSetDesiredCapacityOutput `json:"-", xml:"-"`
+	metadataSetDesiredCapacityOutput `json:"-" xml:"-"`
 }
 
 type metadataSetDesiredCapacityOutput struct {
@@ -3900,7 +3900,7 @@ type SetInstanceHealthInput struct {
 	// for CreateAutoScalingGroup.
 	ShouldRespectGracePeriod *bool `type:"boolean"`
 
-	metadataSetInstanceHealthInput `json:"-", xml:"-"`
+	metadataSetInstanceHealthInput `json:"-" xml:"-"`
 }
 
 type metadataSetInstanceHealthInput struct {
@@ -3908,7 +3908,7 @@ type metadataSetInstanceHealthInput struct {
 }
 
 type SetInstanceHealthOutput struct {
-	metadataSetInstanceHealthOutput `json:"-", xml:"-"`
+	metadataSetInstanceHealthOutput `json:"-" xml:"-"`
 }
 
 type metadataSetInstanceHealthOutput struct {
@@ -3916,7 +3916,7 @@ type metadataSetInstanceHealthOutput struct {
 }
 
 type SuspendProcessesOutput struct {
-	metadataSuspendProcessesOutput `json:"-", xml:"-"`
+	metadataSuspendProcessesOutput `json:"-" xml:"-"`
 }
 
 type metadataSuspendProcessesOutput struct {
@@ -3932,7 +3932,7 @@ type SuspendedProcess struct {
 	// The reason that the process was suspended.
 	SuspensionReason *string `type:"string"`
 
-	metadataSuspendedProcess `json:"-", xml:"-"`
+	metadataSuspendedProcess `json:"-" xml:"-"`
 }
 
 type metadataSuspendedProcess struct {
@@ -3959,7 +3959,7 @@ type Tag struct {
 	// The tag value.
 	Value *string `type:"string"`
 
-	metadataTag `json:"-", xml:"-"`
+	metadataTag `json:"-" xml:"-"`
 }
 
 type metadataTag struct {
@@ -3986,7 +3986,7 @@ type TagDescription struct {
 	// The tag value.
 	Value *string `type:"string"`
 
-	metadataTagDescription `json:"-", xml:"-"`
+	metadataTagDescription `json:"-" xml:"-"`
 }
 
 type metadataTagDescription struct {
@@ -4001,7 +4001,7 @@ type TerminateInstanceInAutoScalingGroupInput struct {
 	// group.
 	ShouldDecrementDesiredCapacity *bool `type:"boolean" required:"true"`
 
-	metadataTerminateInstanceInAutoScalingGroupInput `json:"-", xml:"-"`
+	metadataTerminateInstanceInAutoScalingGroupInput `json:"-" xml:"-"`
 }
 
 type metadataTerminateInstanceInAutoScalingGroupInput struct {
@@ -4012,7 +4012,7 @@ type TerminateInstanceInAutoScalingGroupOutput struct {
 	// A scaling activity.
 	Activity *Activity `type:"structure"`
 
-	metadataTerminateInstanceInAutoScalingGroupOutput `json:"-", xml:"-"`
+	metadataTerminateInstanceInAutoScalingGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataTerminateInstanceInAutoScalingGroupOutput struct {
@@ -4079,7 +4079,7 @@ type UpdateAutoScalingGroupInput struct {
 	// in the Auto Scaling Developer Guide.
 	VPCZoneIdentifier *string `type:"string"`
 
-	metadataUpdateAutoScalingGroupInput `json:"-", xml:"-"`
+	metadataUpdateAutoScalingGroupInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateAutoScalingGroupInput struct {
@@ -4087,7 +4087,7 @@ type metadataUpdateAutoScalingGroupInput struct {
 }
 
 type UpdateAutoScalingGroupOutput struct {
-	metadataUpdateAutoScalingGroupOutput `json:"-", xml:"-"`
+	metadataUpdateAutoScalingGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateAutoScalingGroupOutput struct {

--- a/service/cloudformation/api.go
+++ b/service/cloudformation/api.go
@@ -651,7 +651,7 @@ type CancelUpdateStackInput struct {
 	// The name or the unique identifier associated with the stack.
 	StackName *string `type:"string" required:"true"`
 
-	metadataCancelUpdateStackInput `json:"-", xml:"-"`
+	metadataCancelUpdateStackInput `json:"-" xml:"-"`
 }
 
 type metadataCancelUpdateStackInput struct {
@@ -659,7 +659,7 @@ type metadataCancelUpdateStackInput struct {
 }
 
 type CancelUpdateStackOutput struct {
-	metadataCancelUpdateStackOutput `json:"-", xml:"-"`
+	metadataCancelUpdateStackOutput `json:"-" xml:"-"`
 }
 
 type metadataCancelUpdateStackOutput struct {
@@ -755,7 +755,7 @@ type CreateStackInput struct {
 	// back.
 	TimeoutInMinutes *int64 `type:"integer"`
 
-	metadataCreateStackInput `json:"-", xml:"-"`
+	metadataCreateStackInput `json:"-" xml:"-"`
 }
 
 type metadataCreateStackInput struct {
@@ -767,7 +767,7 @@ type CreateStackOutput struct {
 	// Unique identifier of the stack.
 	StackID *string `locationName:"StackId" type:"string"`
 
-	metadataCreateStackOutput `json:"-", xml:"-"`
+	metadataCreateStackOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateStackOutput struct {
@@ -779,7 +779,7 @@ type DeleteStackInput struct {
 	// The name or the unique identifier associated with the stack.
 	StackName *string `type:"string" required:"true"`
 
-	metadataDeleteStackInput `json:"-", xml:"-"`
+	metadataDeleteStackInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteStackInput struct {
@@ -787,7 +787,7 @@ type metadataDeleteStackInput struct {
 }
 
 type DeleteStackOutput struct {
-	metadataDeleteStackOutput `json:"-", xml:"-"`
+	metadataDeleteStackOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteStackOutput struct {
@@ -810,7 +810,7 @@ type DescribeStackEventsInput struct {
 	// is no default value.
 	StackName *string `type:"string"`
 
-	metadataDescribeStackEventsInput `json:"-", xml:"-"`
+	metadataDescribeStackEventsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeStackEventsInput struct {
@@ -826,7 +826,7 @@ type DescribeStackEventsOutput struct {
 	// A list of StackEvents structures.
 	StackEvents []*StackEvent `type:"list"`
 
-	metadataDescribeStackEventsOutput `json:"-", xml:"-"`
+	metadataDescribeStackEventsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeStackEventsOutput struct {
@@ -848,7 +848,7 @@ type DescribeStackResourceInput struct {
 	// is no default value.
 	StackName *string `type:"string" required:"true"`
 
-	metadataDescribeStackResourceInput `json:"-", xml:"-"`
+	metadataDescribeStackResourceInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeStackResourceInput struct {
@@ -861,7 +861,7 @@ type DescribeStackResourceOutput struct {
 	// resource in the specified stack.
 	StackResourceDetail *StackResourceDetail `type:"structure"`
 
-	metadataDescribeStackResourceOutput `json:"-", xml:"-"`
+	metadataDescribeStackResourceOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeStackResourceOutput struct {
@@ -900,7 +900,7 @@ type DescribeStackResourcesInput struct {
 	// PhysicalResourceId.
 	StackName *string `type:"string"`
 
-	metadataDescribeStackResourcesInput `json:"-", xml:"-"`
+	metadataDescribeStackResourcesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeStackResourcesInput struct {
@@ -912,7 +912,7 @@ type DescribeStackResourcesOutput struct {
 	// A list of StackResource structures.
 	StackResources []*StackResource `type:"list"`
 
-	metadataDescribeStackResourcesOutput `json:"-", xml:"-"`
+	metadataDescribeStackResourcesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeStackResourcesOutput struct {
@@ -933,7 +933,7 @@ type DescribeStacksInput struct {
 	// is no default value.
 	StackName *string `type:"string"`
 
-	metadataDescribeStacksInput `json:"-", xml:"-"`
+	metadataDescribeStacksInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeStacksInput struct {
@@ -949,7 +949,7 @@ type DescribeStacksOutput struct {
 	// A list of stack structures.
 	Stacks []*Stack `type:"list"`
 
-	metadataDescribeStacksOutput `json:"-", xml:"-"`
+	metadataDescribeStacksOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeStacksOutput struct {
@@ -978,7 +978,7 @@ type EstimateTemplateCostInput struct {
 	// only TemplateBody is used.
 	TemplateURL *string `type:"string"`
 
-	metadataEstimateTemplateCostInput `json:"-", xml:"-"`
+	metadataEstimateTemplateCostInput `json:"-" xml:"-"`
 }
 
 type metadataEstimateTemplateCostInput struct {
@@ -991,7 +991,7 @@ type EstimateTemplateCostOutput struct {
 	// resources required to run the template.
 	URL *string `locationName:"Url" type:"string"`
 
-	metadataEstimateTemplateCostOutput `json:"-", xml:"-"`
+	metadataEstimateTemplateCostOutput `json:"-" xml:"-"`
 }
 
 type metadataEstimateTemplateCostOutput struct {
@@ -1004,7 +1004,7 @@ type GetStackPolicyInput struct {
 	// to get.
 	StackName *string `type:"string" required:"true"`
 
-	metadataGetStackPolicyInput `json:"-", xml:"-"`
+	metadataGetStackPolicyInput `json:"-" xml:"-"`
 }
 
 type metadataGetStackPolicyInput struct {
@@ -1018,7 +1018,7 @@ type GetStackPolicyOutput struct {
 	// in the AWS CloudFormation User Guide.)
 	StackPolicyBody *string `type:"string"`
 
-	metadataGetStackPolicyOutput `json:"-", xml:"-"`
+	metadataGetStackPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataGetStackPolicyOutput struct {
@@ -1035,7 +1035,7 @@ type GetTemplateInput struct {
 	// is no default value.
 	StackName *string `type:"string" required:"true"`
 
-	metadataGetTemplateInput `json:"-", xml:"-"`
+	metadataGetTemplateInput `json:"-" xml:"-"`
 }
 
 type metadataGetTemplateInput struct {
@@ -1049,7 +1049,7 @@ type GetTemplateOutput struct {
 	// in the AWS CloudFormation User Guide.)
 	TemplateBody *string `type:"string"`
 
-	metadataGetTemplateOutput `json:"-", xml:"-"`
+	metadataGetTemplateOutput `json:"-" xml:"-"`
 }
 
 type metadataGetTemplateOutput struct {
@@ -1085,7 +1085,7 @@ type GetTemplateSummaryInput struct {
 	// TemplateBody, or TemplateURL.
 	TemplateURL *string `type:"string"`
 
-	metadataGetTemplateSummaryInput `json:"-", xml:"-"`
+	metadataGetTemplateSummaryInput `json:"-" xml:"-"`
 }
 
 type metadataGetTemplateSummaryInput struct {
@@ -1115,7 +1115,7 @@ type GetTemplateSummaryOutput struct {
 	// template.
 	Version *string `type:"string"`
 
-	metadataGetTemplateSummaryOutput `json:"-", xml:"-"`
+	metadataGetTemplateSummaryOutput `json:"-" xml:"-"`
 }
 
 type metadataGetTemplateSummaryOutput struct {
@@ -1138,7 +1138,7 @@ type ListStackResourcesInput struct {
 	// is no default value.
 	StackName *string `type:"string" required:"true"`
 
-	metadataListStackResourcesInput `json:"-", xml:"-"`
+	metadataListStackResourcesInput `json:"-" xml:"-"`
 }
 
 type metadataListStackResourcesInput struct {
@@ -1154,7 +1154,7 @@ type ListStackResourcesOutput struct {
 	// A list of StackResourceSummary structures.
 	StackResourceSummaries []*StackResourceSummary `type:"list"`
 
-	metadataListStackResourcesOutput `json:"-", xml:"-"`
+	metadataListStackResourcesOutput `json:"-" xml:"-"`
 }
 
 type metadataListStackResourcesOutput struct {
@@ -1174,7 +1174,7 @@ type ListStacksInput struct {
 	// stack status codes, see the StackStatus parameter of the Stack data type.
 	StackStatusFilter []*string `type:"list"`
 
-	metadataListStacksInput `json:"-", xml:"-"`
+	metadataListStacksInput `json:"-" xml:"-"`
 }
 
 type metadataListStacksInput struct {
@@ -1191,7 +1191,7 @@ type ListStacksOutput struct {
 	// stacks.
 	StackSummaries []*StackSummary `type:"list"`
 
-	metadataListStacksOutput `json:"-", xml:"-"`
+	metadataListStacksOutput `json:"-" xml:"-"`
 }
 
 type metadataListStacksOutput struct {
@@ -1209,7 +1209,7 @@ type Output struct {
 	// The value associated with the output.
 	OutputValue *string `type:"string"`
 
-	metadataOutput `json:"-", xml:"-"`
+	metadataOutput `json:"-" xml:"-"`
 }
 
 type metadataOutput struct {
@@ -1228,7 +1228,7 @@ type Parameter struct {
 	// for the stack.
 	UsePreviousValue *bool `type:"boolean"`
 
-	metadataParameter `json:"-", xml:"-"`
+	metadataParameter `json:"-" xml:"-"`
 }
 
 type metadataParameter struct {
@@ -1253,7 +1253,7 @@ type ParameterDeclaration struct {
 	// The type of parameter.
 	ParameterType *string `type:"string"`
 
-	metadataParameterDeclaration `json:"-", xml:"-"`
+	metadataParameterDeclaration `json:"-" xml:"-"`
 }
 
 type metadataParameterDeclaration struct {
@@ -1277,7 +1277,7 @@ type SetStackPolicyInput struct {
 	// but not both.
 	StackPolicyURL *string `type:"string"`
 
-	metadataSetStackPolicyInput `json:"-", xml:"-"`
+	metadataSetStackPolicyInput `json:"-" xml:"-"`
 }
 
 type metadataSetStackPolicyInput struct {
@@ -1285,7 +1285,7 @@ type metadataSetStackPolicyInput struct {
 }
 
 type SetStackPolicyOutput struct {
-	metadataSetStackPolicyOutput `json:"-", xml:"-"`
+	metadataSetStackPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataSetStackPolicyOutput struct {
@@ -1311,7 +1311,7 @@ type SignalResourceInput struct {
 	// condition), each signal requires a different unique ID.
 	UniqueID *string `locationName:"UniqueId" type:"string" required:"true"`
 
-	metadataSignalResourceInput `json:"-", xml:"-"`
+	metadataSignalResourceInput `json:"-" xml:"-"`
 }
 
 type metadataSignalResourceInput struct {
@@ -1319,7 +1319,7 @@ type metadataSignalResourceInput struct {
 }
 
 type SignalResourceOutput struct {
-	metadataSignalResourceOutput `json:"-", xml:"-"`
+	metadataSignalResourceOutput `json:"-" xml:"-"`
 }
 
 type metadataSignalResourceOutput struct {
@@ -1373,7 +1373,7 @@ type Stack struct {
 	// The amount of time within which stack creation should complete.
 	TimeoutInMinutes *int64 `type:"integer"`
 
-	metadataStack `json:"-", xml:"-"`
+	metadataStack `json:"-" xml:"-"`
 }
 
 type metadataStack struct {
@@ -1415,7 +1415,7 @@ type StackEvent struct {
 	// Time the status was updated.
 	Timestamp *time.Time `type:"timestamp" timestampFormat:"iso8601" required:"true"`
 
-	metadataStackEvent `json:"-", xml:"-"`
+	metadataStackEvent `json:"-" xml:"-"`
 }
 
 type metadataStackEvent struct {
@@ -1454,7 +1454,7 @@ type StackResource struct {
 	// Time the status was updated.
 	Timestamp *time.Time `type:"timestamp" timestampFormat:"iso8601" required:"true"`
 
-	metadataStackResource `json:"-", xml:"-"`
+	metadataStackResource `json:"-" xml:"-"`
 }
 
 type metadataStackResource struct {
@@ -1498,7 +1498,7 @@ type StackResourceDetail struct {
 	// The name associated with the stack.
 	StackName *string `type:"string"`
 
-	metadataStackResourceDetail `json:"-", xml:"-"`
+	metadataStackResourceDetail `json:"-" xml:"-"`
 }
 
 type metadataStackResourceDetail struct {
@@ -1528,7 +1528,7 @@ type StackResourceSummary struct {
 	// in the AWS CloudFormation User Guide.)
 	ResourceType *string `type:"string" required:"true"`
 
-	metadataStackResourceSummary `json:"-", xml:"-"`
+	metadataStackResourceSummary `json:"-" xml:"-"`
 }
 
 type metadataStackResourceSummary struct {
@@ -1562,7 +1562,7 @@ type StackSummary struct {
 	// The template description of the template used to create the stack.
 	TemplateDescription *string `type:"string"`
 
-	metadataStackSummary `json:"-", xml:"-"`
+	metadataStackSummary `json:"-" xml:"-"`
 }
 
 type metadataStackSummary struct {
@@ -1582,7 +1582,7 @@ type Tag struct {
 	// of 256 characters for a tag value.
 	Value *string `type:"string"`
 
-	metadataTag `json:"-", xml:"-"`
+	metadataTag `json:"-" xml:"-"`
 }
 
 type metadataTag struct {
@@ -1604,7 +1604,7 @@ type TemplateParameter struct {
 	// The name associated with the parameter.
 	ParameterKey *string `type:"string"`
 
-	metadataTemplateParameter `json:"-", xml:"-"`
+	metadataTemplateParameter `json:"-" xml:"-"`
 }
 
 type metadataTemplateParameter struct {
@@ -1702,7 +1702,7 @@ type UpdateStackInput struct {
 	// updating.
 	UsePreviousTemplate *bool `type:"boolean"`
 
-	metadataUpdateStackInput `json:"-", xml:"-"`
+	metadataUpdateStackInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateStackInput struct {
@@ -1714,7 +1714,7 @@ type UpdateStackOutput struct {
 	// Unique identifier of the stack.
 	StackID *string `locationName:"StackId" type:"string"`
 
-	metadataUpdateStackOutput `json:"-", xml:"-"`
+	metadataUpdateStackOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateStackOutput struct {
@@ -1741,7 +1741,7 @@ type ValidateTemplateInput struct {
 	// only TemplateBody is used.
 	TemplateURL *string `type:"string"`
 
-	metadataValidateTemplateInput `json:"-", xml:"-"`
+	metadataValidateTemplateInput `json:"-" xml:"-"`
 }
 
 type metadataValidateTemplateInput struct {
@@ -1766,7 +1766,7 @@ type ValidateTemplateOutput struct {
 	// A list of TemplateParameter structures.
 	Parameters []*TemplateParameter `type:"list"`
 
-	metadataValidateTemplateOutput `json:"-", xml:"-"`
+	metadataValidateTemplateOutput `json:"-" xml:"-"`
 }
 
 type metadataValidateTemplateOutput struct {

--- a/service/cloudfront/api.go
+++ b/service/cloudfront/api.go
@@ -723,7 +723,7 @@ type ActiveTrustedSigners struct {
 	// value of Quantity for ActiveTrustedSigners will be 3.
 	Quantity *int64 `type:"integer" required:"true"`
 
-	metadataActiveTrustedSigners `json:"-", xml:"-"`
+	metadataActiveTrustedSigners `json:"-" xml:"-"`
 }
 
 type metadataActiveTrustedSigners struct {
@@ -740,7 +740,7 @@ type Aliases struct {
 	// The number of CNAMEs, if any, for this distribution.
 	Quantity *int64 `type:"integer" required:"true"`
 
-	metadataAliases `json:"-", xml:"-"`
+	metadataAliases `json:"-" xml:"-"`
 }
 
 type metadataAliases struct {
@@ -773,7 +773,7 @@ type AllowedMethods struct {
 	// requests) and 7 (for GET, HEAD, OPTIONS, PUT, PATCH, POST, and DELETE requests).
 	Quantity *int64 `type:"integer" required:"true"`
 
-	metadataAllowedMethods `json:"-", xml:"-"`
+	metadataAllowedMethods `json:"-" xml:"-"`
 }
 
 type metadataAllowedMethods struct {
@@ -856,7 +856,7 @@ type CacheBehavior struct {
 	// the HTTPS URL.
 	ViewerProtocolPolicy *string `type:"string" required:"true"`
 
-	metadataCacheBehavior `json:"-", xml:"-"`
+	metadataCacheBehavior `json:"-" xml:"-"`
 }
 
 type metadataCacheBehavior struct {
@@ -872,7 +872,7 @@ type CacheBehaviors struct {
 	// The number of cache behaviors for this distribution.
 	Quantity *int64 `type:"integer" required:"true"`
 
-	metadataCacheBehaviors `json:"-", xml:"-"`
+	metadataCacheBehaviors `json:"-" xml:"-"`
 }
 
 type metadataCacheBehaviors struct {
@@ -895,7 +895,7 @@ type CachedMethods struct {
 	// (for caching responses to GET, HEAD, and OPTIONS requests).
 	Quantity *int64 `type:"integer" required:"true"`
 
-	metadataCachedMethods `json:"-", xml:"-"`
+	metadataCachedMethods `json:"-" xml:"-"`
 }
 
 type metadataCachedMethods struct {
@@ -915,7 +915,7 @@ type CloudFrontOriginAccessIdentity struct {
 	// Amazon S3.
 	S3CanonicalUserID *string `locationName:"S3CanonicalUserId" type:"string" required:"true"`
 
-	metadataCloudFrontOriginAccessIdentity `json:"-", xml:"-"`
+	metadataCloudFrontOriginAccessIdentity `json:"-" xml:"-"`
 }
 
 type metadataCloudFrontOriginAccessIdentity struct {
@@ -940,7 +940,7 @@ type CloudFrontOriginAccessIdentityConfig struct {
 	// Any comments you want to include about the origin access identity.
 	Comment *string `type:"string" required:"true"`
 
-	metadataCloudFrontOriginAccessIdentityConfig `json:"-", xml:"-"`
+	metadataCloudFrontOriginAccessIdentityConfig `json:"-" xml:"-"`
 }
 
 type metadataCloudFrontOriginAccessIdentityConfig struct {
@@ -974,7 +974,7 @@ type CloudFrontOriginAccessIdentityList struct {
 	// current AWS account.
 	Quantity *int64 `type:"integer" required:"true"`
 
-	metadataCloudFrontOriginAccessIdentityList `json:"-", xml:"-"`
+	metadataCloudFrontOriginAccessIdentityList `json:"-" xml:"-"`
 }
 
 type metadataCloudFrontOriginAccessIdentityList struct {
@@ -995,7 +995,7 @@ type CloudFrontOriginAccessIdentitySummary struct {
 	// Amazon S3.
 	S3CanonicalUserID *string `locationName:"S3CanonicalUserId" type:"string" required:"true"`
 
-	metadataCloudFrontOriginAccessIdentitySummary `json:"-", xml:"-"`
+	metadataCloudFrontOriginAccessIdentitySummary `json:"-" xml:"-"`
 }
 
 type metadataCloudFrontOriginAccessIdentitySummary struct {
@@ -1012,7 +1012,7 @@ type CookieNames struct {
 	// The number of whitelisted cookies for this cache behavior.
 	Quantity *int64 `type:"integer" required:"true"`
 
-	metadataCookieNames `json:"-", xml:"-"`
+	metadataCookieNames `json:"-" xml:"-"`
 }
 
 type metadataCookieNames struct {
@@ -1032,7 +1032,7 @@ type CookiePreference struct {
 	// CloudFront to forward to your origin that is associated with this cache behavior.
 	WhitelistedNames *CookieNames `type:"structure"`
 
-	metadataCookiePreference `json:"-", xml:"-"`
+	metadataCookiePreference `json:"-" xml:"-"`
 }
 
 type metadataCookiePreference struct {
@@ -1044,7 +1044,7 @@ type CreateCloudFrontOriginAccessIdentityInput struct {
 	// The origin access identity's configuration information.
 	CloudFrontOriginAccessIdentityConfig *CloudFrontOriginAccessIdentityConfig `locationName:"CloudFrontOriginAccessIdentityConfig" type:"structure" required:"true"`
 
-	metadataCreateCloudFrontOriginAccessIdentityInput `json:"-", xml:"-"`
+	metadataCreateCloudFrontOriginAccessIdentityInput `json:"-" xml:"-"`
 }
 
 type metadataCreateCloudFrontOriginAccessIdentityInput struct {
@@ -1063,7 +1063,7 @@ type CreateCloudFrontOriginAccessIdentityOutput struct {
 	// example: https://cloudfront.amazonaws.com/2010-11-01/origin-access-identity/cloudfront/E74FTE3AJFJ256A.
 	Location *string `location:"header" locationName:"Location" type:"string"`
 
-	metadataCreateCloudFrontOriginAccessIdentityOutput `json:"-", xml:"-"`
+	metadataCreateCloudFrontOriginAccessIdentityOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateCloudFrontOriginAccessIdentityOutput struct {
@@ -1075,7 +1075,7 @@ type CreateDistributionInput struct {
 	// The distribution's configuration information.
 	DistributionConfig *DistributionConfig `locationName:"DistributionConfig" type:"structure" required:"true"`
 
-	metadataCreateDistributionInput `json:"-", xml:"-"`
+	metadataCreateDistributionInput `json:"-" xml:"-"`
 }
 
 type metadataCreateDistributionInput struct {
@@ -1094,7 +1094,7 @@ type CreateDistributionOutput struct {
 	// example: https://cloudfront.amazonaws.com/2010-11-01/distribution/EDFDVBD632BHDS5.
 	Location *string `location:"header" locationName:"Location" type:"string"`
 
-	metadataCreateDistributionOutput `json:"-", xml:"-"`
+	metadataCreateDistributionOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateDistributionOutput struct {
@@ -1109,7 +1109,7 @@ type CreateInvalidationInput struct {
 	// The batch information for the invalidation.
 	InvalidationBatch *InvalidationBatch `locationName:"InvalidationBatch" type:"structure" required:"true"`
 
-	metadataCreateInvalidationInput `json:"-", xml:"-"`
+	metadataCreateInvalidationInput `json:"-" xml:"-"`
 }
 
 type metadataCreateInvalidationInput struct {
@@ -1125,7 +1125,7 @@ type CreateInvalidationOutput struct {
 	// including the Invalidation ID.
 	Location *string `location:"header" locationName:"Location" type:"string"`
 
-	metadataCreateInvalidationOutput `json:"-", xml:"-"`
+	metadataCreateInvalidationOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateInvalidationOutput struct {
@@ -1137,7 +1137,7 @@ type CreateStreamingDistributionInput struct {
 	// The streaming distribution's configuration information.
 	StreamingDistributionConfig *StreamingDistributionConfig `locationName:"StreamingDistributionConfig" type:"structure" required:"true"`
 
-	metadataCreateStreamingDistributionInput `json:"-", xml:"-"`
+	metadataCreateStreamingDistributionInput `json:"-" xml:"-"`
 }
 
 type metadataCreateStreamingDistributionInput struct {
@@ -1156,7 +1156,7 @@ type CreateStreamingDistributionOutput struct {
 	// The streaming distribution's information.
 	StreamingDistribution *StreamingDistribution `type:"structure"`
 
-	metadataCreateStreamingDistributionOutput `json:"-", xml:"-"`
+	metadataCreateStreamingDistributionOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateStreamingDistributionOutput struct {
@@ -1197,7 +1197,7 @@ type CustomErrorResponse struct {
 	// return the custom error page to the viewer.
 	ResponsePagePath *string `type:"string"`
 
-	metadataCustomErrorResponse `json:"-", xml:"-"`
+	metadataCustomErrorResponse `json:"-" xml:"-"`
 }
 
 type metadataCustomErrorResponse struct {
@@ -1213,7 +1213,7 @@ type CustomErrorResponses struct {
 	// The number of custom error responses for this distribution.
 	Quantity *int64 `type:"integer" required:"true"`
 
-	metadataCustomErrorResponses `json:"-", xml:"-"`
+	metadataCustomErrorResponses `json:"-" xml:"-"`
 }
 
 type metadataCustomErrorResponses struct {
@@ -1231,7 +1231,7 @@ type CustomOriginConfig struct {
 	// The origin protocol policy to apply to your origin.
 	OriginProtocolPolicy *string `type:"string" required:"true"`
 
-	metadataCustomOriginConfig `json:"-", xml:"-"`
+	metadataCustomOriginConfig `json:"-" xml:"-"`
 }
 
 type metadataCustomOriginConfig struct {
@@ -1294,7 +1294,7 @@ type DefaultCacheBehavior struct {
 	// the HTTPS URL.
 	ViewerProtocolPolicy *string `type:"string" required:"true"`
 
-	metadataDefaultCacheBehavior `json:"-", xml:"-"`
+	metadataDefaultCacheBehavior `json:"-" xml:"-"`
 }
 
 type metadataDefaultCacheBehavior struct {
@@ -1310,7 +1310,7 @@ type DeleteCloudFrontOriginAccessIdentityInput struct {
 	// For example: E2QWRUHAPOMQZL.
 	IfMatch *string `location:"header" locationName:"If-Match" type:"string"`
 
-	metadataDeleteCloudFrontOriginAccessIdentityInput `json:"-", xml:"-"`
+	metadataDeleteCloudFrontOriginAccessIdentityInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteCloudFrontOriginAccessIdentityInput struct {
@@ -1318,7 +1318,7 @@ type metadataDeleteCloudFrontOriginAccessIdentityInput struct {
 }
 
 type DeleteCloudFrontOriginAccessIdentityOutput struct {
-	metadataDeleteCloudFrontOriginAccessIdentityOutput `json:"-", xml:"-"`
+	metadataDeleteCloudFrontOriginAccessIdentityOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteCloudFrontOriginAccessIdentityOutput struct {
@@ -1334,7 +1334,7 @@ type DeleteDistributionInput struct {
 	// For example: E2QWRUHAPOMQZL.
 	IfMatch *string `location:"header" locationName:"If-Match" type:"string"`
 
-	metadataDeleteDistributionInput `json:"-", xml:"-"`
+	metadataDeleteDistributionInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteDistributionInput struct {
@@ -1342,7 +1342,7 @@ type metadataDeleteDistributionInput struct {
 }
 
 type DeleteDistributionOutput struct {
-	metadataDeleteDistributionOutput `json:"-", xml:"-"`
+	metadataDeleteDistributionOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteDistributionOutput struct {
@@ -1358,7 +1358,7 @@ type DeleteStreamingDistributionInput struct {
 	// distribution. For example: E2QWRUHAPOMQZL.
 	IfMatch *string `location:"header" locationName:"If-Match" type:"string"`
 
-	metadataDeleteStreamingDistributionInput `json:"-", xml:"-"`
+	metadataDeleteStreamingDistributionInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteStreamingDistributionInput struct {
@@ -1366,7 +1366,7 @@ type metadataDeleteStreamingDistributionInput struct {
 }
 
 type DeleteStreamingDistributionOutput struct {
-	metadataDeleteStreamingDistributionOutput `json:"-", xml:"-"`
+	metadataDeleteStreamingDistributionOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteStreamingDistributionOutput struct {
@@ -1405,7 +1405,7 @@ type Distribution struct {
 	// throughout the Amazon CloudFront system.
 	Status *string `type:"string" required:"true"`
 
-	metadataDistribution `json:"-", xml:"-"`
+	metadataDistribution `json:"-" xml:"-"`
 }
 
 type metadataDistribution struct {
@@ -1474,7 +1474,7 @@ type DistributionConfig struct {
 	// distribution.
 	ViewerCertificate *ViewerCertificate `type:"structure"`
 
-	metadataDistributionConfig `json:"-", xml:"-"`
+	metadataDistributionConfig `json:"-" xml:"-"`
 }
 
 type metadataDistributionConfig struct {
@@ -1507,7 +1507,7 @@ type DistributionList struct {
 	// The number of distributions that were created by the current AWS account.
 	Quantity *int64 `type:"integer" required:"true"`
 
-	metadataDistributionList `json:"-", xml:"-"`
+	metadataDistributionList `json:"-" xml:"-"`
 }
 
 type metadataDistributionList struct {
@@ -1564,7 +1564,7 @@ type DistributionSummary struct {
 	// distribution.
 	ViewerCertificate *ViewerCertificate `type:"structure" required:"true"`
 
-	metadataDistributionSummary `json:"-", xml:"-"`
+	metadataDistributionSummary `json:"-" xml:"-"`
 }
 
 type metadataDistributionSummary struct {
@@ -1586,7 +1586,7 @@ type ForwardedValues struct {
 	// specify false.
 	QueryString *bool `type:"boolean" required:"true"`
 
-	metadataForwardedValues `json:"-", xml:"-"`
+	metadataForwardedValues `json:"-" xml:"-"`
 }
 
 type metadataForwardedValues struct {
@@ -1624,7 +1624,7 @@ type GeoRestriction struct {
 	// you want CloudFront to distribute your content.
 	RestrictionType *string `type:"string" required:"true"`
 
-	metadataGeoRestriction `json:"-", xml:"-"`
+	metadataGeoRestriction `json:"-" xml:"-"`
 }
 
 type metadataGeoRestriction struct {
@@ -1636,7 +1636,7 @@ type GetCloudFrontOriginAccessIdentityConfigInput struct {
 	// The identity's id.
 	ID *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
-	metadataGetCloudFrontOriginAccessIdentityConfigInput `json:"-", xml:"-"`
+	metadataGetCloudFrontOriginAccessIdentityConfigInput `json:"-" xml:"-"`
 }
 
 type metadataGetCloudFrontOriginAccessIdentityConfigInput struct {
@@ -1651,7 +1651,7 @@ type GetCloudFrontOriginAccessIdentityConfigOutput struct {
 	// The current version of the configuration. For example: E2QWRUHAPOMQZL.
 	ETag *string `location:"header" locationName:"ETag" type:"string"`
 
-	metadataGetCloudFrontOriginAccessIdentityConfigOutput `json:"-", xml:"-"`
+	metadataGetCloudFrontOriginAccessIdentityConfigOutput `json:"-" xml:"-"`
 }
 
 type metadataGetCloudFrontOriginAccessIdentityConfigOutput struct {
@@ -1663,7 +1663,7 @@ type GetCloudFrontOriginAccessIdentityInput struct {
 	// The identity's id.
 	ID *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
-	metadataGetCloudFrontOriginAccessIdentityInput `json:"-", xml:"-"`
+	metadataGetCloudFrontOriginAccessIdentityInput `json:"-" xml:"-"`
 }
 
 type metadataGetCloudFrontOriginAccessIdentityInput struct {
@@ -1679,7 +1679,7 @@ type GetCloudFrontOriginAccessIdentityOutput struct {
 	// E2QWRUHAPOMQZL.
 	ETag *string `location:"header" locationName:"ETag" type:"string"`
 
-	metadataGetCloudFrontOriginAccessIdentityOutput `json:"-", xml:"-"`
+	metadataGetCloudFrontOriginAccessIdentityOutput `json:"-" xml:"-"`
 }
 
 type metadataGetCloudFrontOriginAccessIdentityOutput struct {
@@ -1691,7 +1691,7 @@ type GetDistributionConfigInput struct {
 	// The distribution's id.
 	ID *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
-	metadataGetDistributionConfigInput `json:"-", xml:"-"`
+	metadataGetDistributionConfigInput `json:"-" xml:"-"`
 }
 
 type metadataGetDistributionConfigInput struct {
@@ -1706,7 +1706,7 @@ type GetDistributionConfigOutput struct {
 	// The current version of the configuration. For example: E2QWRUHAPOMQZL.
 	ETag *string `location:"header" locationName:"ETag" type:"string"`
 
-	metadataGetDistributionConfigOutput `json:"-", xml:"-"`
+	metadataGetDistributionConfigOutput `json:"-" xml:"-"`
 }
 
 type metadataGetDistributionConfigOutput struct {
@@ -1718,7 +1718,7 @@ type GetDistributionInput struct {
 	// The distribution's id.
 	ID *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
-	metadataGetDistributionInput `json:"-", xml:"-"`
+	metadataGetDistributionInput `json:"-" xml:"-"`
 }
 
 type metadataGetDistributionInput struct {
@@ -1733,7 +1733,7 @@ type GetDistributionOutput struct {
 	// The current version of the distribution's information. For example: E2QWRUHAPOMQZL.
 	ETag *string `location:"header" locationName:"ETag" type:"string"`
 
-	metadataGetDistributionOutput `json:"-", xml:"-"`
+	metadataGetDistributionOutput `json:"-" xml:"-"`
 }
 
 type metadataGetDistributionOutput struct {
@@ -1748,7 +1748,7 @@ type GetInvalidationInput struct {
 	// The invalidation's id.
 	ID *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
-	metadataGetInvalidationInput `json:"-", xml:"-"`
+	metadataGetInvalidationInput `json:"-" xml:"-"`
 }
 
 type metadataGetInvalidationInput struct {
@@ -1760,7 +1760,7 @@ type GetInvalidationOutput struct {
 	// The invalidation's information.
 	Invalidation *Invalidation `type:"structure"`
 
-	metadataGetInvalidationOutput `json:"-", xml:"-"`
+	metadataGetInvalidationOutput `json:"-" xml:"-"`
 }
 
 type metadataGetInvalidationOutput struct {
@@ -1772,7 +1772,7 @@ type GetStreamingDistributionConfigInput struct {
 	// The streaming distribution's id.
 	ID *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
-	metadataGetStreamingDistributionConfigInput `json:"-", xml:"-"`
+	metadataGetStreamingDistributionConfigInput `json:"-" xml:"-"`
 }
 
 type metadataGetStreamingDistributionConfigInput struct {
@@ -1787,7 +1787,7 @@ type GetStreamingDistributionConfigOutput struct {
 	// The streaming distribution's configuration information.
 	StreamingDistributionConfig *StreamingDistributionConfig `type:"structure"`
 
-	metadataGetStreamingDistributionConfigOutput `json:"-", xml:"-"`
+	metadataGetStreamingDistributionConfigOutput `json:"-" xml:"-"`
 }
 
 type metadataGetStreamingDistributionConfigOutput struct {
@@ -1799,7 +1799,7 @@ type GetStreamingDistributionInput struct {
 	// The streaming distribution's id.
 	ID *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
-	metadataGetStreamingDistributionInput `json:"-", xml:"-"`
+	metadataGetStreamingDistributionInput `json:"-" xml:"-"`
 }
 
 type metadataGetStreamingDistributionInput struct {
@@ -1815,7 +1815,7 @@ type GetStreamingDistributionOutput struct {
 	// The streaming distribution's information.
 	StreamingDistribution *StreamingDistribution `type:"structure"`
 
-	metadataGetStreamingDistributionOutput `json:"-", xml:"-"`
+	metadataGetStreamingDistributionOutput `json:"-" xml:"-"`
 }
 
 type metadataGetStreamingDistributionOutput struct {
@@ -1845,7 +1845,7 @@ type Headers struct {
 	// Items.
 	Quantity *int64 `type:"integer" required:"true"`
 
-	metadataHeaders `json:"-", xml:"-"`
+	metadataHeaders `json:"-" xml:"-"`
 }
 
 type metadataHeaders struct {
@@ -1867,7 +1867,7 @@ type Invalidation struct {
 	// the status is Completed.
 	Status *string `type:"string" required:"true"`
 
-	metadataInvalidation `json:"-", xml:"-"`
+	metadataInvalidation `json:"-" xml:"-"`
 }
 
 type metadataInvalidation struct {
@@ -1895,7 +1895,7 @@ type InvalidationBatch struct {
 	// path, or CloudFront will not invalidate the old version of the updated object.
 	Paths *Paths `type:"structure" required:"true"`
 
-	metadataInvalidationBatch `json:"-", xml:"-"`
+	metadataInvalidationBatch `json:"-" xml:"-"`
 }
 
 type metadataInvalidationBatch struct {
@@ -1928,7 +1928,7 @@ type InvalidationList struct {
 	// The number of invalidation batches that were created by the current AWS account.
 	Quantity *int64 `type:"integer" required:"true"`
 
-	metadataInvalidationList `json:"-", xml:"-"`
+	metadataInvalidationList `json:"-" xml:"-"`
 }
 
 type metadataInvalidationList struct {
@@ -1945,7 +1945,7 @@ type InvalidationSummary struct {
 	// The status of an invalidation request.
 	Status *string `type:"string" required:"true"`
 
-	metadataInvalidationSummary `json:"-", xml:"-"`
+	metadataInvalidationSummary `json:"-" xml:"-"`
 }
 
 type metadataInvalidationSummary struct {
@@ -1962,7 +1962,7 @@ type KeyPairIDs struct {
 	// The number of active CloudFront key pairs for AwsAccountNumber.
 	Quantity *int64 `type:"integer" required:"true"`
 
-	metadataKeyPairIDs `json:"-", xml:"-"`
+	metadataKeyPairIDs `json:"-" xml:"-"`
 }
 
 type metadataKeyPairIDs struct {
@@ -1981,7 +1981,7 @@ type ListCloudFrontOriginAccessIdentitiesInput struct {
 	// The maximum number of origin access identities you want in the response body.
 	MaxItems *string `location:"querystring" locationName:"MaxItems" type:"string"`
 
-	metadataListCloudFrontOriginAccessIdentitiesInput `json:"-", xml:"-"`
+	metadataListCloudFrontOriginAccessIdentitiesInput `json:"-" xml:"-"`
 }
 
 type metadataListCloudFrontOriginAccessIdentitiesInput struct {
@@ -1993,7 +1993,7 @@ type ListCloudFrontOriginAccessIdentitiesOutput struct {
 	// The CloudFrontOriginAccessIdentityList type.
 	CloudFrontOriginAccessIdentityList *CloudFrontOriginAccessIdentityList `type:"structure"`
 
-	metadataListCloudFrontOriginAccessIdentitiesOutput `json:"-", xml:"-"`
+	metadataListCloudFrontOriginAccessIdentitiesOutput `json:"-" xml:"-"`
 }
 
 type metadataListCloudFrontOriginAccessIdentitiesOutput struct {
@@ -2012,7 +2012,7 @@ type ListDistributionsInput struct {
 	// The maximum number of distributions you want in the response body.
 	MaxItems *string `location:"querystring" locationName:"MaxItems" type:"string"`
 
-	metadataListDistributionsInput `json:"-", xml:"-"`
+	metadataListDistributionsInput `json:"-" xml:"-"`
 }
 
 type metadataListDistributionsInput struct {
@@ -2024,7 +2024,7 @@ type ListDistributionsOutput struct {
 	// The DistributionList type.
 	DistributionList *DistributionList `type:"structure"`
 
-	metadataListDistributionsOutput `json:"-", xml:"-"`
+	metadataListDistributionsOutput `json:"-" xml:"-"`
 }
 
 type metadataListDistributionsOutput struct {
@@ -2048,7 +2048,7 @@ type ListInvalidationsInput struct {
 	// The maximum number of invalidation batches you want in the response body.
 	MaxItems *string `location:"querystring" locationName:"MaxItems" type:"string"`
 
-	metadataListInvalidationsInput `json:"-", xml:"-"`
+	metadataListInvalidationsInput `json:"-" xml:"-"`
 }
 
 type metadataListInvalidationsInput struct {
@@ -2060,7 +2060,7 @@ type ListInvalidationsOutput struct {
 	// Information about invalidation batches.
 	InvalidationList *InvalidationList `type:"structure"`
 
-	metadataListInvalidationsOutput `json:"-", xml:"-"`
+	metadataListInvalidationsOutput `json:"-" xml:"-"`
 }
 
 type metadataListInvalidationsOutput struct {
@@ -2079,7 +2079,7 @@ type ListStreamingDistributionsInput struct {
 	// The maximum number of streaming distributions you want in the response body.
 	MaxItems *string `location:"querystring" locationName:"MaxItems" type:"string"`
 
-	metadataListStreamingDistributionsInput `json:"-", xml:"-"`
+	metadataListStreamingDistributionsInput `json:"-" xml:"-"`
 }
 
 type metadataListStreamingDistributionsInput struct {
@@ -2091,7 +2091,7 @@ type ListStreamingDistributionsOutput struct {
 	// The StreamingDistributionList type.
 	StreamingDistributionList *StreamingDistributionList `type:"structure"`
 
-	metadataListStreamingDistributionsOutput `json:"-", xml:"-"`
+	metadataListStreamingDistributionsOutput `json:"-" xml:"-"`
 }
 
 type metadataListStreamingDistributionsOutput struct {
@@ -2125,7 +2125,7 @@ type LoggingConfig struct {
 	// Prefix element in the Logging element.
 	Prefix *string `type:"string" required:"true"`
 
-	metadataLoggingConfig `json:"-", xml:"-"`
+	metadataLoggingConfig `json:"-" xml:"-"`
 }
 
 type metadataLoggingConfig struct {
@@ -2162,7 +2162,7 @@ type Origin struct {
 	// origin is a custom origin, use the CustomOriginConfig element instead.
 	S3OriginConfig *S3OriginConfig `type:"structure"`
 
-	metadataOrigin `json:"-", xml:"-"`
+	metadataOrigin `json:"-" xml:"-"`
 }
 
 type metadataOrigin struct {
@@ -2177,7 +2177,7 @@ type Origins struct {
 	// The number of origins for this distribution.
 	Quantity *int64 `type:"integer" required:"true"`
 
-	metadataOrigins `json:"-", xml:"-"`
+	metadataOrigins `json:"-" xml:"-"`
 }
 
 type metadataOrigins struct {
@@ -2193,7 +2193,7 @@ type Paths struct {
 	// The number of objects that you want to invalidate.
 	Quantity *int64 `type:"integer" required:"true"`
 
-	metadataPaths `json:"-", xml:"-"`
+	metadataPaths `json:"-" xml:"-"`
 }
 
 type metadataPaths struct {
@@ -2211,7 +2211,7 @@ type Restrictions struct {
 	// website.
 	GeoRestriction *GeoRestriction `type:"structure" required:"true"`
 
-	metadataRestrictions `json:"-", xml:"-"`
+	metadataRestrictions `json:"-" xml:"-"`
 }
 
 type metadataRestrictions struct {
@@ -2227,7 +2227,7 @@ type S3Origin struct {
 	// Your S3 origin's origin access identity.
 	OriginAccessIdentity *string `type:"string" required:"true"`
 
-	metadataS3Origin `json:"-", xml:"-"`
+	metadataS3Origin `json:"-" xml:"-"`
 }
 
 type metadataS3Origin struct {
@@ -2250,7 +2250,7 @@ type S3OriginConfig struct {
 	// created the origin access identity.
 	OriginAccessIdentity *string `type:"string" required:"true"`
 
-	metadataS3OriginConfig `json:"-", xml:"-"`
+	metadataS3OriginConfig `json:"-" xml:"-"`
 }
 
 type metadataS3OriginConfig struct {
@@ -2270,7 +2270,7 @@ type Signer struct {
 	// associated with AwsAccountNumber.
 	KeyPairIDs *KeyPairIDs `locationName:"KeyPairIds" type:"structure"`
 
-	metadataSigner `json:"-", xml:"-"`
+	metadataSigner `json:"-" xml:"-"`
 }
 
 type metadataSigner struct {
@@ -2307,7 +2307,7 @@ type StreamingDistribution struct {
 	// The current configuration information for the streaming distribution.
 	StreamingDistributionConfig *StreamingDistributionConfig `type:"structure" required:"true"`
 
-	metadataStreamingDistribution `json:"-", xml:"-"`
+	metadataStreamingDistribution `json:"-" xml:"-"`
 }
 
 type metadataStreamingDistribution struct {
@@ -2364,7 +2364,7 @@ type StreamingDistributionConfig struct {
 	// of the trusted signers that you want to include in the updated distribution.
 	TrustedSigners *TrustedSigners `type:"structure" required:"true"`
 
-	metadataStreamingDistributionConfig `json:"-", xml:"-"`
+	metadataStreamingDistributionConfig `json:"-" xml:"-"`
 }
 
 type metadataStreamingDistributionConfig struct {
@@ -2398,7 +2398,7 @@ type StreamingDistributionList struct {
 	// account.
 	Quantity *int64 `type:"integer" required:"true"`
 
-	metadataStreamingDistributionList `json:"-", xml:"-"`
+	metadataStreamingDistributionList `json:"-" xml:"-"`
 }
 
 type metadataStreamingDistributionList struct {
@@ -2450,7 +2450,7 @@ type StreamingDistributionSummary struct {
 	// of the trusted signers that you want to include in the updated distribution.
 	TrustedSigners *TrustedSigners `type:"structure" required:"true"`
 
-	metadataStreamingDistributionSummary `json:"-", xml:"-"`
+	metadataStreamingDistributionSummary `json:"-" xml:"-"`
 }
 
 type metadataStreamingDistributionSummary struct {
@@ -2477,7 +2477,7 @@ type StreamingLoggingConfig struct {
 	// an empty Prefix element in the Logging element.
 	Prefix *string `type:"string" required:"true"`
 
-	metadataStreamingLoggingConfig `json:"-", xml:"-"`
+	metadataStreamingLoggingConfig `json:"-" xml:"-"`
 }
 
 type metadataStreamingLoggingConfig struct {
@@ -2507,7 +2507,7 @@ type TrustedSigners struct {
 	// The number of trusted signers for this cache behavior.
 	Quantity *int64 `type:"integer" required:"true"`
 
-	metadataTrustedSigners `json:"-", xml:"-"`
+	metadataTrustedSigners `json:"-" xml:"-"`
 }
 
 type metadataTrustedSigners struct {
@@ -2526,7 +2526,7 @@ type UpdateCloudFrontOriginAccessIdentityInput struct {
 	// configuration. For example: E2QWRUHAPOMQZL.
 	IfMatch *string `location:"header" locationName:"If-Match" type:"string"`
 
-	metadataUpdateCloudFrontOriginAccessIdentityInput `json:"-", xml:"-"`
+	metadataUpdateCloudFrontOriginAccessIdentityInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateCloudFrontOriginAccessIdentityInput struct {
@@ -2541,7 +2541,7 @@ type UpdateCloudFrontOriginAccessIdentityOutput struct {
 	// The current version of the configuration. For example: E2QWRUHAPOMQZL.
 	ETag *string `location:"header" locationName:"ETag" type:"string"`
 
-	metadataUpdateCloudFrontOriginAccessIdentityOutput `json:"-", xml:"-"`
+	metadataUpdateCloudFrontOriginAccessIdentityOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateCloudFrontOriginAccessIdentityOutput struct {
@@ -2560,7 +2560,7 @@ type UpdateDistributionInput struct {
 	// configuration. For example: E2QWRUHAPOMQZL.
 	IfMatch *string `location:"header" locationName:"If-Match" type:"string"`
 
-	metadataUpdateDistributionInput `json:"-", xml:"-"`
+	metadataUpdateDistributionInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateDistributionInput struct {
@@ -2575,7 +2575,7 @@ type UpdateDistributionOutput struct {
 	// The current version of the configuration. For example: E2QWRUHAPOMQZL.
 	ETag *string `location:"header" locationName:"ETag" type:"string"`
 
-	metadataUpdateDistributionOutput `json:"-", xml:"-"`
+	metadataUpdateDistributionOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateDistributionOutput struct {
@@ -2594,7 +2594,7 @@ type UpdateStreamingDistributionInput struct {
 	// The streaming distribution's configuration information.
 	StreamingDistributionConfig *StreamingDistributionConfig `locationName:"StreamingDistributionConfig" type:"structure" required:"true"`
 
-	metadataUpdateStreamingDistributionInput `json:"-", xml:"-"`
+	metadataUpdateStreamingDistributionInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateStreamingDistributionInput struct {
@@ -2609,7 +2609,7 @@ type UpdateStreamingDistributionOutput struct {
 	// The streaming distribution's information.
 	StreamingDistribution *StreamingDistribution `type:"structure"`
 
-	metadataUpdateStreamingDistributionOutput `json:"-", xml:"-"`
+	metadataUpdateStreamingDistributionOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateStreamingDistributionOutput struct {
@@ -2655,7 +2655,7 @@ type ViewerCertificate struct {
 	// for SSLSupportMethod if you specified true for CloudFrontDefaultCertificate.
 	SSLSupportMethod *string `type:"string"`
 
-	metadataViewerCertificate `json:"-", xml:"-"`
+	metadataViewerCertificate `json:"-" xml:"-"`
 }
 
 type metadataViewerCertificate struct {

--- a/service/cloudhsm/api.go
+++ b/service/cloudhsm/api.go
@@ -601,7 +601,7 @@ type CreateHAPGInput struct {
 	// The label of the new high-availability partition group.
 	Label *string `type:"string" required:"true"`
 
-	metadataCreateHAPGInput `json:"-", xml:"-"`
+	metadataCreateHAPGInput `json:"-" xml:"-"`
 }
 
 type metadataCreateHAPGInput struct {
@@ -613,7 +613,7 @@ type CreateHAPGOutput struct {
 	// The ARN of the high-availability partition group.
 	HAPGARN *string `locationName:"HapgArn" type:"string"`
 
-	metadataCreateHAPGOutput `json:"-", xml:"-"`
+	metadataCreateHAPGOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateHAPGOutput struct {
@@ -648,7 +648,7 @@ type CreateHSMInput struct {
 	// The IP address for the syslog monitoring server.
 	SyslogIP *string `locationName:"SyslogIp" type:"string"`
 
-	metadataCreateHSMInput `json:"-", xml:"-"`
+	metadataCreateHSMInput `json:"-" xml:"-"`
 }
 
 type metadataCreateHSMInput struct {
@@ -660,7 +660,7 @@ type CreateHSMOutput struct {
 	// The ARN of the HSM.
 	HSMARN *string `locationName:"HsmArn" type:"string"`
 
-	metadataCreateHSMOutput `json:"-", xml:"-"`
+	metadataCreateHSMOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateHSMOutput struct {
@@ -676,7 +676,7 @@ type CreateLunaClientInput struct {
 	// The label for the client.
 	Label *string `type:"string"`
 
-	metadataCreateLunaClientInput `json:"-", xml:"-"`
+	metadataCreateLunaClientInput `json:"-" xml:"-"`
 }
 
 type metadataCreateLunaClientInput struct {
@@ -688,7 +688,7 @@ type CreateLunaClientOutput struct {
 	// The ARN of the client.
 	ClientARN *string `locationName:"ClientArn" type:"string"`
 
-	metadataCreateLunaClientOutput `json:"-", xml:"-"`
+	metadataCreateLunaClientOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateLunaClientOutput struct {
@@ -700,7 +700,7 @@ type DeleteHAPGInput struct {
 	// The ARN of the high-availability partition group to delete.
 	HAPGARN *string `locationName:"HapgArn" type:"string" required:"true"`
 
-	metadataDeleteHAPGInput `json:"-", xml:"-"`
+	metadataDeleteHAPGInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteHAPGInput struct {
@@ -712,7 +712,7 @@ type DeleteHAPGOutput struct {
 	// The status of the action.
 	Status *string `type:"string" required:"true"`
 
-	metadataDeleteHAPGOutput `json:"-", xml:"-"`
+	metadataDeleteHAPGOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteHAPGOutput struct {
@@ -724,7 +724,7 @@ type DeleteHSMInput struct {
 	// The ARN of the HSM to delete.
 	HSMARN *string `locationName:"HsmArn" type:"string" required:"true"`
 
-	metadataDeleteHSMInput `json:"-", xml:"-"`
+	metadataDeleteHSMInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteHSMInput struct {
@@ -736,7 +736,7 @@ type DeleteHSMOutput struct {
 	// The status of the action.
 	Status *string `type:"string" required:"true"`
 
-	metadataDeleteHSMOutput `json:"-", xml:"-"`
+	metadataDeleteHSMOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteHSMOutput struct {
@@ -747,7 +747,7 @@ type DeleteLunaClientInput struct {
 	// The ARN of the client to delete.
 	ClientARN *string `locationName:"ClientArn" type:"string" required:"true"`
 
-	metadataDeleteLunaClientInput `json:"-", xml:"-"`
+	metadataDeleteLunaClientInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteLunaClientInput struct {
@@ -758,7 +758,7 @@ type DeleteLunaClientOutput struct {
 	// The status of the action.
 	Status *string `type:"string" required:"true"`
 
-	metadataDeleteLunaClientOutput `json:"-", xml:"-"`
+	metadataDeleteLunaClientOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteLunaClientOutput struct {
@@ -770,7 +770,7 @@ type DescribeHAPGInput struct {
 	// The ARN of the high-availability partition group to describe.
 	HAPGARN *string `locationName:"HapgArn" type:"string" required:"true"`
 
-	metadataDescribeHAPGInput `json:"-", xml:"-"`
+	metadataDescribeHAPGInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeHAPGInput struct {
@@ -807,7 +807,7 @@ type DescribeHAPGOutput struct {
 	// The state of the high-availability partition group.
 	State *string `type:"string"`
 
-	metadataDescribeHAPGOutput `json:"-", xml:"-"`
+	metadataDescribeHAPGOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeHAPGOutput struct {
@@ -824,7 +824,7 @@ type DescribeHSMInput struct {
 	// must be specified.
 	HSMSerialNumber *string `locationName:"HsmSerialNumber" type:"string"`
 
-	metadataDescribeHSMInput `json:"-", xml:"-"`
+	metadataDescribeHSMInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeHSMInput struct {
@@ -896,7 +896,7 @@ type DescribeHSMOutput struct {
 	// The name of the HSM vendor.
 	VendorName *string `type:"string"`
 
-	metadataDescribeHSMOutput `json:"-", xml:"-"`
+	metadataDescribeHSMOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeHSMOutput struct {
@@ -910,7 +910,7 @@ type DescribeLunaClientInput struct {
 	// The ARN of the client.
 	ClientARN *string `locationName:"ClientArn" type:"string"`
 
-	metadataDescribeLunaClientInput `json:"-", xml:"-"`
+	metadataDescribeLunaClientInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeLunaClientInput struct {
@@ -933,7 +933,7 @@ type DescribeLunaClientOutput struct {
 	// The date and time the client was last modified.
 	LastModifiedTimestamp *string `type:"string"`
 
-	metadataDescribeLunaClientOutput `json:"-", xml:"-"`
+	metadataDescribeLunaClientOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeLunaClientOutput struct {
@@ -951,7 +951,7 @@ type GetConfigInput struct {
 	// are associated with the client.
 	HAPGList []*string `locationName:"HapgList" type:"list" required:"true"`
 
-	metadataGetConfigInput `json:"-", xml:"-"`
+	metadataGetConfigInput `json:"-" xml:"-"`
 }
 
 type metadataGetConfigInput struct {
@@ -968,7 +968,7 @@ type GetConfigOutput struct {
 	// The type of credentials.
 	ConfigType *string `type:"string"`
 
-	metadataGetConfigOutput `json:"-", xml:"-"`
+	metadataGetConfigOutput `json:"-" xml:"-"`
 }
 
 type metadataGetConfigOutput struct {
@@ -977,7 +977,7 @@ type metadataGetConfigOutput struct {
 
 // Contains the inputs for the ListAvailableZones action.
 type ListAvailableZonesInput struct {
-	metadataListAvailableZonesInput `json:"-", xml:"-"`
+	metadataListAvailableZonesInput `json:"-" xml:"-"`
 }
 
 type metadataListAvailableZonesInput struct {
@@ -988,7 +988,7 @@ type ListAvailableZonesOutput struct {
 	// The list of Availability Zones that have available AWS CloudHSM capacity.
 	AZList []*string `type:"list"`
 
-	metadataListAvailableZonesOutput `json:"-", xml:"-"`
+	metadataListAvailableZonesOutput `json:"-" xml:"-"`
 }
 
 type metadataListAvailableZonesOutput struct {
@@ -1000,7 +1000,7 @@ type ListHSMsInput struct {
 	// the first call.
 	NextToken *string `type:"string"`
 
-	metadataListHSMsInput `json:"-", xml:"-"`
+	metadataListHSMsInput `json:"-" xml:"-"`
 }
 
 type metadataListHSMsInput struct {
@@ -1016,7 +1016,7 @@ type ListHSMsOutput struct {
 	// the next set of items.
 	NextToken *string `type:"string"`
 
-	metadataListHSMsOutput `json:"-", xml:"-"`
+	metadataListHSMsOutput `json:"-" xml:"-"`
 }
 
 type metadataListHSMsOutput struct {
@@ -1028,7 +1028,7 @@ type ListHapgsInput struct {
 	// is the first call.
 	NextToken *string `type:"string"`
 
-	metadataListHapgsInput `json:"-", xml:"-"`
+	metadataListHapgsInput `json:"-" xml:"-"`
 }
 
 type metadataListHapgsInput struct {
@@ -1043,7 +1043,7 @@ type ListHapgsOutput struct {
 	// retrieve the next set of items.
 	NextToken *string `type:"string"`
 
-	metadataListHapgsOutput `json:"-", xml:"-"`
+	metadataListHapgsOutput `json:"-" xml:"-"`
 }
 
 type metadataListHapgsOutput struct {
@@ -1055,7 +1055,7 @@ type ListLunaClientsInput struct {
 	// this is the first call.
 	NextToken *string `type:"string"`
 
-	metadataListLunaClientsInput `json:"-", xml:"-"`
+	metadataListLunaClientsInput `json:"-" xml:"-"`
 }
 
 type metadataListLunaClientsInput struct {
@@ -1070,7 +1070,7 @@ type ListLunaClientsOutput struct {
 	// retrieve the next set of items.
 	NextToken *string `type:"string"`
 
-	metadataListLunaClientsOutput `json:"-", xml:"-"`
+	metadataListLunaClientsOutput `json:"-" xml:"-"`
 }
 
 type metadataListLunaClientsOutput struct {
@@ -1088,7 +1088,7 @@ type ModifyHAPGInput struct {
 	// partition group.
 	PartitionSerialList []*string `type:"list"`
 
-	metadataModifyHAPGInput `json:"-", xml:"-"`
+	metadataModifyHAPGInput `json:"-" xml:"-"`
 }
 
 type metadataModifyHAPGInput struct {
@@ -1099,7 +1099,7 @@ type ModifyHAPGOutput struct {
 	// The ARN of the high-availability partition group.
 	HAPGARN *string `locationName:"HapgArn" type:"string"`
 
-	metadataModifyHAPGOutput `json:"-", xml:"-"`
+	metadataModifyHAPGOutput `json:"-" xml:"-"`
 }
 
 type metadataModifyHAPGOutput struct {
@@ -1126,7 +1126,7 @@ type ModifyHSMInput struct {
 	// The new IP address for the syslog monitoring server.
 	SyslogIP *string `locationName:"SyslogIp" type:"string"`
 
-	metadataModifyHSMInput `json:"-", xml:"-"`
+	metadataModifyHSMInput `json:"-" xml:"-"`
 }
 
 type metadataModifyHSMInput struct {
@@ -1138,7 +1138,7 @@ type ModifyHSMOutput struct {
 	// The ARN of the HSM.
 	HSMARN *string `locationName:"HsmArn" type:"string"`
 
-	metadataModifyHSMOutput `json:"-", xml:"-"`
+	metadataModifyHSMOutput `json:"-" xml:"-"`
 }
 
 type metadataModifyHSMOutput struct {
@@ -1152,7 +1152,7 @@ type ModifyLunaClientInput struct {
 	// The ARN of the client.
 	ClientARN *string `locationName:"ClientArn" type:"string" required:"true"`
 
-	metadataModifyLunaClientInput `json:"-", xml:"-"`
+	metadataModifyLunaClientInput `json:"-" xml:"-"`
 }
 
 type metadataModifyLunaClientInput struct {
@@ -1163,7 +1163,7 @@ type ModifyLunaClientOutput struct {
 	// The ARN of the client.
 	ClientARN *string `locationName:"ClientArn" type:"string"`
 
-	metadataModifyLunaClientOutput `json:"-", xml:"-"`
+	metadataModifyLunaClientOutput `json:"-" xml:"-"`
 }
 
 type metadataModifyLunaClientOutput struct {

--- a/service/cloudsearch/api.go
+++ b/service/cloudsearch/api.go
@@ -905,7 +905,7 @@ type AccessPoliciesStatus struct {
 	// The status of domain configuration option.
 	Status *OptionStatus `type:"structure" required:"true"`
 
-	metadataAccessPoliciesStatus `json:"-", xml:"-"`
+	metadataAccessPoliciesStatus `json:"-" xml:"-"`
 }
 
 type metadataAccessPoliciesStatus struct {
@@ -951,7 +951,7 @@ type AnalysisOptions struct {
 	// in the Amazon CloudSearch Developer Guide.
 	Synonyms *string `type:"string"`
 
-	metadataAnalysisOptions `json:"-", xml:"-"`
+	metadataAnalysisOptions `json:"-" xml:"-"`
 }
 
 type metadataAnalysisOptions struct {
@@ -975,7 +975,7 @@ type AnalysisScheme struct {
 	// a-z (lowercase), 0-9, and _ (underscore).
 	AnalysisSchemeName *string `type:"string" required:"true"`
 
-	metadataAnalysisScheme `json:"-", xml:"-"`
+	metadataAnalysisScheme `json:"-" xml:"-"`
 }
 
 type metadataAnalysisScheme struct {
@@ -993,7 +993,7 @@ type AnalysisSchemeStatus struct {
 	// The status of domain configuration option.
 	Status *OptionStatus `type:"structure" required:"true"`
 
-	metadataAnalysisSchemeStatus `json:"-", xml:"-"`
+	metadataAnalysisSchemeStatus `json:"-" xml:"-"`
 }
 
 type metadataAnalysisSchemeStatus struct {
@@ -1008,7 +1008,7 @@ type AvailabilityOptionsStatus struct {
 	// The status of domain configuration option.
 	Status *OptionStatus `type:"structure" required:"true"`
 
-	metadataAvailabilityOptionsStatus `json:"-", xml:"-"`
+	metadataAvailabilityOptionsStatus `json:"-" xml:"-"`
 }
 
 type metadataAvailabilityOptionsStatus struct {
@@ -1024,7 +1024,7 @@ type BuildSuggestersInput struct {
 	// 0-9, and - (hyphen).
 	DomainName *string `type:"string" required:"true"`
 
-	metadataBuildSuggestersInput `json:"-", xml:"-"`
+	metadataBuildSuggestersInput `json:"-" xml:"-"`
 }
 
 type metadataBuildSuggestersInput struct {
@@ -1037,7 +1037,7 @@ type BuildSuggestersOutput struct {
 	// A list of field names.
 	FieldNames []*string `type:"list"`
 
-	metadataBuildSuggestersOutput `json:"-", xml:"-"`
+	metadataBuildSuggestersOutput `json:"-" xml:"-"`
 }
 
 type metadataBuildSuggestersOutput struct {
@@ -1052,7 +1052,7 @@ type CreateDomainInput struct {
 	// and be at least 3 and no more than 28 characters long.
 	DomainName *string `type:"string" required:"true"`
 
-	metadataCreateDomainInput `json:"-", xml:"-"`
+	metadataCreateDomainInput `json:"-" xml:"-"`
 }
 
 type metadataCreateDomainInput struct {
@@ -1065,7 +1065,7 @@ type CreateDomainOutput struct {
 	// The current status of the search domain.
 	DomainStatus *DomainStatus `type:"structure"`
 
-	metadataCreateDomainOutput `json:"-", xml:"-"`
+	metadataCreateDomainOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateDomainOutput struct {
@@ -1090,7 +1090,7 @@ type DateArrayOptions struct {
 	// A list of source fields to map to the field.
 	SourceFields *string `type:"string"`
 
-	metadataDateArrayOptions `json:"-", xml:"-"`
+	metadataDateArrayOptions `json:"-" xml:"-"`
 }
 
 type metadataDateArrayOptions struct {
@@ -1133,7 +1133,7 @@ type DateOptions struct {
 	// a document's ID, you can use the name _id.
 	SourceField *string `type:"string"`
 
-	metadataDateOptions `json:"-", xml:"-"`
+	metadataDateOptions `json:"-" xml:"-"`
 }
 
 type metadataDateOptions struct {
@@ -1155,7 +1155,7 @@ type DefineAnalysisSchemeInput struct {
 	// 0-9, and - (hyphen).
 	DomainName *string `type:"string" required:"true"`
 
-	metadataDefineAnalysisSchemeInput `json:"-", xml:"-"`
+	metadataDefineAnalysisSchemeInput `json:"-" xml:"-"`
 }
 
 type metadataDefineAnalysisSchemeInput struct {
@@ -1168,7 +1168,7 @@ type DefineAnalysisSchemeOutput struct {
 	// The status and configuration of an AnalysisScheme.
 	AnalysisScheme *AnalysisSchemeStatus `type:"structure" required:"true"`
 
-	metadataDefineAnalysisSchemeOutput `json:"-", xml:"-"`
+	metadataDefineAnalysisSchemeOutput `json:"-" xml:"-"`
 }
 
 type metadataDefineAnalysisSchemeOutput struct {
@@ -1190,7 +1190,7 @@ type DefineExpressionInput struct {
 	// in the search results.
 	Expression *Expression `type:"structure" required:"true"`
 
-	metadataDefineExpressionInput `json:"-", xml:"-"`
+	metadataDefineExpressionInput `json:"-" xml:"-"`
 }
 
 type metadataDefineExpressionInput struct {
@@ -1203,7 +1203,7 @@ type DefineExpressionOutput struct {
 	// The value of an Expression and its current status.
 	Expression *ExpressionStatus `type:"structure" required:"true"`
 
-	metadataDefineExpressionOutput `json:"-", xml:"-"`
+	metadataDefineExpressionOutput `json:"-" xml:"-"`
 }
 
 type metadataDefineExpressionOutput struct {
@@ -1222,7 +1222,7 @@ type DefineIndexFieldInput struct {
 	// The index field and field options you want to configure.
 	IndexField *IndexField `type:"structure" required:"true"`
 
-	metadataDefineIndexFieldInput `json:"-", xml:"-"`
+	metadataDefineIndexFieldInput `json:"-" xml:"-"`
 }
 
 type metadataDefineIndexFieldInput struct {
@@ -1235,7 +1235,7 @@ type DefineIndexFieldOutput struct {
 	// The value of an IndexField and its current status.
 	IndexField *IndexFieldStatus `type:"structure" required:"true"`
 
-	metadataDefineIndexFieldOutput `json:"-", xml:"-"`
+	metadataDefineIndexFieldOutput `json:"-" xml:"-"`
 }
 
 type metadataDefineIndexFieldOutput struct {
@@ -1256,7 +1256,7 @@ type DefineSuggesterInput struct {
 	// options can be configured for a suggester: FuzzyMatching, SortExpression.
 	Suggester *Suggester `type:"structure" required:"true"`
 
-	metadataDefineSuggesterInput `json:"-", xml:"-"`
+	metadataDefineSuggesterInput `json:"-" xml:"-"`
 }
 
 type metadataDefineSuggesterInput struct {
@@ -1269,7 +1269,7 @@ type DefineSuggesterOutput struct {
 	// The value of a Suggester and its current status.
 	Suggester *SuggesterStatus `type:"structure" required:"true"`
 
-	metadataDefineSuggesterOutput `json:"-", xml:"-"`
+	metadataDefineSuggesterOutput `json:"-" xml:"-"`
 }
 
 type metadataDefineSuggesterOutput struct {
@@ -1289,7 +1289,7 @@ type DeleteAnalysisSchemeInput struct {
 	// 0-9, and - (hyphen).
 	DomainName *string `type:"string" required:"true"`
 
-	metadataDeleteAnalysisSchemeInput `json:"-", xml:"-"`
+	metadataDeleteAnalysisSchemeInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteAnalysisSchemeInput struct {
@@ -1302,7 +1302,7 @@ type DeleteAnalysisSchemeOutput struct {
 	// The status of the analysis scheme being deleted.
 	AnalysisScheme *AnalysisSchemeStatus `type:"structure" required:"true"`
 
-	metadataDeleteAnalysisSchemeOutput `json:"-", xml:"-"`
+	metadataDeleteAnalysisSchemeOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteAnalysisSchemeOutput struct {
@@ -1315,7 +1315,7 @@ type DeleteDomainInput struct {
 	// The name of the domain you want to permanently delete.
 	DomainName *string `type:"string" required:"true"`
 
-	metadataDeleteDomainInput `json:"-", xml:"-"`
+	metadataDeleteDomainInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteDomainInput struct {
@@ -1328,7 +1328,7 @@ type DeleteDomainOutput struct {
 	// The current status of the search domain.
 	DomainStatus *DomainStatus `type:"structure"`
 
-	metadataDeleteDomainOutput `json:"-", xml:"-"`
+	metadataDeleteDomainOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteDomainOutput struct {
@@ -1348,7 +1348,7 @@ type DeleteExpressionInput struct {
 	// The name of the Expression to delete.
 	ExpressionName *string `type:"string" required:"true"`
 
-	metadataDeleteExpressionInput `json:"-", xml:"-"`
+	metadataDeleteExpressionInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteExpressionInput struct {
@@ -1361,7 +1361,7 @@ type DeleteExpressionOutput struct {
 	// The status of the expression being deleted.
 	Expression *ExpressionStatus `type:"structure" required:"true"`
 
-	metadataDeleteExpressionOutput `json:"-", xml:"-"`
+	metadataDeleteExpressionOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteExpressionOutput struct {
@@ -1382,7 +1382,7 @@ type DeleteIndexFieldInput struct {
 	// options.
 	IndexFieldName *string `type:"string" required:"true"`
 
-	metadataDeleteIndexFieldInput `json:"-", xml:"-"`
+	metadataDeleteIndexFieldInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteIndexFieldInput struct {
@@ -1394,7 +1394,7 @@ type DeleteIndexFieldOutput struct {
 	// The status of the index field being deleted.
 	IndexField *IndexFieldStatus `type:"structure" required:"true"`
 
-	metadataDeleteIndexFieldOutput `json:"-", xml:"-"`
+	metadataDeleteIndexFieldOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteIndexFieldOutput struct {
@@ -1414,7 +1414,7 @@ type DeleteSuggesterInput struct {
 	// Specifies the name of the suggester you want to delete.
 	SuggesterName *string `type:"string" required:"true"`
 
-	metadataDeleteSuggesterInput `json:"-", xml:"-"`
+	metadataDeleteSuggesterInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteSuggesterInput struct {
@@ -1427,7 +1427,7 @@ type DeleteSuggesterOutput struct {
 	// The status of the suggester being deleted.
 	Suggester *SuggesterStatus `type:"structure" required:"true"`
 
-	metadataDeleteSuggesterOutput `json:"-", xml:"-"`
+	metadataDeleteSuggesterOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteSuggesterOutput struct {
@@ -1450,7 +1450,7 @@ type DescribeAnalysisSchemesInput struct {
 	// The name of the domain you want to describe.
 	DomainName *string `type:"string" required:"true"`
 
-	metadataDescribeAnalysisSchemesInput `json:"-", xml:"-"`
+	metadataDescribeAnalysisSchemesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeAnalysisSchemesInput struct {
@@ -1463,7 +1463,7 @@ type DescribeAnalysisSchemesOutput struct {
 	// The analysis scheme descriptions.
 	AnalysisSchemes []*AnalysisSchemeStatus `type:"list" required:"true"`
 
-	metadataDescribeAnalysisSchemesOutput `json:"-", xml:"-"`
+	metadataDescribeAnalysisSchemesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeAnalysisSchemesOutput struct {
@@ -1482,7 +1482,7 @@ type DescribeAvailabilityOptionsInput struct {
 	// The name of the domain you want to describe.
 	DomainName *string `type:"string" required:"true"`
 
-	metadataDescribeAvailabilityOptionsInput `json:"-", xml:"-"`
+	metadataDescribeAvailabilityOptionsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeAvailabilityOptionsInput struct {
@@ -1496,7 +1496,7 @@ type DescribeAvailabilityOptionsOutput struct {
 	// is enabled for the domain.
 	AvailabilityOptions *AvailabilityOptionsStatus `type:"structure"`
 
-	metadataDescribeAvailabilityOptionsOutput `json:"-", xml:"-"`
+	metadataDescribeAvailabilityOptionsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeAvailabilityOptionsOutput struct {
@@ -1510,7 +1510,7 @@ type DescribeDomainsInput struct {
 	// The names of the domains you want to include in the response.
 	DomainNames []*string `type:"list"`
 
-	metadataDescribeDomainsInput `json:"-", xml:"-"`
+	metadataDescribeDomainsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeDomainsInput struct {
@@ -1523,7 +1523,7 @@ type DescribeDomainsOutput struct {
 	// A list that contains the status of each requested domain.
 	DomainStatusList []*DomainStatus `type:"list" required:"true"`
 
-	metadataDescribeDomainsOutput `json:"-", xml:"-"`
+	metadataDescribeDomainsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeDomainsOutput struct {
@@ -1547,7 +1547,7 @@ type DescribeExpressionsInput struct {
 	// not specified, all expressions are shown.
 	ExpressionNames []*string `type:"list"`
 
-	metadataDescribeExpressionsInput `json:"-", xml:"-"`
+	metadataDescribeExpressionsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeExpressionsInput struct {
@@ -1560,7 +1560,7 @@ type DescribeExpressionsOutput struct {
 	// The expressions configured for the domain.
 	Expressions []*ExpressionStatus `type:"list" required:"true"`
 
-	metadataDescribeExpressionsOutput `json:"-", xml:"-"`
+	metadataDescribeExpressionsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeExpressionsOutput struct {
@@ -1584,7 +1584,7 @@ type DescribeIndexFieldsInput struct {
 	// is returned for all configured index fields.
 	FieldNames []*string `type:"list"`
 
-	metadataDescribeIndexFieldsInput `json:"-", xml:"-"`
+	metadataDescribeIndexFieldsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeIndexFieldsInput struct {
@@ -1597,7 +1597,7 @@ type DescribeIndexFieldsOutput struct {
 	// The index fields configured for the domain.
 	IndexFields []*IndexFieldStatus `type:"list" required:"true"`
 
-	metadataDescribeIndexFieldsOutput `json:"-", xml:"-"`
+	metadataDescribeIndexFieldsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeIndexFieldsOutput struct {
@@ -1613,7 +1613,7 @@ type DescribeScalingParametersInput struct {
 	// 0-9, and - (hyphen).
 	DomainName *string `type:"string" required:"true"`
 
-	metadataDescribeScalingParametersInput `json:"-", xml:"-"`
+	metadataDescribeScalingParametersInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeScalingParametersInput struct {
@@ -1626,7 +1626,7 @@ type DescribeScalingParametersOutput struct {
 	// The status and configuration of a search domain's scaling parameters.
 	ScalingParameters *ScalingParametersStatus `type:"structure" required:"true"`
 
-	metadataDescribeScalingParametersOutput `json:"-", xml:"-"`
+	metadataDescribeScalingParametersOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeScalingParametersOutput struct {
@@ -1645,7 +1645,7 @@ type DescribeServiceAccessPoliciesInput struct {
 	// The name of the domain you want to describe.
 	DomainName *string `type:"string" required:"true"`
 
-	metadataDescribeServiceAccessPoliciesInput `json:"-", xml:"-"`
+	metadataDescribeServiceAccessPoliciesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeServiceAccessPoliciesInput struct {
@@ -1657,7 +1657,7 @@ type DescribeServiceAccessPoliciesOutput struct {
 	// The access rules configured for the domain specified in the request.
 	AccessPolicies *AccessPoliciesStatus `type:"structure" required:"true"`
 
-	metadataDescribeServiceAccessPoliciesOutput `json:"-", xml:"-"`
+	metadataDescribeServiceAccessPoliciesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeServiceAccessPoliciesOutput struct {
@@ -1680,7 +1680,7 @@ type DescribeSuggestersInput struct {
 	// The suggesters you want to describe.
 	SuggesterNames []*string `type:"list"`
 
-	metadataDescribeSuggestersInput `json:"-", xml:"-"`
+	metadataDescribeSuggestersInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeSuggestersInput struct {
@@ -1692,7 +1692,7 @@ type DescribeSuggestersOutput struct {
 	// The suggesters configured for the domain specified in the request.
 	Suggesters []*SuggesterStatus `type:"list" required:"true"`
 
-	metadataDescribeSuggestersOutput `json:"-", xml:"-"`
+	metadataDescribeSuggestersOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeSuggestersOutput struct {
@@ -1720,7 +1720,7 @@ type DocumentSuggesterOptions struct {
 	// The name of the index field you want to use for suggestions.
 	SourceField *string `type:"string" required:"true"`
 
-	metadataDocumentSuggesterOptions `json:"-", xml:"-"`
+	metadataDocumentSuggesterOptions `json:"-" xml:"-"`
 }
 
 type metadataDocumentSuggesterOptions struct {
@@ -1779,7 +1779,7 @@ type DomainStatus struct {
 	// The service endpoint for requesting search results from a search domain.
 	SearchService *ServiceEndpoint `type:"structure"`
 
-	metadataDomainStatus `json:"-", xml:"-"`
+	metadataDomainStatus `json:"-" xml:"-"`
 }
 
 type metadataDomainStatus struct {
@@ -1805,7 +1805,7 @@ type DoubleArrayOptions struct {
 	// A list of source fields to map to the field.
 	SourceFields *string `type:"string"`
 
-	metadataDoubleArrayOptions `json:"-", xml:"-"`
+	metadataDoubleArrayOptions `json:"-" xml:"-"`
 }
 
 type metadataDoubleArrayOptions struct {
@@ -1835,7 +1835,7 @@ type DoubleOptions struct {
 	// The name of the source field to map to the field.
 	SourceField *string `type:"string"`
 
-	metadataDoubleOptions `json:"-", xml:"-"`
+	metadataDoubleOptions `json:"-" xml:"-"`
 }
 
 type metadataDoubleOptions struct {
@@ -1856,7 +1856,7 @@ type Expression struct {
 	// target="_blank) in the Amazon CloudSearch Developer Guide.
 	ExpressionValue *string `type:"string" required:"true"`
 
-	metadataExpression `json:"-", xml:"-"`
+	metadataExpression `json:"-" xml:"-"`
 }
 
 type metadataExpression struct {
@@ -1871,7 +1871,7 @@ type ExpressionStatus struct {
 	// The status of domain configuration option.
 	Status *OptionStatus `type:"structure" required:"true"`
 
-	metadataExpressionStatus `json:"-", xml:"-"`
+	metadataExpressionStatus `json:"-" xml:"-"`
 }
 
 type metadataExpressionStatus struct {
@@ -1887,7 +1887,7 @@ type IndexDocumentsInput struct {
 	// 0-9, and - (hyphen).
 	DomainName *string `type:"string" required:"true"`
 
-	metadataIndexDocumentsInput `json:"-", xml:"-"`
+	metadataIndexDocumentsInput `json:"-" xml:"-"`
 }
 
 type metadataIndexDocumentsInput struct {
@@ -1900,7 +1900,7 @@ type IndexDocumentsOutput struct {
 	// The names of the fields that are currently being indexed.
 	FieldNames []*string `type:"list"`
 
-	metadataIndexDocumentsOutput `json:"-", xml:"-"`
+	metadataIndexDocumentsOutput `json:"-" xml:"-"`
 }
 
 type metadataIndexDocumentsOutput struct {
@@ -1984,7 +1984,7 @@ type IndexField struct {
 	// by default.
 	TextOptions *TextOptions `type:"structure"`
 
-	metadataIndexField `json:"-", xml:"-"`
+	metadataIndexField `json:"-" xml:"-"`
 }
 
 type metadataIndexField struct {
@@ -2000,7 +2000,7 @@ type IndexFieldStatus struct {
 	// The status of domain configuration option.
 	Status *OptionStatus `type:"structure" required:"true"`
 
-	metadataIndexFieldStatus `json:"-", xml:"-"`
+	metadataIndexFieldStatus `json:"-" xml:"-"`
 }
 
 type metadataIndexFieldStatus struct {
@@ -2026,7 +2026,7 @@ type IntArrayOptions struct {
 	// A list of source fields to map to the field.
 	SourceFields *string `type:"string"`
 
-	metadataIntArrayOptions `json:"-", xml:"-"`
+	metadataIntArrayOptions `json:"-" xml:"-"`
 }
 
 type metadataIntArrayOptions struct {
@@ -2056,7 +2056,7 @@ type IntOptions struct {
 	// The name of the source field to map to the field.
 	SourceField *string `type:"string"`
 
-	metadataIntOptions `json:"-", xml:"-"`
+	metadataIntOptions `json:"-" xml:"-"`
 }
 
 type metadataIntOptions struct {
@@ -2098,7 +2098,7 @@ type LatLonOptions struct {
 	// a document's ID, you can use the name _id.
 	SourceField *string `type:"string"`
 
-	metadataLatLonOptions `json:"-", xml:"-"`
+	metadataLatLonOptions `json:"-" xml:"-"`
 }
 
 type metadataLatLonOptions struct {
@@ -2110,7 +2110,7 @@ type Limits struct {
 
 	MaximumReplicationCount *int64 `type:"integer" required:"true"`
 
-	metadataLimits `json:"-", xml:"-"`
+	metadataLimits `json:"-" xml:"-"`
 }
 
 type metadataLimits struct {
@@ -2118,7 +2118,7 @@ type metadataLimits struct {
 }
 
 type ListDomainNamesInput struct {
-	metadataListDomainNamesInput `json:"-", xml:"-"`
+	metadataListDomainNamesInput `json:"-" xml:"-"`
 }
 
 type metadataListDomainNamesInput struct {
@@ -2131,7 +2131,7 @@ type ListDomainNamesOutput struct {
 	// The names of the search domains owned by an account.
 	DomainNames *map[string]*string `type:"map"`
 
-	metadataListDomainNamesOutput `json:"-", xml:"-"`
+	metadataListDomainNamesOutput `json:"-" xml:"-"`
 }
 
 type metadataListDomainNamesOutput struct {
@@ -2157,7 +2157,7 @@ type LiteralArrayOptions struct {
 	// A list of source fields to map to the field.
 	SourceFields *string `type:"string"`
 
-	metadataLiteralArrayOptions `json:"-", xml:"-"`
+	metadataLiteralArrayOptions `json:"-" xml:"-"`
 }
 
 type metadataLiteralArrayOptions struct {
@@ -2198,7 +2198,7 @@ type LiteralOptions struct {
 	// a document's ID, you can use the name _id.
 	SourceField *string `type:"string"`
 
-	metadataLiteralOptions `json:"-", xml:"-"`
+	metadataLiteralOptions `json:"-" xml:"-"`
 }
 
 type metadataLiteralOptions struct {
@@ -2230,7 +2230,7 @@ type OptionStatus struct {
 	// A unique integer that indicates when this option was last updated.
 	UpdateVersion *int64 `type:"integer"`
 
-	metadataOptionStatus `json:"-", xml:"-"`
+	metadataOptionStatus `json:"-" xml:"-"`
 }
 
 type metadataOptionStatus struct {
@@ -2250,7 +2250,7 @@ type ScalingParameters struct {
 	// The number of replicas you want to preconfigure for each index partition.
 	DesiredReplicationCount *int64 `type:"integer"`
 
-	metadataScalingParameters `json:"-", xml:"-"`
+	metadataScalingParameters `json:"-" xml:"-"`
 }
 
 type metadataScalingParameters struct {
@@ -2265,7 +2265,7 @@ type ScalingParametersStatus struct {
 	// The status of domain configuration option.
 	Status *OptionStatus `type:"structure" required:"true"`
 
-	metadataScalingParametersStatus `json:"-", xml:"-"`
+	metadataScalingParametersStatus `json:"-" xml:"-"`
 }
 
 type metadataScalingParametersStatus struct {
@@ -2278,7 +2278,7 @@ type ServiceEndpoint struct {
 	// or doc-imdb-movies-oopcnjfn6ugofer3zx5iadxxca.eu-west-1.cloudsearch.amazonaws.com.
 	Endpoint *string `type:"string"`
 
-	metadataServiceEndpoint `json:"-", xml:"-"`
+	metadataServiceEndpoint `json:"-" xml:"-"`
 }
 
 type metadataServiceEndpoint struct {
@@ -2296,7 +2296,7 @@ type Suggester struct {
 	// a-z (lowercase), 0-9, and _ (underscore).
 	SuggesterName *string `type:"string" required:"true"`
 
-	metadataSuggester `json:"-", xml:"-"`
+	metadataSuggester `json:"-" xml:"-"`
 }
 
 type metadataSuggester struct {
@@ -2313,7 +2313,7 @@ type SuggesterStatus struct {
 	// The status of domain configuration option.
 	Status *OptionStatus `type:"structure" required:"true"`
 
-	metadataSuggesterStatus `json:"-", xml:"-"`
+	metadataSuggesterStatus `json:"-" xml:"-"`
 }
 
 type metadataSuggesterStatus struct {
@@ -2339,7 +2339,7 @@ type TextArrayOptions struct {
 	// A list of source fields to map to the field.
 	SourceFields *string `type:"string"`
 
-	metadataTextArrayOptions `json:"-", xml:"-"`
+	metadataTextArrayOptions `json:"-" xml:"-"`
 }
 
 type metadataTextArrayOptions struct {
@@ -2381,7 +2381,7 @@ type TextOptions struct {
 	// a document's ID, you can use the name _id.
 	SourceField *string `type:"string"`
 
-	metadataTextOptions `json:"-", xml:"-"`
+	metadataTextOptions `json:"-" xml:"-"`
 }
 
 type metadataTextOptions struct {
@@ -2404,7 +2404,7 @@ type UpdateAvailabilityOptionsInput struct {
 	// option to false.
 	MultiAZ *bool `type:"boolean" required:"true"`
 
-	metadataUpdateAvailabilityOptionsInput `json:"-", xml:"-"`
+	metadataUpdateAvailabilityOptionsInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateAvailabilityOptionsInput struct {
@@ -2418,7 +2418,7 @@ type UpdateAvailabilityOptionsOutput struct {
 	// enabled for the domain.
 	AvailabilityOptions *AvailabilityOptionsStatus `type:"structure"`
 
-	metadataUpdateAvailabilityOptionsOutput `json:"-", xml:"-"`
+	metadataUpdateAvailabilityOptionsOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateAvailabilityOptionsOutput struct {
@@ -2438,7 +2438,7 @@ type UpdateScalingParametersInput struct {
 	// The desired instance type and desired number of replicas of each index partition.
 	ScalingParameters *ScalingParameters `type:"structure" required:"true"`
 
-	metadataUpdateScalingParametersInput `json:"-", xml:"-"`
+	metadataUpdateScalingParametersInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateScalingParametersInput struct {
@@ -2451,7 +2451,7 @@ type UpdateScalingParametersOutput struct {
 	// The status and configuration of a search domain's scaling parameters.
 	ScalingParameters *ScalingParametersStatus `type:"structure" required:"true"`
 
-	metadataUpdateScalingParametersOutput `json:"-", xml:"-"`
+	metadataUpdateScalingParametersOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateScalingParametersOutput struct {
@@ -2472,7 +2472,7 @@ type UpdateServiceAccessPoliciesInput struct {
 	// 0-9, and - (hyphen).
 	DomainName *string `type:"string" required:"true"`
 
-	metadataUpdateServiceAccessPoliciesInput `json:"-", xml:"-"`
+	metadataUpdateServiceAccessPoliciesInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateServiceAccessPoliciesInput struct {
@@ -2485,7 +2485,7 @@ type UpdateServiceAccessPoliciesOutput struct {
 	// The access rules configured for the domain.
 	AccessPolicies *AccessPoliciesStatus `type:"structure" required:"true"`
 
-	metadataUpdateServiceAccessPoliciesOutput `json:"-", xml:"-"`
+	metadataUpdateServiceAccessPoliciesOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateServiceAccessPoliciesOutput struct {

--- a/service/cloudsearchdomain/api.go
+++ b/service/cloudsearchdomain/api.go
@@ -174,7 +174,7 @@ type Bucket struct {
 	// The facet value being counted.
 	Value *string `locationName:"value" type:"string"`
 
-	metadataBucket `json:"-", xml:"-"`
+	metadataBucket `json:"-" xml:"-"`
 }
 
 type metadataBucket struct {
@@ -186,7 +186,7 @@ type BucketInfo struct {
 	// A list of the calculated facet values and counts.
 	Buckets []*Bucket `locationName:"buckets" type:"list"`
 
-	metadataBucketInfo `json:"-", xml:"-"`
+	metadataBucketInfo `json:"-" xml:"-"`
 }
 
 type metadataBucketInfo struct {
@@ -199,7 +199,7 @@ type DocumentServiceWarning struct {
 	// The description for a warning returned by the document service.
 	Message *string `locationName:"message" type:"string"`
 
-	metadataDocumentServiceWarning `json:"-", xml:"-"`
+	metadataDocumentServiceWarning `json:"-" xml:"-"`
 }
 
 type metadataDocumentServiceWarning struct {
@@ -220,7 +220,7 @@ type Hit struct {
 	// The document ID of a document that matches the search request.
 	ID *string `locationName:"id" type:"string"`
 
-	metadataHit `json:"-", xml:"-"`
+	metadataHit `json:"-" xml:"-"`
 }
 
 type metadataHit struct {
@@ -242,7 +242,7 @@ type Hits struct {
 	// The index of the first matching document.
 	Start *int64 `locationName:"start" type:"long"`
 
-	metadataHits `json:"-", xml:"-"`
+	metadataHits `json:"-" xml:"-"`
 }
 
 type metadataHits struct {
@@ -528,7 +528,7 @@ type SearchInput struct {
 	// in the Amazon CloudSearch Developer Guide.
 	Start *int64 `location:"querystring" locationName:"start" type:"long"`
 
-	metadataSearchInput `json:"-", xml:"-"`
+	metadataSearchInput `json:"-" xml:"-"`
 }
 
 type metadataSearchInput struct {
@@ -547,7 +547,7 @@ type SearchOutput struct {
 	// The status information returned for the search request.
 	Status *SearchStatus `locationName:"status" type:"structure"`
 
-	metadataSearchOutput `json:"-", xml:"-"`
+	metadataSearchOutput `json:"-" xml:"-"`
 }
 
 type metadataSearchOutput struct {
@@ -563,7 +563,7 @@ type SearchStatus struct {
 	// How long it took to process the request, in milliseconds.
 	TimeMS *int64 `locationName:"timems" type:"long"`
 
-	metadataSearchStatus `json:"-", xml:"-"`
+	metadataSearchStatus `json:"-" xml:"-"`
 }
 
 type metadataSearchStatus struct {
@@ -581,7 +581,7 @@ type SuggestInput struct {
 	// Specifies the name of the suggester to use to find suggested matches.
 	Suggester *string `location:"querystring" locationName:"suggester" type:"string" required:"true"`
 
-	metadataSuggestInput `json:"-", xml:"-"`
+	metadataSuggestInput `json:"-" xml:"-"`
 }
 
 type metadataSuggestInput struct {
@@ -599,7 +599,7 @@ type SuggestModel struct {
 	// The documents that match the query string.
 	Suggestions []*SuggestionMatch `locationName:"suggestions" type:"list"`
 
-	metadataSuggestModel `json:"-", xml:"-"`
+	metadataSuggestModel `json:"-" xml:"-"`
 }
 
 type metadataSuggestModel struct {
@@ -615,7 +615,7 @@ type SuggestOutput struct {
 	// Container for the matching search suggestion information.
 	Suggest *SuggestModel `locationName:"suggest" type:"structure"`
 
-	metadataSuggestOutput `json:"-", xml:"-"`
+	metadataSuggestOutput `json:"-" xml:"-"`
 }
 
 type metadataSuggestOutput struct {
@@ -631,7 +631,7 @@ type SuggestStatus struct {
 	// How long it took to process the request, in milliseconds.
 	TimeMS *int64 `locationName:"timems" type:"long"`
 
-	metadataSuggestStatus `json:"-", xml:"-"`
+	metadataSuggestStatus `json:"-" xml:"-"`
 }
 
 type metadataSuggestStatus struct {
@@ -649,7 +649,7 @@ type SuggestionMatch struct {
 	// The string that matches the query string specified in the SuggestRequest.
 	Suggestion *string `locationName:"suggestion" type:"string"`
 
-	metadataSuggestionMatch `json:"-", xml:"-"`
+	metadataSuggestionMatch `json:"-" xml:"-"`
 }
 
 type metadataSuggestionMatch struct {
@@ -667,7 +667,7 @@ type UploadDocumentsInput struct {
 	// A batch of documents formatted in JSON or HTML.
 	Documents io.ReadSeeker `locationName:"documents" type:"blob" required:"true"`
 
-	metadataUploadDocumentsInput `json:"-", xml:"-"`
+	metadataUploadDocumentsInput `json:"-" xml:"-"`
 }
 
 type metadataUploadDocumentsInput struct {
@@ -688,7 +688,7 @@ type UploadDocumentsOutput struct {
 	// Any warnings returned by the document service about the documents being uploaded.
 	Warnings []*DocumentServiceWarning `locationName:"warnings" type:"list"`
 
-	metadataUploadDocumentsOutput `json:"-", xml:"-"`
+	metadataUploadDocumentsOutput `json:"-" xml:"-"`
 }
 
 type metadataUploadDocumentsOutput struct {

--- a/service/cloudtrail/api.go
+++ b/service/cloudtrail/api.go
@@ -333,7 +333,7 @@ type CreateTrailInput struct {
 	// file delivery.
 	SNSTopicName *string `locationName:"SnsTopicName" type:"string"`
 
-	metadataCreateTrailInput `json:"-", xml:"-"`
+	metadataCreateTrailInput `json:"-" xml:"-"`
 }
 
 type metadataCreateTrailInput struct {
@@ -370,7 +370,7 @@ type CreateTrailOutput struct {
 	// file delivery.
 	SNSTopicName *string `locationName:"SnsTopicName" type:"string"`
 
-	metadataCreateTrailOutput `json:"-", xml:"-"`
+	metadataCreateTrailOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateTrailOutput struct {
@@ -382,7 +382,7 @@ type DeleteTrailInput struct {
 	// The name of a trail to be deleted.
 	Name *string `type:"string" required:"true"`
 
-	metadataDeleteTrailInput `json:"-", xml:"-"`
+	metadataDeleteTrailInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteTrailInput struct {
@@ -392,7 +392,7 @@ type metadataDeleteTrailInput struct {
 // Returns the objects or data listed below if successful. Otherwise, returns
 // an error.
 type DeleteTrailOutput struct {
-	metadataDeleteTrailOutput `json:"-", xml:"-"`
+	metadataDeleteTrailOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteTrailOutput struct {
@@ -404,7 +404,7 @@ type DescribeTrailsInput struct {
 	// The trail returned.
 	TrailNameList []*string `locationName:"trailNameList" type:"list"`
 
-	metadataDescribeTrailsInput `json:"-", xml:"-"`
+	metadataDescribeTrailsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeTrailsInput struct {
@@ -417,7 +417,7 @@ type DescribeTrailsOutput struct {
 	// The list of trails.
 	TrailList []*Trail `locationName:"trailList" type:"list"`
 
-	metadataDescribeTrailsOutput `json:"-", xml:"-"`
+	metadataDescribeTrailsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeTrailsOutput struct {
@@ -446,7 +446,7 @@ type Event struct {
 	// returned.
 	Username *string `type:"string"`
 
-	metadataEvent `json:"-", xml:"-"`
+	metadataEvent `json:"-" xml:"-"`
 }
 
 type metadataEvent struct {
@@ -458,7 +458,7 @@ type GetTrailStatusInput struct {
 	// The name of the trail for which you are requesting the current status.
 	Name *string `type:"string" required:"true"`
 
-	metadataGetTrailStatusInput `json:"-", xml:"-"`
+	metadataGetTrailStatusInput `json:"-" xml:"-"`
 }
 
 type metadataGetTrailStatusInput struct {
@@ -506,7 +506,7 @@ type GetTrailStatusOutput struct {
 	// API calls for an AWS account.
 	StopLoggingTime *time.Time `type:"timestamp" timestampFormat:"unix"`
 
-	metadataGetTrailStatusOutput `json:"-", xml:"-"`
+	metadataGetTrailStatusOutput `json:"-" xml:"-"`
 }
 
 type metadataGetTrailStatusOutput struct {
@@ -521,7 +521,7 @@ type LookupAttribute struct {
 	// Specifies a value for the specified AttributeKey.
 	AttributeValue *string `type:"string" required:"true"`
 
-	metadataLookupAttribute `json:"-", xml:"-"`
+	metadataLookupAttribute `json:"-" xml:"-"`
 }
 
 type metadataLookupAttribute struct {
@@ -555,7 +555,7 @@ type LookupEventsInput struct {
 	// error is returned.
 	StartTime *time.Time `type:"timestamp" timestampFormat:"unix"`
 
-	metadataLookupEventsInput `json:"-", xml:"-"`
+	metadataLookupEventsInput `json:"-" xml:"-"`
 }
 
 type metadataLookupEventsInput struct {
@@ -576,7 +576,7 @@ type LookupEventsOutput struct {
 	// of 'root', the call with NextToken should include those same parameters.
 	NextToken *string `type:"string"`
 
-	metadataLookupEventsOutput `json:"-", xml:"-"`
+	metadataLookupEventsOutput `json:"-" xml:"-"`
 }
 
 type metadataLookupEventsOutput struct {
@@ -598,7 +598,7 @@ type Resource struct {
 	// Types Supported for Event Lookup (http://docs.aws.amazon.com/awscloudtrail/latest/userguide/lookup_supported_resourcetypes.html).
 	ResourceType *string `type:"string"`
 
-	metadataResource `json:"-", xml:"-"`
+	metadataResource `json:"-" xml:"-"`
 }
 
 type metadataResource struct {
@@ -610,7 +610,7 @@ type StartLoggingInput struct {
 	// The name of the trail for which CloudTrail logs AWS API calls.
 	Name *string `type:"string" required:"true"`
 
-	metadataStartLoggingInput `json:"-", xml:"-"`
+	metadataStartLoggingInput `json:"-" xml:"-"`
 }
 
 type metadataStartLoggingInput struct {
@@ -620,7 +620,7 @@ type metadataStartLoggingInput struct {
 // Returns the objects or data listed below if successful. Otherwise, returns
 // an error.
 type StartLoggingOutput struct {
-	metadataStartLoggingOutput `json:"-", xml:"-"`
+	metadataStartLoggingOutput `json:"-" xml:"-"`
 }
 
 type metadataStartLoggingOutput struct {
@@ -634,7 +634,7 @@ type StopLoggingInput struct {
 	// AWS API calls.
 	Name *string `type:"string" required:"true"`
 
-	metadataStopLoggingInput `json:"-", xml:"-"`
+	metadataStopLoggingInput `json:"-" xml:"-"`
 }
 
 type metadataStopLoggingInput struct {
@@ -644,7 +644,7 @@ type metadataStopLoggingInput struct {
 // Returns the objects or data listed below if successful. Otherwise, returns
 // an error.
 type StopLoggingOutput struct {
-	metadataStopLoggingOutput `json:"-", xml:"-"`
+	metadataStopLoggingOutput `json:"-" xml:"-"`
 }
 
 type metadataStopLoggingOutput struct {
@@ -678,7 +678,7 @@ type Trail struct {
 	// account owner when new CloudTrail log files have been delivered.
 	SNSTopicName *string `locationName:"SnsTopicName" type:"string"`
 
-	metadataTrail `json:"-", xml:"-"`
+	metadataTrail `json:"-" xml:"-"`
 }
 
 type metadataTrail struct {
@@ -715,7 +715,7 @@ type UpdateTrailInput struct {
 	// file delivery.
 	SNSTopicName *string `locationName:"SnsTopicName" type:"string"`
 
-	metadataUpdateTrailInput `json:"-", xml:"-"`
+	metadataUpdateTrailInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateTrailInput struct {
@@ -752,7 +752,7 @@ type UpdateTrailOutput struct {
 	// file delivery.
 	SNSTopicName *string `locationName:"SnsTopicName" type:"string"`
 
-	metadataUpdateTrailOutput `json:"-", xml:"-"`
+	metadataUpdateTrailOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateTrailOutput struct {

--- a/service/cloudwatch/api.go
+++ b/service/cloudwatch/api.go
@@ -453,7 +453,7 @@ type AlarmHistoryItem struct {
 	// in the Amazon CloudWatch Developer Guide.
 	Timestamp *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataAlarmHistoryItem `json:"-", xml:"-"`
+	metadataAlarmHistoryItem `json:"-" xml:"-"`
 }
 
 type metadataAlarmHistoryItem struct {
@@ -489,7 +489,7 @@ type Datapoint struct {
 	// The standard unit used for the datapoint.
 	Unit *string `type:"string"`
 
-	metadataDatapoint `json:"-", xml:"-"`
+	metadataDatapoint `json:"-" xml:"-"`
 }
 
 type metadataDatapoint struct {
@@ -500,7 +500,7 @@ type DeleteAlarmsInput struct {
 	// A list of alarms to be deleted.
 	AlarmNames []*string `type:"list" required:"true"`
 
-	metadataDeleteAlarmsInput `json:"-", xml:"-"`
+	metadataDeleteAlarmsInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteAlarmsInput struct {
@@ -508,7 +508,7 @@ type metadataDeleteAlarmsInput struct {
 }
 
 type DeleteAlarmsOutput struct {
-	metadataDeleteAlarmsOutput `json:"-", xml:"-"`
+	metadataDeleteAlarmsOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteAlarmsOutput struct {
@@ -535,7 +535,7 @@ type DescribeAlarmHistoryInput struct {
 	// The starting date to retrieve alarm history.
 	StartDate *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataDescribeAlarmHistoryInput `json:"-", xml:"-"`
+	metadataDescribeAlarmHistoryInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeAlarmHistoryInput struct {
@@ -550,7 +550,7 @@ type DescribeAlarmHistoryOutput struct {
 	// A string that marks the start of the next batch of returned results.
 	NextToken *string `type:"string"`
 
-	metadataDescribeAlarmHistoryOutput `json:"-", xml:"-"`
+	metadataDescribeAlarmHistoryOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeAlarmHistoryOutput struct {
@@ -576,7 +576,7 @@ type DescribeAlarmsForMetricInput struct {
 	// The unit for the metric.
 	Unit *string `type:"string"`
 
-	metadataDescribeAlarmsForMetricInput `json:"-", xml:"-"`
+	metadataDescribeAlarmsForMetricInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeAlarmsForMetricInput struct {
@@ -588,7 +588,7 @@ type DescribeAlarmsForMetricOutput struct {
 	// A list of information for each alarm with the specified metric.
 	MetricAlarms []*MetricAlarm `type:"list"`
 
-	metadataDescribeAlarmsForMetricOutput `json:"-", xml:"-"`
+	metadataDescribeAlarmsForMetricOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeAlarmsForMetricOutput struct {
@@ -616,7 +616,7 @@ type DescribeAlarmsInput struct {
 	// The state value to be used in matching alarms.
 	StateValue *string `type:"string"`
 
-	metadataDescribeAlarmsInput `json:"-", xml:"-"`
+	metadataDescribeAlarmsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeAlarmsInput struct {
@@ -631,7 +631,7 @@ type DescribeAlarmsOutput struct {
 	// A string that marks the start of the next batch of returned results.
 	NextToken *string `type:"string"`
 
-	metadataDescribeAlarmsOutput `json:"-", xml:"-"`
+	metadataDescribeAlarmsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeAlarmsOutput struct {
@@ -649,7 +649,7 @@ type Dimension struct {
 	// The value representing the dimension measurement
 	Value *string `type:"string" required:"true"`
 
-	metadataDimension `json:"-", xml:"-"`
+	metadataDimension `json:"-" xml:"-"`
 }
 
 type metadataDimension struct {
@@ -664,7 +664,7 @@ type DimensionFilter struct {
 	// The value of the dimension to be matched.
 	Value *string `type:"string"`
 
-	metadataDimensionFilter `json:"-", xml:"-"`
+	metadataDimensionFilter `json:"-" xml:"-"`
 }
 
 type metadataDimensionFilter struct {
@@ -675,7 +675,7 @@ type DisableAlarmActionsInput struct {
 	// The names of the alarms to disable actions for.
 	AlarmNames []*string `type:"list" required:"true"`
 
-	metadataDisableAlarmActionsInput `json:"-", xml:"-"`
+	metadataDisableAlarmActionsInput `json:"-" xml:"-"`
 }
 
 type metadataDisableAlarmActionsInput struct {
@@ -683,7 +683,7 @@ type metadataDisableAlarmActionsInput struct {
 }
 
 type DisableAlarmActionsOutput struct {
-	metadataDisableAlarmActionsOutput `json:"-", xml:"-"`
+	metadataDisableAlarmActionsOutput `json:"-" xml:"-"`
 }
 
 type metadataDisableAlarmActionsOutput struct {
@@ -694,7 +694,7 @@ type EnableAlarmActionsInput struct {
 	// The names of the alarms to enable actions for.
 	AlarmNames []*string `type:"list" required:"true"`
 
-	metadataEnableAlarmActionsInput `json:"-", xml:"-"`
+	metadataEnableAlarmActionsInput `json:"-" xml:"-"`
 }
 
 type metadataEnableAlarmActionsInput struct {
@@ -702,7 +702,7 @@ type metadataEnableAlarmActionsInput struct {
 }
 
 type EnableAlarmActionsOutput struct {
-	metadataEnableAlarmActionsOutput `json:"-", xml:"-"`
+	metadataEnableAlarmActionsOutput `json:"-" xml:"-"`
 }
 
 type metadataEnableAlarmActionsOutput struct {
@@ -743,7 +743,7 @@ type GetMetricStatisticsInput struct {
 	// The unit for the metric.
 	Unit *string `type:"string"`
 
-	metadataGetMetricStatisticsInput `json:"-", xml:"-"`
+	metadataGetMetricStatisticsInput `json:"-" xml:"-"`
 }
 
 type metadataGetMetricStatisticsInput struct {
@@ -758,7 +758,7 @@ type GetMetricStatisticsOutput struct {
 	// A label describing the specified metric.
 	Label *string `type:"string"`
 
-	metadataGetMetricStatisticsOutput `json:"-", xml:"-"`
+	metadataGetMetricStatisticsOutput `json:"-" xml:"-"`
 }
 
 type metadataGetMetricStatisticsOutput struct {
@@ -779,7 +779,7 @@ type ListMetricsInput struct {
 	// available.
 	NextToken *string `type:"string"`
 
-	metadataListMetricsInput `json:"-", xml:"-"`
+	metadataListMetricsInput `json:"-" xml:"-"`
 }
 
 type metadataListMetricsInput struct {
@@ -794,7 +794,7 @@ type ListMetricsOutput struct {
 	// A string that marks the start of the next batch of returned results.
 	NextToken *string `type:"string"`
 
-	metadataListMetricsOutput `json:"-", xml:"-"`
+	metadataListMetricsOutput `json:"-" xml:"-"`
 }
 
 type metadataListMetricsOutput struct {
@@ -818,7 +818,7 @@ type Metric struct {
 	// The namespace of the metric.
 	Namespace *string `type:"string"`
 
-	metadataMetric `json:"-", xml:"-"`
+	metadataMetric `json:"-" xml:"-"`
 }
 
 type metadataMetric struct {
@@ -912,7 +912,7 @@ type MetricAlarm struct {
 	// The unit of the alarm's associated metric.
 	Unit *string `type:"string"`
 
-	metadataMetricAlarm `json:"-", xml:"-"`
+	metadataMetricAlarm `json:"-" xml:"-"`
 }
 
 type metadataMetricAlarm struct {
@@ -952,7 +952,7 @@ type MetricDatum struct {
 	// exponents less than -130 (1 x 10^-130) are also truncated.
 	Value *float64 `type:"double"`
 
-	metadataMetricDatum `json:"-", xml:"-"`
+	metadataMetricDatum `json:"-" xml:"-"`
 }
 
 type metadataMetricDatum struct {
@@ -1017,7 +1017,7 @@ type PutMetricAlarmInput struct {
 	// The unit for the alarm's associated metric.
 	Unit *string `type:"string"`
 
-	metadataPutMetricAlarmInput `json:"-", xml:"-"`
+	metadataPutMetricAlarmInput `json:"-" xml:"-"`
 }
 
 type metadataPutMetricAlarmInput struct {
@@ -1025,7 +1025,7 @@ type metadataPutMetricAlarmInput struct {
 }
 
 type PutMetricAlarmOutput struct {
-	metadataPutMetricAlarmOutput `json:"-", xml:"-"`
+	metadataPutMetricAlarmOutput `json:"-" xml:"-"`
 }
 
 type metadataPutMetricAlarmOutput struct {
@@ -1039,7 +1039,7 @@ type PutMetricDataInput struct {
 	// The namespace for the metric data.
 	Namespace *string `type:"string" required:"true"`
 
-	metadataPutMetricDataInput `json:"-", xml:"-"`
+	metadataPutMetricDataInput `json:"-" xml:"-"`
 }
 
 type metadataPutMetricDataInput struct {
@@ -1047,7 +1047,7 @@ type metadataPutMetricDataInput struct {
 }
 
 type PutMetricDataOutput struct {
-	metadataPutMetricDataOutput `json:"-", xml:"-"`
+	metadataPutMetricDataOutput `json:"-" xml:"-"`
 }
 
 type metadataPutMetricDataOutput struct {
@@ -1070,7 +1070,7 @@ type SetAlarmStateInput struct {
 	// The value of the state.
 	StateValue *string `type:"string" required:"true"`
 
-	metadataSetAlarmStateInput `json:"-", xml:"-"`
+	metadataSetAlarmStateInput `json:"-" xml:"-"`
 }
 
 type metadataSetAlarmStateInput struct {
@@ -1078,7 +1078,7 @@ type metadataSetAlarmStateInput struct {
 }
 
 type SetAlarmStateOutput struct {
-	metadataSetAlarmStateOutput `json:"-", xml:"-"`
+	metadataSetAlarmStateOutput `json:"-" xml:"-"`
 }
 
 type metadataSetAlarmStateOutput struct {
@@ -1100,7 +1100,7 @@ type StatisticSet struct {
 	// The sum of values for the sample set.
 	Sum *float64 `type:"double" required:"true"`
 
-	metadataStatisticSet `json:"-", xml:"-"`
+	metadataStatisticSet `json:"-" xml:"-"`
 }
 
 type metadataStatisticSet struct {

--- a/service/cloudwatchlogs/api.go
+++ b/service/cloudwatchlogs/api.go
@@ -539,7 +539,7 @@ var opTestMetricFilter *aws.Operation
 type CreateLogGroupInput struct {
 	LogGroupName *string `locationName:"logGroupName" type:"string" required:"true"`
 
-	metadataCreateLogGroupInput `json:"-", xml:"-"`
+	metadataCreateLogGroupInput `json:"-" xml:"-"`
 }
 
 type metadataCreateLogGroupInput struct {
@@ -547,7 +547,7 @@ type metadataCreateLogGroupInput struct {
 }
 
 type CreateLogGroupOutput struct {
-	metadataCreateLogGroupOutput `json:"-", xml:"-"`
+	metadataCreateLogGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateLogGroupOutput struct {
@@ -559,7 +559,7 @@ type CreateLogStreamInput struct {
 
 	LogStreamName *string `locationName:"logStreamName" type:"string" required:"true"`
 
-	metadataCreateLogStreamInput `json:"-", xml:"-"`
+	metadataCreateLogStreamInput `json:"-" xml:"-"`
 }
 
 type metadataCreateLogStreamInput struct {
@@ -567,7 +567,7 @@ type metadataCreateLogStreamInput struct {
 }
 
 type CreateLogStreamOutput struct {
-	metadataCreateLogStreamOutput `json:"-", xml:"-"`
+	metadataCreateLogStreamOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateLogStreamOutput struct {
@@ -577,7 +577,7 @@ type metadataCreateLogStreamOutput struct {
 type DeleteLogGroupInput struct {
 	LogGroupName *string `locationName:"logGroupName" type:"string" required:"true"`
 
-	metadataDeleteLogGroupInput `json:"-", xml:"-"`
+	metadataDeleteLogGroupInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteLogGroupInput struct {
@@ -585,7 +585,7 @@ type metadataDeleteLogGroupInput struct {
 }
 
 type DeleteLogGroupOutput struct {
-	metadataDeleteLogGroupOutput `json:"-", xml:"-"`
+	metadataDeleteLogGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteLogGroupOutput struct {
@@ -597,7 +597,7 @@ type DeleteLogStreamInput struct {
 
 	LogStreamName *string `locationName:"logStreamName" type:"string" required:"true"`
 
-	metadataDeleteLogStreamInput `json:"-", xml:"-"`
+	metadataDeleteLogStreamInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteLogStreamInput struct {
@@ -605,7 +605,7 @@ type metadataDeleteLogStreamInput struct {
 }
 
 type DeleteLogStreamOutput struct {
-	metadataDeleteLogStreamOutput `json:"-", xml:"-"`
+	metadataDeleteLogStreamOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteLogStreamOutput struct {
@@ -618,7 +618,7 @@ type DeleteMetricFilterInput struct {
 
 	LogGroupName *string `locationName:"logGroupName" type:"string" required:"true"`
 
-	metadataDeleteMetricFilterInput `json:"-", xml:"-"`
+	metadataDeleteMetricFilterInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteMetricFilterInput struct {
@@ -626,7 +626,7 @@ type metadataDeleteMetricFilterInput struct {
 }
 
 type DeleteMetricFilterOutput struct {
-	metadataDeleteMetricFilterOutput `json:"-", xml:"-"`
+	metadataDeleteMetricFilterOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteMetricFilterOutput struct {
@@ -636,7 +636,7 @@ type metadataDeleteMetricFilterOutput struct {
 type DeleteRetentionPolicyInput struct {
 	LogGroupName *string `locationName:"logGroupName" type:"string" required:"true"`
 
-	metadataDeleteRetentionPolicyInput `json:"-", xml:"-"`
+	metadataDeleteRetentionPolicyInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteRetentionPolicyInput struct {
@@ -644,7 +644,7 @@ type metadataDeleteRetentionPolicyInput struct {
 }
 
 type DeleteRetentionPolicyOutput struct {
-	metadataDeleteRetentionPolicyOutput `json:"-", xml:"-"`
+	metadataDeleteRetentionPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteRetentionPolicyOutput struct {
@@ -663,7 +663,7 @@ type DescribeLogGroupsInput struct {
 	// request.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataDescribeLogGroupsInput `json:"-", xml:"-"`
+	metadataDescribeLogGroupsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeLogGroupsInput struct {
@@ -679,7 +679,7 @@ type DescribeLogGroupsOutput struct {
 	// token expires after 24 hours.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataDescribeLogGroupsOutput `json:"-", xml:"-"`
+	metadataDescribeLogGroupsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeLogGroupsOutput struct {
@@ -712,7 +712,7 @@ type DescribeLogStreamsInput struct {
 	// also contain a logStreamNamePrefix.
 	OrderBy *string `locationName:"orderBy" type:"string"`
 
-	metadataDescribeLogStreamsInput `json:"-", xml:"-"`
+	metadataDescribeLogStreamsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeLogStreamsInput struct {
@@ -728,7 +728,7 @@ type DescribeLogStreamsOutput struct {
 	// token expires after 24 hours.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataDescribeLogStreamsOutput `json:"-", xml:"-"`
+	metadataDescribeLogStreamsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeLogStreamsOutput struct {
@@ -750,7 +750,7 @@ type DescribeMetricFiltersInput struct {
 	// request.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataDescribeMetricFiltersInput `json:"-", xml:"-"`
+	metadataDescribeMetricFiltersInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeMetricFiltersInput struct {
@@ -765,7 +765,7 @@ type DescribeMetricFiltersOutput struct {
 	// token expires after 24 hours.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataDescribeMetricFiltersOutput `json:"-", xml:"-"`
+	metadataDescribeMetricFiltersOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeMetricFiltersOutput struct {
@@ -799,7 +799,7 @@ type GetLogEventsInput struct {
 	// UTC.
 	StartTime *int64 `locationName:"startTime" type:"long"`
 
-	metadataGetLogEventsInput `json:"-", xml:"-"`
+	metadataGetLogEventsInput `json:"-" xml:"-"`
 }
 
 type metadataGetLogEventsInput struct {
@@ -819,7 +819,7 @@ type GetLogEventsOutput struct {
 	// token expires after 24 hours.
 	NextForwardToken *string `locationName:"nextForwardToken" type:"string"`
 
-	metadataGetLogEventsOutput `json:"-", xml:"-"`
+	metadataGetLogEventsOutput `json:"-" xml:"-"`
 }
 
 type metadataGetLogEventsOutput struct {
@@ -837,7 +837,7 @@ type InputLogEvent struct {
 	// UTC.
 	Timestamp *int64 `locationName:"timestamp" type:"long" required:"true"`
 
-	metadataInputLogEvent `json:"-", xml:"-"`
+	metadataInputLogEvent `json:"-" xml:"-"`
 }
 
 type metadataInputLogEvent struct {
@@ -863,7 +863,7 @@ type LogGroup struct {
 
 	StoredBytes *int64 `locationName:"storedBytes" type:"long"`
 
-	metadataLogGroup `json:"-", xml:"-"`
+	metadataLogGroup `json:"-" xml:"-"`
 }
 
 type metadataLogGroup struct {
@@ -899,7 +899,7 @@ type LogStream struct {
 	// obtained from the response of the previous request.
 	UploadSequenceToken *string `locationName:"uploadSequenceToken" type:"string"`
 
-	metadataLogStream `json:"-", xml:"-"`
+	metadataLogStream `json:"-" xml:"-"`
 }
 
 type metadataLogStream struct {
@@ -925,7 +925,7 @@ type MetricFilter struct {
 
 	MetricTransformations []*MetricTransformation `locationName:"metricTransformations" type:"list"`
 
-	metadataMetricFilter `json:"-", xml:"-"`
+	metadataMetricFilter `json:"-" xml:"-"`
 }
 
 type metadataMetricFilter struct {
@@ -939,7 +939,7 @@ type MetricFilterMatchRecord struct {
 
 	ExtractedValues *map[string]*string `locationName:"extractedValues" type:"map"`
 
-	metadataMetricFilterMatchRecord `json:"-", xml:"-"`
+	metadataMetricFilterMatchRecord `json:"-" xml:"-"`
 }
 
 type metadataMetricFilterMatchRecord struct {
@@ -960,7 +960,7 @@ type MetricTransformation struct {
 	// value in the log event.
 	MetricValue *string `locationName:"metricValue" type:"string" required:"true"`
 
-	metadataMetricTransformation `json:"-", xml:"-"`
+	metadataMetricTransformation `json:"-" xml:"-"`
 }
 
 type metadataMetricTransformation struct {
@@ -978,7 +978,7 @@ type OutputLogEvent struct {
 	// UTC.
 	Timestamp *int64 `locationName:"timestamp" type:"long"`
 
-	metadataOutputLogEvent `json:"-", xml:"-"`
+	metadataOutputLogEvent `json:"-" xml:"-"`
 }
 
 type metadataOutputLogEvent struct {
@@ -997,7 +997,7 @@ type PutLogEventsInput struct {
 	// request.
 	SequenceToken *string `locationName:"sequenceToken" type:"string"`
 
-	metadataPutLogEventsInput `json:"-", xml:"-"`
+	metadataPutLogEventsInput `json:"-" xml:"-"`
 }
 
 type metadataPutLogEventsInput struct {
@@ -1012,7 +1012,7 @@ type PutLogEventsOutput struct {
 
 	RejectedLogEventsInfo *RejectedLogEventsInfo `locationName:"rejectedLogEventsInfo" type:"structure"`
 
-	metadataPutLogEventsOutput `json:"-", xml:"-"`
+	metadataPutLogEventsOutput `json:"-" xml:"-"`
 }
 
 type metadataPutLogEventsOutput struct {
@@ -1033,7 +1033,7 @@ type PutMetricFilterInput struct {
 
 	MetricTransformations []*MetricTransformation `locationName:"metricTransformations" type:"list" required:"true"`
 
-	metadataPutMetricFilterInput `json:"-", xml:"-"`
+	metadataPutMetricFilterInput `json:"-" xml:"-"`
 }
 
 type metadataPutMetricFilterInput struct {
@@ -1041,7 +1041,7 @@ type metadataPutMetricFilterInput struct {
 }
 
 type PutMetricFilterOutput struct {
-	metadataPutMetricFilterOutput `json:"-", xml:"-"`
+	metadataPutMetricFilterOutput `json:"-" xml:"-"`
 }
 
 type metadataPutMetricFilterOutput struct {
@@ -1056,7 +1056,7 @@ type PutRetentionPolicyInput struct {
 	// 365, 400, 545, 731, 1827, 3653.
 	RetentionInDays *int64 `locationName:"retentionInDays" type:"integer" required:"true"`
 
-	metadataPutRetentionPolicyInput `json:"-", xml:"-"`
+	metadataPutRetentionPolicyInput `json:"-" xml:"-"`
 }
 
 type metadataPutRetentionPolicyInput struct {
@@ -1064,7 +1064,7 @@ type metadataPutRetentionPolicyInput struct {
 }
 
 type PutRetentionPolicyOutput struct {
-	metadataPutRetentionPolicyOutput `json:"-", xml:"-"`
+	metadataPutRetentionPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataPutRetentionPolicyOutput struct {
@@ -1078,7 +1078,7 @@ type RejectedLogEventsInfo struct {
 
 	TooOldLogEventEndIndex *int64 `locationName:"tooOldLogEventEndIndex" type:"integer"`
 
-	metadataRejectedLogEventsInfo `json:"-", xml:"-"`
+	metadataRejectedLogEventsInfo `json:"-" xml:"-"`
 }
 
 type metadataRejectedLogEventsInfo struct {
@@ -1094,7 +1094,7 @@ type TestMetricFilterInput struct {
 
 	LogEventMessages []*string `locationName:"logEventMessages" type:"list" required:"true"`
 
-	metadataTestMetricFilterInput `json:"-", xml:"-"`
+	metadataTestMetricFilterInput `json:"-" xml:"-"`
 }
 
 type metadataTestMetricFilterInput struct {
@@ -1104,7 +1104,7 @@ type metadataTestMetricFilterInput struct {
 type TestMetricFilterOutput struct {
 	Matches []*MetricFilterMatchRecord `locationName:"matches" type:"list"`
 
-	metadataTestMetricFilterOutput `json:"-", xml:"-"`
+	metadataTestMetricFilterOutput `json:"-" xml:"-"`
 }
 
 type metadataTestMetricFilterOutput struct {

--- a/service/codedeploy/api.go
+++ b/service/codedeploy/api.go
@@ -857,7 +857,7 @@ type ApplicationInfo struct {
 	// otherwise, false.
 	LinkedToGitHub *bool `locationName:"linkedToGitHub" type:"boolean"`
 
-	metadataApplicationInfo `json:"-", xml:"-"`
+	metadataApplicationInfo `json:"-" xml:"-"`
 }
 
 type metadataApplicationInfo struct {
@@ -872,7 +872,7 @@ type AutoScalingGroup struct {
 	// The Auto Scaling group name.
 	Name *string `locationName:"name" type:"string"`
 
-	metadataAutoScalingGroup `json:"-", xml:"-"`
+	metadataAutoScalingGroup `json:"-" xml:"-"`
 }
 
 type metadataAutoScalingGroup struct {
@@ -885,7 +885,7 @@ type BatchGetApplicationsInput struct {
 	// spaces.
 	ApplicationNames []*string `locationName:"applicationNames" type:"list"`
 
-	metadataBatchGetApplicationsInput `json:"-", xml:"-"`
+	metadataBatchGetApplicationsInput `json:"-" xml:"-"`
 }
 
 type metadataBatchGetApplicationsInput struct {
@@ -897,7 +897,7 @@ type BatchGetApplicationsOutput struct {
 	// Information about the applications.
 	ApplicationsInfo []*ApplicationInfo `locationName:"applicationsInfo" type:"list"`
 
-	metadataBatchGetApplicationsOutput `json:"-", xml:"-"`
+	metadataBatchGetApplicationsOutput `json:"-" xml:"-"`
 }
 
 type metadataBatchGetApplicationsOutput struct {
@@ -909,7 +909,7 @@ type BatchGetDeploymentsInput struct {
 	// A list of deployment IDs, with multiple deployment IDs separated by spaces.
 	DeploymentIDs []*string `locationName:"deploymentIds" type:"list"`
 
-	metadataBatchGetDeploymentsInput `json:"-", xml:"-"`
+	metadataBatchGetDeploymentsInput `json:"-" xml:"-"`
 }
 
 type metadataBatchGetDeploymentsInput struct {
@@ -921,7 +921,7 @@ type BatchGetDeploymentsOutput struct {
 	// Information about the deployments.
 	DeploymentsInfo []*DeploymentInfo `locationName:"deploymentsInfo" type:"list"`
 
-	metadataBatchGetDeploymentsOutput `json:"-", xml:"-"`
+	metadataBatchGetDeploymentsOutput `json:"-" xml:"-"`
 }
 
 type metadataBatchGetDeploymentsOutput struct {
@@ -934,7 +934,7 @@ type CreateApplicationInput struct {
 	// account.
 	ApplicationName *string `locationName:"applicationName" type:"string" required:"true"`
 
-	metadataCreateApplicationInput `json:"-", xml:"-"`
+	metadataCreateApplicationInput `json:"-" xml:"-"`
 }
 
 type metadataCreateApplicationInput struct {
@@ -946,7 +946,7 @@ type CreateApplicationOutput struct {
 	// A unique application ID.
 	ApplicationID *string `locationName:"applicationId" type:"string"`
 
-	metadataCreateApplicationOutput `json:"-", xml:"-"`
+	metadataCreateApplicationOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateApplicationOutput struct {
@@ -976,7 +976,7 @@ type CreateDeploymentConfigInput struct {
 	// FLEET_PERCENT and a value of 95.
 	MinimumHealthyHosts *MinimumHealthyHosts `locationName:"minimumHealthyHosts" type:"structure"`
 
-	metadataCreateDeploymentConfigInput `json:"-", xml:"-"`
+	metadataCreateDeploymentConfigInput `json:"-" xml:"-"`
 }
 
 type metadataCreateDeploymentConfigInput struct {
@@ -988,7 +988,7 @@ type CreateDeploymentConfigOutput struct {
 	// A unique deployment configuration ID.
 	DeploymentConfigID *string `locationName:"deploymentConfigId" type:"string"`
 
-	metadataCreateDeploymentConfigOutput `json:"-", xml:"-"`
+	metadataCreateDeploymentConfigOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateDeploymentConfigOutput struct {
@@ -1044,7 +1044,7 @@ type CreateDeploymentGroupInput struct {
 	// when interacting with AWS services.
 	ServiceRoleARN *string `locationName:"serviceRoleArn" type:"string"`
 
-	metadataCreateDeploymentGroupInput `json:"-", xml:"-"`
+	metadataCreateDeploymentGroupInput `json:"-" xml:"-"`
 }
 
 type metadataCreateDeploymentGroupInput struct {
@@ -1056,7 +1056,7 @@ type CreateDeploymentGroupOutput struct {
 	// A unique deployment group ID.
 	DeploymentGroupID *string `locationName:"deploymentGroupId" type:"string"`
 
-	metadataCreateDeploymentGroupOutput `json:"-", xml:"-"`
+	metadataCreateDeploymentGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateDeploymentGroupOutput struct {
@@ -1096,7 +1096,7 @@ type CreateDeploymentInput struct {
 	// location.
 	Revision *RevisionLocation `locationName:"revision" type:"structure"`
 
-	metadataCreateDeploymentInput `json:"-", xml:"-"`
+	metadataCreateDeploymentInput `json:"-" xml:"-"`
 }
 
 type metadataCreateDeploymentInput struct {
@@ -1108,7 +1108,7 @@ type CreateDeploymentOutput struct {
 	// A unique deployment ID.
 	DeploymentID *string `locationName:"deploymentId" type:"string"`
 
-	metadataCreateDeploymentOutput `json:"-", xml:"-"`
+	metadataCreateDeploymentOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateDeploymentOutput struct {
@@ -1120,7 +1120,7 @@ type DeleteApplicationInput struct {
 	// The name of an existing AWS CodeDeploy application within the AWS user account.
 	ApplicationName *string `locationName:"applicationName" type:"string" required:"true"`
 
-	metadataDeleteApplicationInput `json:"-", xml:"-"`
+	metadataDeleteApplicationInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteApplicationInput struct {
@@ -1128,7 +1128,7 @@ type metadataDeleteApplicationInput struct {
 }
 
 type DeleteApplicationOutput struct {
-	metadataDeleteApplicationOutput `json:"-", xml:"-"`
+	metadataDeleteApplicationOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteApplicationOutput struct {
@@ -1140,7 +1140,7 @@ type DeleteDeploymentConfigInput struct {
 	// The name of an existing deployment configuration within the AWS user account.
 	DeploymentConfigName *string `locationName:"deploymentConfigName" type:"string" required:"true"`
 
-	metadataDeleteDeploymentConfigInput `json:"-", xml:"-"`
+	metadataDeleteDeploymentConfigInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteDeploymentConfigInput struct {
@@ -1148,7 +1148,7 @@ type metadataDeleteDeploymentConfigInput struct {
 }
 
 type DeleteDeploymentConfigOutput struct {
-	metadataDeleteDeploymentConfigOutput `json:"-", xml:"-"`
+	metadataDeleteDeploymentConfigOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteDeploymentConfigOutput struct {
@@ -1163,7 +1163,7 @@ type DeleteDeploymentGroupInput struct {
 	// The name of an existing deployment group for the specified application.
 	DeploymentGroupName *string `locationName:"deploymentGroupName" type:"string" required:"true"`
 
-	metadataDeleteDeploymentGroupInput `json:"-", xml:"-"`
+	metadataDeleteDeploymentGroupInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteDeploymentGroupInput struct {
@@ -1180,7 +1180,7 @@ type DeleteDeploymentGroupOutput struct {
 	// group.
 	HooksNotCleanedUp []*AutoScalingGroup `locationName:"hooksNotCleanedUp" type:"list"`
 
-	metadataDeleteDeploymentGroupOutput `json:"-", xml:"-"`
+	metadataDeleteDeploymentGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteDeploymentGroupOutput struct {
@@ -1201,7 +1201,7 @@ type DeploymentConfigInfo struct {
 	// Information about the number or percentage of minimum healthy instances.
 	MinimumHealthyHosts *MinimumHealthyHosts `locationName:"minimumHealthyHosts" type:"structure"`
 
-	metadataDeploymentConfigInfo `json:"-", xml:"-"`
+	metadataDeploymentConfigInfo `json:"-" xml:"-"`
 }
 
 type metadataDeploymentConfigInfo struct {
@@ -1235,7 +1235,7 @@ type DeploymentGroupInfo struct {
 	// type and its location.
 	TargetRevision *RevisionLocation `locationName:"targetRevision" type:"structure"`
 
-	metadataDeploymentGroupInfo `json:"-", xml:"-"`
+	metadataDeploymentGroupInfo `json:"-" xml:"-"`
 }
 
 type metadataDeploymentGroupInfo struct {
@@ -1303,7 +1303,7 @@ type DeploymentInfo struct {
 	// The current state of the deployment as a whole.
 	Status *string `locationName:"status" type:"string"`
 
-	metadataDeploymentInfo `json:"-", xml:"-"`
+	metadataDeploymentInfo `json:"-" xml:"-"`
 }
 
 type metadataDeploymentInfo struct {
@@ -1327,7 +1327,7 @@ type DeploymentOverview struct {
 	// The number of instances that have succeeded in the deployment.
 	Succeeded *int64 `type:"long"`
 
-	metadataDeploymentOverview `json:"-", xml:"-"`
+	metadataDeploymentOverview `json:"-" xml:"-"`
 }
 
 type metadataDeploymentOverview struct {
@@ -1355,7 +1355,7 @@ type Diagnostics struct {
 	// The name of the script.
 	ScriptName *string `locationName:"scriptName" type:"string"`
 
-	metadataDiagnostics `json:"-", xml:"-"`
+	metadataDiagnostics `json:"-" xml:"-"`
 }
 
 type metadataDiagnostics struct {
@@ -1375,7 +1375,7 @@ type EC2TagFilter struct {
 	// The Amazon EC2 tag filter value.
 	Value *string `type:"string"`
 
-	metadataEC2TagFilter `json:"-", xml:"-"`
+	metadataEC2TagFilter `json:"-" xml:"-"`
 }
 
 type metadataEC2TagFilter struct {
@@ -1407,7 +1407,7 @@ type ErrorInformation struct {
 	// An accompanying error message.
 	Message *string `locationName:"message" type:"string"`
 
-	metadataErrorInformation `json:"-", xml:"-"`
+	metadataErrorInformation `json:"-" xml:"-"`
 }
 
 type metadataErrorInformation struct {
@@ -1431,7 +1431,7 @@ type GenericRevisionInfo struct {
 	// When the revision was registered with AWS CodeDeploy.
 	RegisterTime *time.Time `locationName:"registerTime" type:"timestamp" timestampFormat:"unix"`
 
-	metadataGenericRevisionInfo `json:"-", xml:"-"`
+	metadataGenericRevisionInfo `json:"-" xml:"-"`
 }
 
 type metadataGenericRevisionInfo struct {
@@ -1443,7 +1443,7 @@ type GetApplicationInput struct {
 	// The name of an existing AWS CodeDeploy application within the AWS user account.
 	ApplicationName *string `locationName:"applicationName" type:"string" required:"true"`
 
-	metadataGetApplicationInput `json:"-", xml:"-"`
+	metadataGetApplicationInput `json:"-" xml:"-"`
 }
 
 type metadataGetApplicationInput struct {
@@ -1455,7 +1455,7 @@ type GetApplicationOutput struct {
 	// Information about the application.
 	Application *ApplicationInfo `locationName:"application" type:"structure"`
 
-	metadataGetApplicationOutput `json:"-", xml:"-"`
+	metadataGetApplicationOutput `json:"-" xml:"-"`
 }
 
 type metadataGetApplicationOutput struct {
@@ -1471,7 +1471,7 @@ type GetApplicationRevisionInput struct {
 	// type and its location.
 	Revision *RevisionLocation `locationName:"revision" type:"structure" required:"true"`
 
-	metadataGetApplicationRevisionInput `json:"-", xml:"-"`
+	metadataGetApplicationRevisionInput `json:"-" xml:"-"`
 }
 
 type metadataGetApplicationRevisionInput struct {
@@ -1490,7 +1490,7 @@ type GetApplicationRevisionOutput struct {
 	// General information about the revision.
 	RevisionInfo *GenericRevisionInfo `locationName:"revisionInfo" type:"structure"`
 
-	metadataGetApplicationRevisionOutput `json:"-", xml:"-"`
+	metadataGetApplicationRevisionOutput `json:"-" xml:"-"`
 }
 
 type metadataGetApplicationRevisionOutput struct {
@@ -1502,7 +1502,7 @@ type GetDeploymentConfigInput struct {
 	// The name of an existing deployment configuration within the AWS user account.
 	DeploymentConfigName *string `locationName:"deploymentConfigName" type:"string" required:"true"`
 
-	metadataGetDeploymentConfigInput `json:"-", xml:"-"`
+	metadataGetDeploymentConfigInput `json:"-" xml:"-"`
 }
 
 type metadataGetDeploymentConfigInput struct {
@@ -1514,7 +1514,7 @@ type GetDeploymentConfigOutput struct {
 	// Information about the deployment configuration.
 	DeploymentConfigInfo *DeploymentConfigInfo `locationName:"deploymentConfigInfo" type:"structure"`
 
-	metadataGetDeploymentConfigOutput `json:"-", xml:"-"`
+	metadataGetDeploymentConfigOutput `json:"-" xml:"-"`
 }
 
 type metadataGetDeploymentConfigOutput struct {
@@ -1529,7 +1529,7 @@ type GetDeploymentGroupInput struct {
 	// The name of an existing deployment group for the specified application.
 	DeploymentGroupName *string `locationName:"deploymentGroupName" type:"string" required:"true"`
 
-	metadataGetDeploymentGroupInput `json:"-", xml:"-"`
+	metadataGetDeploymentGroupInput `json:"-" xml:"-"`
 }
 
 type metadataGetDeploymentGroupInput struct {
@@ -1541,7 +1541,7 @@ type GetDeploymentGroupOutput struct {
 	// Information about the deployment group.
 	DeploymentGroupInfo *DeploymentGroupInfo `locationName:"deploymentGroupInfo" type:"structure"`
 
-	metadataGetDeploymentGroupOutput `json:"-", xml:"-"`
+	metadataGetDeploymentGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataGetDeploymentGroupOutput struct {
@@ -1553,7 +1553,7 @@ type GetDeploymentInput struct {
 	// An existing deployment ID within the AWS user account.
 	DeploymentID *string `locationName:"deploymentId" type:"string" required:"true"`
 
-	metadataGetDeploymentInput `json:"-", xml:"-"`
+	metadataGetDeploymentInput `json:"-" xml:"-"`
 }
 
 type metadataGetDeploymentInput struct {
@@ -1568,7 +1568,7 @@ type GetDeploymentInstanceInput struct {
 	// The unique ID of an Amazon EC2 instance in the deployment's deployment group.
 	InstanceID *string `locationName:"instanceId" type:"string" required:"true"`
 
-	metadataGetDeploymentInstanceInput `json:"-", xml:"-"`
+	metadataGetDeploymentInstanceInput `json:"-" xml:"-"`
 }
 
 type metadataGetDeploymentInstanceInput struct {
@@ -1580,7 +1580,7 @@ type GetDeploymentInstanceOutput struct {
 	// Information about the instance.
 	InstanceSummary *InstanceSummary `locationName:"instanceSummary" type:"structure"`
 
-	metadataGetDeploymentInstanceOutput `json:"-", xml:"-"`
+	metadataGetDeploymentInstanceOutput `json:"-" xml:"-"`
 }
 
 type metadataGetDeploymentInstanceOutput struct {
@@ -1592,7 +1592,7 @@ type GetDeploymentOutput struct {
 	// Information about the deployment.
 	DeploymentInfo *DeploymentInfo `locationName:"deploymentInfo" type:"structure"`
 
-	metadataGetDeploymentOutput `json:"-", xml:"-"`
+	metadataGetDeploymentOutput `json:"-" xml:"-"`
 }
 
 type metadataGetDeploymentOutput struct {
@@ -1612,7 +1612,7 @@ type GitHubLocation struct {
 	// Specified as account/repository.
 	Repository *string `locationName:"repository" type:"string"`
 
-	metadataGitHubLocation `json:"-", xml:"-"`
+	metadataGitHubLocation `json:"-" xml:"-"`
 }
 
 type metadataGitHubLocation struct {
@@ -1642,7 +1642,7 @@ type InstanceSummary struct {
 	// deployment status is unknown for this instance.
 	Status *string `locationName:"status" type:"string"`
 
-	metadataInstanceSummary `json:"-", xml:"-"`
+	metadataInstanceSummary `json:"-" xml:"-"`
 }
 
 type metadataInstanceSummary struct {
@@ -1673,7 +1673,7 @@ type LifecycleEvent struct {
 	// lifecycle event is unknown.
 	Status *string `locationName:"status" type:"string"`
 
-	metadataLifecycleEvent `json:"-", xml:"-"`
+	metadataLifecycleEvent `json:"-" xml:"-"`
 }
 
 type metadataLifecycleEvent struct {
@@ -1725,7 +1725,7 @@ type ListApplicationRevisionsInput struct {
 	// If set to null, the results will be sorted in an arbitrary order.
 	SortOrder *string `locationName:"sortOrder" type:"string"`
 
-	metadataListApplicationRevisionsInput `json:"-", xml:"-"`
+	metadataListApplicationRevisionsInput `json:"-" xml:"-"`
 }
 
 type metadataListApplicationRevisionsInput struct {
@@ -1743,7 +1743,7 @@ type ListApplicationRevisionsOutput struct {
 	// A list of revision locations that contain the matching revisions.
 	Revisions []*RevisionLocation `locationName:"revisions" type:"list"`
 
-	metadataListApplicationRevisionsOutput `json:"-", xml:"-"`
+	metadataListApplicationRevisionsOutput `json:"-" xml:"-"`
 }
 
 type metadataListApplicationRevisionsOutput struct {
@@ -1756,7 +1756,7 @@ type ListApplicationsInput struct {
 	// which can be used to return the next set of applications in the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListApplicationsInput `json:"-", xml:"-"`
+	metadataListApplicationsInput `json:"-" xml:"-"`
 }
 
 type metadataListApplicationsInput struct {
@@ -1773,7 +1773,7 @@ type ListApplicationsOutput struct {
 	// applications call to return the next set of applications in the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListApplicationsOutput `json:"-", xml:"-"`
+	metadataListApplicationsOutput `json:"-" xml:"-"`
 }
 
 type metadataListApplicationsOutput struct {
@@ -1787,7 +1787,7 @@ type ListDeploymentConfigsInput struct {
 	// in the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListDeploymentConfigsInput `json:"-", xml:"-"`
+	metadataListDeploymentConfigsInput `json:"-" xml:"-"`
 }
 
 type metadataListDeploymentConfigsInput struct {
@@ -1806,7 +1806,7 @@ type ListDeploymentConfigsOutput struct {
 	// in the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListDeploymentConfigsOutput `json:"-", xml:"-"`
+	metadataListDeploymentConfigsOutput `json:"-" xml:"-"`
 }
 
 type metadataListDeploymentConfigsOutput struct {
@@ -1823,7 +1823,7 @@ type ListDeploymentGroupsInput struct {
 	// list.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListDeploymentGroupsInput `json:"-", xml:"-"`
+	metadataListDeploymentGroupsInput `json:"-" xml:"-"`
 }
 
 type metadataListDeploymentGroupsInput struct {
@@ -1844,7 +1844,7 @@ type ListDeploymentGroupsOutput struct {
 	// list.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListDeploymentGroupsOutput `json:"-", xml:"-"`
+	metadataListDeploymentGroupsOutput `json:"-" xml:"-"`
 }
 
 type metadataListDeploymentGroupsOutput struct {
@@ -1872,7 +1872,7 @@ type ListDeploymentInstancesInput struct {
 	// the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListDeploymentInstancesInput `json:"-", xml:"-"`
+	metadataListDeploymentInstancesInput `json:"-" xml:"-"`
 }
 
 type metadataListDeploymentInstancesInput struct {
@@ -1890,7 +1890,7 @@ type ListDeploymentInstancesOutput struct {
 	// in the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListDeploymentInstancesOutput `json:"-", xml:"-"`
+	metadataListDeploymentInstancesOutput `json:"-" xml:"-"`
 }
 
 type metadataListDeploymentInstancesOutput struct {
@@ -1921,7 +1921,7 @@ type ListDeploymentsInput struct {
 	// which can be used to return the next set of deployments in the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListDeploymentsInput `json:"-", xml:"-"`
+	metadataListDeploymentsInput `json:"-" xml:"-"`
 }
 
 type metadataListDeploymentsInput struct {
@@ -1938,7 +1938,7 @@ type ListDeploymentsOutput struct {
 	// deployments call to return the next set of deployments in the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListDeploymentsOutput `json:"-", xml:"-"`
+	metadataListDeploymentsOutput `json:"-" xml:"-"`
 }
 
 type metadataListDeploymentsOutput struct {
@@ -1968,7 +1968,7 @@ type MinimumHealthyHosts struct {
 	// The minimum healthy instances value.
 	Value *int64 `locationName:"value" type:"integer"`
 
-	metadataMinimumHealthyHosts `json:"-", xml:"-"`
+	metadataMinimumHealthyHosts `json:"-" xml:"-"`
 }
 
 type metadataMinimumHealthyHosts struct {
@@ -1987,7 +1987,7 @@ type RegisterApplicationRevisionInput struct {
 	// type and its location.
 	Revision *RevisionLocation `locationName:"revision" type:"structure" required:"true"`
 
-	metadataRegisterApplicationRevisionInput `json:"-", xml:"-"`
+	metadataRegisterApplicationRevisionInput `json:"-" xml:"-"`
 }
 
 type metadataRegisterApplicationRevisionInput struct {
@@ -1995,7 +1995,7 @@ type metadataRegisterApplicationRevisionInput struct {
 }
 
 type RegisterApplicationRevisionOutput struct {
-	metadataRegisterApplicationRevisionOutput `json:"-", xml:"-"`
+	metadataRegisterApplicationRevisionOutput `json:"-" xml:"-"`
 }
 
 type metadataRegisterApplicationRevisionOutput struct {
@@ -2018,7 +2018,7 @@ type RevisionLocation struct {
 	// Amazon S3.
 	S3Location *S3Location `locationName:"s3Location" type:"structure"`
 
-	metadataRevisionLocation `json:"-", xml:"-"`
+	metadataRevisionLocation `json:"-" xml:"-"`
 }
 
 type metadataRevisionLocation struct {
@@ -2055,7 +2055,7 @@ type S3Location struct {
 	// by default.
 	Version *string `locationName:"version" type:"string"`
 
-	metadataS3Location `json:"-", xml:"-"`
+	metadataS3Location `json:"-" xml:"-"`
 }
 
 type metadataS3Location struct {
@@ -2067,7 +2067,7 @@ type StopDeploymentInput struct {
 	// The unique ID of a deployment.
 	DeploymentID *string `locationName:"deploymentId" type:"string" required:"true"`
 
-	metadataStopDeploymentInput `json:"-", xml:"-"`
+	metadataStopDeploymentInput `json:"-" xml:"-"`
 }
 
 type metadataStopDeploymentInput struct {
@@ -2084,7 +2084,7 @@ type StopDeploymentOutput struct {
 	// An accompanying status message.
 	StatusMessage *string `locationName:"statusMessage" type:"string"`
 
-	metadataStopDeploymentOutput `json:"-", xml:"-"`
+	metadataStopDeploymentOutput `json:"-" xml:"-"`
 }
 
 type metadataStopDeploymentOutput struct {
@@ -2103,7 +2103,7 @@ type TimeRange struct {
 	// Specify null to leave the time range's start time open-ended.
 	Start *time.Time `locationName:"start" type:"timestamp" timestampFormat:"unix"`
 
-	metadataTimeRange `json:"-", xml:"-"`
+	metadataTimeRange `json:"-" xml:"-"`
 }
 
 type metadataTimeRange struct {
@@ -2118,7 +2118,7 @@ type UpdateApplicationInput struct {
 	// The new name that you want to change the application to.
 	NewApplicationName *string `locationName:"newApplicationName" type:"string"`
 
-	metadataUpdateApplicationInput `json:"-", xml:"-"`
+	metadataUpdateApplicationInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateApplicationInput struct {
@@ -2126,7 +2126,7 @@ type metadataUpdateApplicationInput struct {
 }
 
 type UpdateApplicationOutput struct {
-	metadataUpdateApplicationOutput `json:"-", xml:"-"`
+	metadataUpdateApplicationOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateApplicationOutput struct {
@@ -2159,7 +2159,7 @@ type UpdateDeploymentGroupInput struct {
 	// A replacement service role's ARN, if you want to change it.
 	ServiceRoleARN *string `locationName:"serviceRoleArn" type:"string"`
 
-	metadataUpdateDeploymentGroupInput `json:"-", xml:"-"`
+	metadataUpdateDeploymentGroupInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateDeploymentGroupInput struct {
@@ -2175,7 +2175,7 @@ type UpdateDeploymentGroupOutput struct {
 	// Scaling lifecycle event hooks from the AWS user account.
 	HooksNotCleanedUp []*AutoScalingGroup `locationName:"hooksNotCleanedUp" type:"list"`
 
-	metadataUpdateDeploymentGroupOutput `json:"-", xml:"-"`
+	metadataUpdateDeploymentGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateDeploymentGroupOutput struct {

--- a/service/cognitoidentity/api.go
+++ b/service/cognitoidentity/api.go
@@ -641,7 +641,7 @@ type CreateIdentityPoolInput struct {
 	// Optional key:value pairs mapping provider names to provider app IDs.
 	SupportedLoginProviders *map[string]*string `type:"map"`
 
-	metadataCreateIdentityPoolInput `json:"-", xml:"-"`
+	metadataCreateIdentityPoolInput `json:"-" xml:"-"`
 }
 
 type metadataCreateIdentityPoolInput struct {
@@ -662,7 +662,7 @@ type Credentials struct {
 	// The Session Token portion of the credentials
 	SessionToken *string `type:"string"`
 
-	metadataCredentials `json:"-", xml:"-"`
+	metadataCredentials `json:"-" xml:"-"`
 }
 
 type metadataCredentials struct {
@@ -674,7 +674,7 @@ type DeleteIdentityPoolInput struct {
 	// An identity pool ID in the format REGION:GUID.
 	IdentityPoolID *string `locationName:"IdentityPoolId" type:"string" required:"true"`
 
-	metadataDeleteIdentityPoolInput `json:"-", xml:"-"`
+	metadataDeleteIdentityPoolInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteIdentityPoolInput struct {
@@ -682,7 +682,7 @@ type metadataDeleteIdentityPoolInput struct {
 }
 
 type DeleteIdentityPoolOutput struct {
-	metadataDeleteIdentityPoolOutput `json:"-", xml:"-"`
+	metadataDeleteIdentityPoolOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteIdentityPoolOutput struct {
@@ -694,7 +694,7 @@ type DescribeIdentityInput struct {
 	// A unique identifier in the format REGION:GUID.
 	IdentityID *string `locationName:"IdentityId" type:"string" required:"true"`
 
-	metadataDescribeIdentityInput `json:"-", xml:"-"`
+	metadataDescribeIdentityInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeIdentityInput struct {
@@ -706,7 +706,7 @@ type DescribeIdentityPoolInput struct {
 	// An identity pool ID in the format REGION:GUID.
 	IdentityPoolID *string `locationName:"IdentityPoolId" type:"string" required:"true"`
 
-	metadataDescribeIdentityPoolInput `json:"-", xml:"-"`
+	metadataDescribeIdentityPoolInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeIdentityPoolInput struct {
@@ -721,7 +721,7 @@ type GetCredentialsForIdentityInput struct {
 	// A set of optional name-value pairs that map provider names to provider tokens.
 	Logins *map[string]*string `type:"map"`
 
-	metadataGetCredentialsForIdentityInput `json:"-", xml:"-"`
+	metadataGetCredentialsForIdentityInput `json:"-" xml:"-"`
 }
 
 type metadataGetCredentialsForIdentityInput struct {
@@ -736,7 +736,7 @@ type GetCredentialsForIdentityOutput struct {
 	// A unique identifier in the format REGION:GUID.
 	IdentityID *string `locationName:"IdentityId" type:"string"`
 
-	metadataGetCredentialsForIdentityOutput `json:"-", xml:"-"`
+	metadataGetCredentialsForIdentityOutput `json:"-" xml:"-"`
 }
 
 type metadataGetCredentialsForIdentityOutput struct {
@@ -757,7 +757,7 @@ type GetIDInput struct {
 	//  Google: accounts.google.com  Amazon: www.amazon.com
 	Logins *map[string]*string `type:"map"`
 
-	metadataGetIDInput `json:"-", xml:"-"`
+	metadataGetIDInput `json:"-" xml:"-"`
 }
 
 type metadataGetIDInput struct {
@@ -769,7 +769,7 @@ type GetIDOutput struct {
 	// A unique identifier in the format REGION:GUID.
 	IdentityID *string `locationName:"IdentityId" type:"string"`
 
-	metadataGetIDOutput `json:"-", xml:"-"`
+	metadataGetIDOutput `json:"-" xml:"-"`
 }
 
 type metadataGetIDOutput struct {
@@ -781,7 +781,7 @@ type GetIdentityPoolRolesInput struct {
 	// An identity pool ID in the format REGION:GUID.
 	IdentityPoolID *string `locationName:"IdentityPoolId" type:"string"`
 
-	metadataGetIdentityPoolRolesInput `json:"-", xml:"-"`
+	metadataGetIdentityPoolRolesInput `json:"-" xml:"-"`
 }
 
 type metadataGetIdentityPoolRolesInput struct {
@@ -797,7 +797,7 @@ type GetIdentityPoolRolesOutput struct {
 	// and unauthenticated roles are supported.
 	Roles *map[string]*string `type:"map"`
 
-	metadataGetIdentityPoolRolesOutput `json:"-", xml:"-"`
+	metadataGetIdentityPoolRolesOutput `json:"-" xml:"-"`
 }
 
 type metadataGetIdentityPoolRolesOutput struct {
@@ -833,7 +833,7 @@ type GetOpenIDTokenForDeveloperIdentityInput struct {
 	// AWS resources for the token's duration.
 	TokenDuration *int64 `type:"long"`
 
-	metadataGetOpenIDTokenForDeveloperIdentityInput `json:"-", xml:"-"`
+	metadataGetOpenIDTokenForDeveloperIdentityInput `json:"-" xml:"-"`
 }
 
 type metadataGetOpenIDTokenForDeveloperIdentityInput struct {
@@ -848,7 +848,7 @@ type GetOpenIDTokenForDeveloperIdentityOutput struct {
 	// An OpenID token.
 	Token *string `type:"string"`
 
-	metadataGetOpenIDTokenForDeveloperIdentityOutput `json:"-", xml:"-"`
+	metadataGetOpenIDTokenForDeveloperIdentityOutput `json:"-" xml:"-"`
 }
 
 type metadataGetOpenIDTokenForDeveloperIdentityOutput struct {
@@ -863,7 +863,7 @@ type GetOpenIDTokenInput struct {
 	// A set of optional name-value pairs that map provider names to provider tokens.
 	Logins *map[string]*string `type:"map"`
 
-	metadataGetOpenIDTokenInput `json:"-", xml:"-"`
+	metadataGetOpenIDTokenInput `json:"-" xml:"-"`
 }
 
 type metadataGetOpenIDTokenInput struct {
@@ -879,7 +879,7 @@ type GetOpenIDTokenOutput struct {
 	// An OpenID token, valid for 15 minutes.
 	Token *string `type:"string"`
 
-	metadataGetOpenIDTokenOutput `json:"-", xml:"-"`
+	metadataGetOpenIDTokenOutput `json:"-" xml:"-"`
 }
 
 type metadataGetOpenIDTokenOutput struct {
@@ -900,7 +900,7 @@ type IdentityDescription struct {
 	// A set of optional name-value pairs that map provider names to provider tokens.
 	Logins []*string `type:"list"`
 
-	metadataIdentityDescription `json:"-", xml:"-"`
+	metadataIdentityDescription `json:"-" xml:"-"`
 }
 
 type metadataIdentityDescription struct {
@@ -927,7 +927,7 @@ type IdentityPool struct {
 	// Optional key:value pairs mapping provider names to provider app IDs.
 	SupportedLoginProviders *map[string]*string `type:"map"`
 
-	metadataIdentityPool `json:"-", xml:"-"`
+	metadataIdentityPool `json:"-" xml:"-"`
 }
 
 type metadataIdentityPool struct {
@@ -942,7 +942,7 @@ type IdentityPoolShortDescription struct {
 	// A string that you provide.
 	IdentityPoolName *string `type:"string"`
 
-	metadataIdentityPoolShortDescription `json:"-", xml:"-"`
+	metadataIdentityPoolShortDescription `json:"-" xml:"-"`
 }
 
 type metadataIdentityPoolShortDescription struct {
@@ -960,7 +960,7 @@ type ListIdentitiesInput struct {
 	// A pagination token.
 	NextToken *string `type:"string"`
 
-	metadataListIdentitiesInput `json:"-", xml:"-"`
+	metadataListIdentitiesInput `json:"-" xml:"-"`
 }
 
 type metadataListIdentitiesInput struct {
@@ -978,7 +978,7 @@ type ListIdentitiesOutput struct {
 	// A pagination token.
 	NextToken *string `type:"string"`
 
-	metadataListIdentitiesOutput `json:"-", xml:"-"`
+	metadataListIdentitiesOutput `json:"-" xml:"-"`
 }
 
 type metadataListIdentitiesOutput struct {
@@ -993,7 +993,7 @@ type ListIdentityPoolsInput struct {
 	// A pagination token.
 	NextToken *string `type:"string"`
 
-	metadataListIdentityPoolsInput `json:"-", xml:"-"`
+	metadataListIdentityPoolsInput `json:"-" xml:"-"`
 }
 
 type metadataListIdentityPoolsInput struct {
@@ -1008,7 +1008,7 @@ type ListIdentityPoolsOutput struct {
 	// A pagination token.
 	NextToken *string `type:"string"`
 
-	metadataListIdentityPoolsOutput `json:"-", xml:"-"`
+	metadataListIdentityPoolsOutput `json:"-" xml:"-"`
 }
 
 type metadataListIdentityPoolsOutput struct {
@@ -1039,7 +1039,7 @@ type LookupDeveloperIdentityInput struct {
 	// results starting from the 11th match.
 	NextToken *string `type:"string"`
 
-	metadataLookupDeveloperIdentityInput `json:"-", xml:"-"`
+	metadataLookupDeveloperIdentityInput `json:"-" xml:"-"`
 }
 
 type metadataLookupDeveloperIdentityInput struct {
@@ -1064,7 +1064,7 @@ type LookupDeveloperIdentityOutput struct {
 	// results starting from the 11th match.
 	NextToken *string `type:"string"`
 
-	metadataLookupDeveloperIdentityOutput `json:"-", xml:"-"`
+	metadataLookupDeveloperIdentityOutput `json:"-" xml:"-"`
 }
 
 type metadataLookupDeveloperIdentityOutput struct {
@@ -1089,7 +1089,7 @@ type MergeDeveloperIdentitiesInput struct {
 	// User identifier for the source user. The value should be a DeveloperUserIdentifier.
 	SourceUserIdentifier *string `type:"string" required:"true"`
 
-	metadataMergeDeveloperIdentitiesInput `json:"-", xml:"-"`
+	metadataMergeDeveloperIdentitiesInput `json:"-" xml:"-"`
 }
 
 type metadataMergeDeveloperIdentitiesInput struct {
@@ -1101,7 +1101,7 @@ type MergeDeveloperIdentitiesOutput struct {
 	// A unique identifier in the format REGION:GUID.
 	IdentityID *string `locationName:"IdentityId" type:"string"`
 
-	metadataMergeDeveloperIdentitiesOutput `json:"-", xml:"-"`
+	metadataMergeDeveloperIdentitiesOutput `json:"-" xml:"-"`
 }
 
 type metadataMergeDeveloperIdentitiesOutput struct {
@@ -1117,7 +1117,7 @@ type SetIdentityPoolRolesInput struct {
 	// and unauthenticated roles are supported.
 	Roles *map[string]*string `type:"map" required:"true"`
 
-	metadataSetIdentityPoolRolesInput `json:"-", xml:"-"`
+	metadataSetIdentityPoolRolesInput `json:"-" xml:"-"`
 }
 
 type metadataSetIdentityPoolRolesInput struct {
@@ -1125,7 +1125,7 @@ type metadataSetIdentityPoolRolesInput struct {
 }
 
 type SetIdentityPoolRolesOutput struct {
-	metadataSetIdentityPoolRolesOutput `json:"-", xml:"-"`
+	metadataSetIdentityPoolRolesOutput `json:"-" xml:"-"`
 }
 
 type metadataSetIdentityPoolRolesOutput struct {
@@ -1146,7 +1146,7 @@ type UnlinkDeveloperIdentityInput struct {
 	// An identity pool ID in the format REGION:GUID.
 	IdentityPoolID *string `locationName:"IdentityPoolId" type:"string" required:"true"`
 
-	metadataUnlinkDeveloperIdentityInput `json:"-", xml:"-"`
+	metadataUnlinkDeveloperIdentityInput `json:"-" xml:"-"`
 }
 
 type metadataUnlinkDeveloperIdentityInput struct {
@@ -1154,7 +1154,7 @@ type metadataUnlinkDeveloperIdentityInput struct {
 }
 
 type UnlinkDeveloperIdentityOutput struct {
-	metadataUnlinkDeveloperIdentityOutput `json:"-", xml:"-"`
+	metadataUnlinkDeveloperIdentityOutput `json:"-" xml:"-"`
 }
 
 type metadataUnlinkDeveloperIdentityOutput struct {
@@ -1172,7 +1172,7 @@ type UnlinkIdentityInput struct {
 	// Provider names to unlink from this identity.
 	LoginsToRemove []*string `type:"list" required:"true"`
 
-	metadataUnlinkIdentityInput `json:"-", xml:"-"`
+	metadataUnlinkIdentityInput `json:"-" xml:"-"`
 }
 
 type metadataUnlinkIdentityInput struct {
@@ -1180,7 +1180,7 @@ type metadataUnlinkIdentityInput struct {
 }
 
 type UnlinkIdentityOutput struct {
-	metadataUnlinkIdentityOutput `json:"-", xml:"-"`
+	metadataUnlinkIdentityOutput `json:"-" xml:"-"`
 }
 
 type metadataUnlinkIdentityOutput struct {

--- a/service/cognitosync/api.go
+++ b/service/cognitosync/api.go
@@ -559,7 +559,7 @@ type BulkPublishInput struct {
 	// created by Amazon Cognito. GUID generation is unique within a region.
 	IdentityPoolID *string `location:"uri" locationName:"IdentityPoolId" type:"string" required:"true"`
 
-	metadataBulkPublishInput `json:"-", xml:"-"`
+	metadataBulkPublishInput `json:"-" xml:"-"`
 }
 
 type metadataBulkPublishInput struct {
@@ -572,7 +572,7 @@ type BulkPublishOutput struct {
 	// created by Amazon Cognito. GUID generation is unique within a region.
 	IdentityPoolID *string `locationName:"IdentityPoolId" type:"string"`
 
-	metadataBulkPublishOutput `json:"-", xml:"-"`
+	metadataBulkPublishOutput `json:"-" xml:"-"`
 }
 
 type metadataBulkPublishOutput struct {
@@ -597,7 +597,7 @@ type CognitoStreams struct {
 	// will also fail if StreamingStatus is DISABLED.
 	StreamingStatus *string `type:"string"`
 
-	metadataCognitoStreams `json:"-", xml:"-"`
+	metadataCognitoStreams `json:"-" xml:"-"`
 }
 
 type metadataCognitoStreams struct {
@@ -633,7 +633,7 @@ type Dataset struct {
 	// Number of records in this dataset.
 	NumRecords *int64 `type:"long"`
 
-	metadataDataset `json:"-", xml:"-"`
+	metadataDataset `json:"-" xml:"-"`
 }
 
 type metadataDataset struct {
@@ -654,7 +654,7 @@ type DeleteDatasetInput struct {
 	// created by Amazon Cognito. GUID generation is unique within a region.
 	IdentityPoolID *string `location:"uri" locationName:"IdentityPoolId" type:"string" required:"true"`
 
-	metadataDeleteDatasetInput `json:"-", xml:"-"`
+	metadataDeleteDatasetInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteDatasetInput struct {
@@ -670,7 +670,7 @@ type DeleteDatasetOutput struct {
 	// hold up to 1MB of key-value pairs.
 	Dataset *Dataset `type:"structure"`
 
-	metadataDeleteDatasetOutput `json:"-", xml:"-"`
+	metadataDeleteDatasetOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteDatasetOutput struct {
@@ -692,7 +692,7 @@ type DescribeDatasetInput struct {
 	// created by Amazon Cognito. GUID generation is unique within a region.
 	IdentityPoolID *string `location:"uri" locationName:"IdentityPoolId" type:"string" required:"true"`
 
-	metadataDescribeDatasetInput `json:"-", xml:"-"`
+	metadataDescribeDatasetInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeDatasetInput struct {
@@ -708,7 +708,7 @@ type DescribeDatasetOutput struct {
 	// hold up to 1MB of key-value pairs.
 	Dataset *Dataset `type:"structure"`
 
-	metadataDescribeDatasetOutput `json:"-", xml:"-"`
+	metadataDescribeDatasetOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeDatasetOutput struct {
@@ -721,7 +721,7 @@ type DescribeIdentityPoolUsageInput struct {
 	// created by Amazon Cognito. GUID generation is unique within a region.
 	IdentityPoolID *string `location:"uri" locationName:"IdentityPoolId" type:"string" required:"true"`
 
-	metadataDescribeIdentityPoolUsageInput `json:"-", xml:"-"`
+	metadataDescribeIdentityPoolUsageInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeIdentityPoolUsageInput struct {
@@ -733,7 +733,7 @@ type DescribeIdentityPoolUsageOutput struct {
 	// Information about the usage of the identity pool.
 	IdentityPoolUsage *IdentityPoolUsage `type:"structure"`
 
-	metadataDescribeIdentityPoolUsageOutput `json:"-", xml:"-"`
+	metadataDescribeIdentityPoolUsageOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeIdentityPoolUsageOutput struct {
@@ -750,7 +750,7 @@ type DescribeIdentityUsageInput struct {
 	// created by Amazon Cognito. GUID generation is unique within a region.
 	IdentityPoolID *string `location:"uri" locationName:"IdentityPoolId" type:"string" required:"true"`
 
-	metadataDescribeIdentityUsageInput `json:"-", xml:"-"`
+	metadataDescribeIdentityUsageInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeIdentityUsageInput struct {
@@ -762,7 +762,7 @@ type DescribeIdentityUsageOutput struct {
 	// Usage information for the identity.
 	IdentityUsage *IdentityUsage `type:"structure"`
 
-	metadataDescribeIdentityUsageOutput `json:"-", xml:"-"`
+	metadataDescribeIdentityUsageOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeIdentityUsageOutput struct {
@@ -775,7 +775,7 @@ type GetBulkPublishDetailsInput struct {
 	// created by Amazon Cognito. GUID generation is unique within a region.
 	IdentityPoolID *string `location:"uri" locationName:"IdentityPoolId" type:"string" required:"true"`
 
-	metadataGetBulkPublishDetailsInput `json:"-", xml:"-"`
+	metadataGetBulkPublishDetailsInput `json:"-" xml:"-"`
 }
 
 type metadataGetBulkPublishDetailsInput struct {
@@ -811,7 +811,7 @@ type GetBulkPublishDetailsOutput struct {
 	// created by Amazon Cognito. GUID generation is unique within a region.
 	IdentityPoolID *string `locationName:"IdentityPoolId" type:"string"`
 
-	metadataGetBulkPublishDetailsOutput `json:"-", xml:"-"`
+	metadataGetBulkPublishDetailsOutput `json:"-" xml:"-"`
 }
 
 type metadataGetBulkPublishDetailsOutput struct {
@@ -825,7 +825,7 @@ type GetIdentityPoolConfigurationInput struct {
 	// a configuration.
 	IdentityPoolID *string `location:"uri" locationName:"IdentityPoolId" type:"string" required:"true"`
 
-	metadataGetIdentityPoolConfigurationInput `json:"-", xml:"-"`
+	metadataGetIdentityPoolConfigurationInput `json:"-" xml:"-"`
 }
 
 type metadataGetIdentityPoolConfigurationInput struct {
@@ -844,7 +844,7 @@ type GetIdentityPoolConfigurationOutput struct {
 	// Options to apply to this identity pool for push synchronization.
 	PushSync *PushSync `type:"structure"`
 
-	metadataGetIdentityPoolConfigurationOutput `json:"-", xml:"-"`
+	metadataGetIdentityPoolConfigurationOutput `json:"-" xml:"-"`
 }
 
 type metadataGetIdentityPoolConfigurationOutput struct {
@@ -866,7 +866,7 @@ type IdentityPoolUsage struct {
 	// Number of sync sessions for the identity pool.
 	SyncSessionsCount *int64 `type:"long"`
 
-	metadataIdentityPoolUsage `json:"-", xml:"-"`
+	metadataIdentityPoolUsage `json:"-" xml:"-"`
 }
 
 type metadataIdentityPoolUsage struct {
@@ -892,7 +892,7 @@ type IdentityUsage struct {
 	// Date on which the identity was last modified.
 	LastModifiedDate *time.Time `type:"timestamp" timestampFormat:"unix"`
 
-	metadataIdentityUsage `json:"-", xml:"-"`
+	metadataIdentityUsage `json:"-" xml:"-"`
 }
 
 type metadataIdentityUsage struct {
@@ -915,7 +915,7 @@ type ListDatasetsInput struct {
 	// A pagination token for obtaining the next page of results.
 	NextToken *string `location:"querystring" locationName:"nextToken" type:"string"`
 
-	metadataListDatasetsInput `json:"-", xml:"-"`
+	metadataListDatasetsInput `json:"-" xml:"-"`
 }
 
 type metadataListDatasetsInput struct {
@@ -933,7 +933,7 @@ type ListDatasetsOutput struct {
 	// A pagination token for obtaining the next page of results.
 	NextToken *string `type:"string"`
 
-	metadataListDatasetsOutput `json:"-", xml:"-"`
+	metadataListDatasetsOutput `json:"-" xml:"-"`
 }
 
 type metadataListDatasetsOutput struct {
@@ -948,7 +948,7 @@ type ListIdentityPoolUsageInput struct {
 	// A pagination token for obtaining the next page of results.
 	NextToken *string `location:"querystring" locationName:"nextToken" type:"string"`
 
-	metadataListIdentityPoolUsageInput `json:"-", xml:"-"`
+	metadataListIdentityPoolUsageInput `json:"-" xml:"-"`
 }
 
 type metadataListIdentityPoolUsageInput struct {
@@ -969,7 +969,7 @@ type ListIdentityPoolUsageOutput struct {
 	// A pagination token for obtaining the next page of results.
 	NextToken *string `type:"string"`
 
-	metadataListIdentityPoolUsageOutput `json:"-", xml:"-"`
+	metadataListIdentityPoolUsageOutput `json:"-" xml:"-"`
 }
 
 type metadataListIdentityPoolUsageOutput struct {
@@ -1002,7 +1002,7 @@ type ListRecordsInput struct {
 	// A token containing a session ID, identity ID, and expiration.
 	SyncSessionToken *string `location:"querystring" locationName:"syncSessionToken" type:"string"`
 
-	metadataListRecordsInput `json:"-", xml:"-"`
+	metadataListRecordsInput `json:"-" xml:"-"`
 }
 
 type metadataListRecordsInput struct {
@@ -1038,7 +1038,7 @@ type ListRecordsOutput struct {
 	// A token containing a session ID, identity ID, and expiration.
 	SyncSessionToken *string `type:"string"`
 
-	metadataListRecordsOutput `json:"-", xml:"-"`
+	metadataListRecordsOutput `json:"-" xml:"-"`
 }
 
 type metadataListRecordsOutput struct {
@@ -1053,7 +1053,7 @@ type PushSync struct {
 	// A role configured to allow Cognito to call SNS on behalf of the developer.
 	RoleARN *string `locationName:"RoleArn" type:"string"`
 
-	metadataPushSync `json:"-", xml:"-"`
+	metadataPushSync `json:"-" xml:"-"`
 }
 
 type metadataPushSync struct {
@@ -1080,7 +1080,7 @@ type Record struct {
 	// The value for the record.
 	Value *string `type:"string"`
 
-	metadataRecord `json:"-", xml:"-"`
+	metadataRecord `json:"-" xml:"-"`
 }
 
 type metadataRecord struct {
@@ -1104,7 +1104,7 @@ type RecordPatch struct {
 	// The value associated with the record patch.
 	Value *string `type:"string"`
 
-	metadataRecordPatch `json:"-", xml:"-"`
+	metadataRecordPatch `json:"-" xml:"-"`
 }
 
 type metadataRecordPatch struct {
@@ -1127,7 +1127,7 @@ type RegisterDeviceInput struct {
 	// The push token.
 	Token *string `type:"string" required:"true"`
 
-	metadataRegisterDeviceInput `json:"-", xml:"-"`
+	metadataRegisterDeviceInput `json:"-" xml:"-"`
 }
 
 type metadataRegisterDeviceInput struct {
@@ -1139,7 +1139,7 @@ type RegisterDeviceOutput struct {
 	// The unique ID generated for this device by Cognito.
 	DeviceID *string `locationName:"DeviceId" type:"string"`
 
-	metadataRegisterDeviceOutput `json:"-", xml:"-"`
+	metadataRegisterDeviceOutput `json:"-" xml:"-"`
 }
 
 type metadataRegisterDeviceOutput struct {
@@ -1158,7 +1158,7 @@ type SetIdentityPoolConfigurationInput struct {
 	// Options to apply to this identity pool for push synchronization.
 	PushSync *PushSync `type:"structure"`
 
-	metadataSetIdentityPoolConfigurationInput `json:"-", xml:"-"`
+	metadataSetIdentityPoolConfigurationInput `json:"-" xml:"-"`
 }
 
 type metadataSetIdentityPoolConfigurationInput struct {
@@ -1177,7 +1177,7 @@ type SetIdentityPoolConfigurationOutput struct {
 	// Options to apply to this identity pool for push synchronization.
 	PushSync *PushSync `type:"structure"`
 
-	metadataSetIdentityPoolConfigurationOutput `json:"-", xml:"-"`
+	metadataSetIdentityPoolConfigurationOutput `json:"-" xml:"-"`
 }
 
 type metadataSetIdentityPoolConfigurationOutput struct {
@@ -1199,7 +1199,7 @@ type SubscribeToDatasetInput struct {
 	// created by Amazon Cognito. The ID of the pool to which the identity belongs.
 	IdentityPoolID *string `location:"uri" locationName:"IdentityPoolId" type:"string" required:"true"`
 
-	metadataSubscribeToDatasetInput `json:"-", xml:"-"`
+	metadataSubscribeToDatasetInput `json:"-" xml:"-"`
 }
 
 type metadataSubscribeToDatasetInput struct {
@@ -1208,7 +1208,7 @@ type metadataSubscribeToDatasetInput struct {
 
 // Response to a SubscribeToDataset request.
 type SubscribeToDatasetOutput struct {
-	metadataSubscribeToDatasetOutput `json:"-", xml:"-"`
+	metadataSubscribeToDatasetOutput `json:"-" xml:"-"`
 }
 
 type metadataSubscribeToDatasetOutput struct {
@@ -1230,7 +1230,7 @@ type UnsubscribeFromDatasetInput struct {
 	// created by Amazon Cognito. The ID of the pool to which this identity belongs.
 	IdentityPoolID *string `location:"uri" locationName:"IdentityPoolId" type:"string" required:"true"`
 
-	metadataUnsubscribeFromDatasetInput `json:"-", xml:"-"`
+	metadataUnsubscribeFromDatasetInput `json:"-" xml:"-"`
 }
 
 type metadataUnsubscribeFromDatasetInput struct {
@@ -1239,7 +1239,7 @@ type metadataUnsubscribeFromDatasetInput struct {
 
 // Response to an UnsubscribeFromDataset request.
 type UnsubscribeFromDatasetOutput struct {
-	metadataUnsubscribeFromDatasetOutput `json:"-", xml:"-"`
+	metadataUnsubscribeFromDatasetOutput `json:"-" xml:"-"`
 }
 
 type metadataUnsubscribeFromDatasetOutput struct {
@@ -1275,7 +1275,7 @@ type UpdateRecordsInput struct {
 	// dataset and identity.
 	SyncSessionToken *string `type:"string" required:"true"`
 
-	metadataUpdateRecordsInput `json:"-", xml:"-"`
+	metadataUpdateRecordsInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateRecordsInput struct {
@@ -1287,7 +1287,7 @@ type UpdateRecordsOutput struct {
 	// A list of records that have been updated.
 	Records []*Record `type:"list"`
 
-	metadataUpdateRecordsOutput `json:"-", xml:"-"`
+	metadataUpdateRecordsOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateRecordsOutput struct {

--- a/service/configservice/api.go
+++ b/service/configservice/api.go
@@ -432,7 +432,7 @@ type ConfigExportDeliveryInfo struct {
 	// The time of the last successful delivery.
 	LastSuccessfulTime *time.Time `locationName:"lastSuccessfulTime" type:"timestamp" timestampFormat:"unix"`
 
-	metadataConfigExportDeliveryInfo `json:"-", xml:"-"`
+	metadataConfigExportDeliveryInfo `json:"-" xml:"-"`
 }
 
 type metadataConfigExportDeliveryInfo struct {
@@ -454,7 +454,7 @@ type ConfigStreamDeliveryInfo struct {
 	// The time from the last status change.
 	LastStatusChangeTime *time.Time `locationName:"lastStatusChangeTime" type:"timestamp" timestampFormat:"unix"`
 
-	metadataConfigStreamDeliveryInfo `json:"-", xml:"-"`
+	metadataConfigStreamDeliveryInfo `json:"-" xml:"-"`
 }
 
 type metadataConfigStreamDeliveryInfo struct {
@@ -519,7 +519,7 @@ type ConfigurationItem struct {
 	// The version number of the resource configuration.
 	Version *string `locationName:"version" type:"string"`
 
-	metadataConfigurationItem `json:"-", xml:"-"`
+	metadataConfigurationItem `json:"-" xml:"-"`
 }
 
 type metadataConfigurationItem struct {
@@ -538,7 +538,7 @@ type ConfigurationRecorder struct {
 	// associated with the account.
 	RoleARN *string `locationName:"roleARN" type:"string"`
 
-	metadataConfigurationRecorder `json:"-", xml:"-"`
+	metadataConfigurationRecorder `json:"-" xml:"-"`
 }
 
 type metadataConfigurationRecorder struct {
@@ -571,7 +571,7 @@ type ConfigurationRecorderStatus struct {
 	// Specifies whether the recorder is currently recording or not.
 	Recording *bool `locationName:"recording" type:"boolean"`
 
-	metadataConfigurationRecorderStatus `json:"-", xml:"-"`
+	metadataConfigurationRecorderStatus `json:"-" xml:"-"`
 }
 
 type metadataConfigurationRecorderStatus struct {
@@ -584,7 +584,7 @@ type DeleteDeliveryChannelInput struct {
 	// The name of the delivery channel to delete.
 	DeliveryChannelName *string `type:"string" required:"true"`
 
-	metadataDeleteDeliveryChannelInput `json:"-", xml:"-"`
+	metadataDeleteDeliveryChannelInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteDeliveryChannelInput struct {
@@ -592,7 +592,7 @@ type metadataDeleteDeliveryChannelInput struct {
 }
 
 type DeleteDeliveryChannelOutput struct {
-	metadataDeleteDeliveryChannelOutput `json:"-", xml:"-"`
+	metadataDeleteDeliveryChannelOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteDeliveryChannelOutput struct {
@@ -604,7 +604,7 @@ type DeliverConfigSnapshotInput struct {
 	// The name of the delivery channel through which the snapshot is delivered.
 	DeliveryChannelName *string `locationName:"deliveryChannelName" type:"string" required:"true"`
 
-	metadataDeliverConfigSnapshotInput `json:"-", xml:"-"`
+	metadataDeliverConfigSnapshotInput `json:"-" xml:"-"`
 }
 
 type metadataDeliverConfigSnapshotInput struct {
@@ -616,7 +616,7 @@ type DeliverConfigSnapshotOutput struct {
 	// The ID of the snapshot that is being created.
 	ConfigSnapshotID *string `locationName:"configSnapshotId" type:"string"`
 
-	metadataDeliverConfigSnapshotOutput `json:"-", xml:"-"`
+	metadataDeliverConfigSnapshotOutput `json:"-" xml:"-"`
 }
 
 type metadataDeliverConfigSnapshotOutput struct {
@@ -642,7 +642,7 @@ type DeliveryChannel struct {
 	// S3 bucket and the Amazon SNS topic.
 	SNSTopicARN *string `locationName:"snsTopicARN" type:"string"`
 
-	metadataDeliveryChannel `json:"-", xml:"-"`
+	metadataDeliveryChannel `json:"-" xml:"-"`
 }
 
 type metadataDeliveryChannel struct {
@@ -668,7 +668,7 @@ type DeliveryChannelStatus struct {
 	// The name of the delivery channel.
 	Name *string `locationName:"name" type:"string"`
 
-	metadataDeliveryChannelStatus `json:"-", xml:"-"`
+	metadataDeliveryChannelStatus `json:"-" xml:"-"`
 }
 
 type metadataDeliveryChannelStatus struct {
@@ -682,7 +682,7 @@ type DescribeConfigurationRecorderStatusInput struct {
 	// associated with the account.
 	ConfigurationRecorderNames []*string `type:"list"`
 
-	metadataDescribeConfigurationRecorderStatusInput `json:"-", xml:"-"`
+	metadataDescribeConfigurationRecorderStatusInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeConfigurationRecorderStatusInput struct {
@@ -694,7 +694,7 @@ type DescribeConfigurationRecorderStatusOutput struct {
 	// A list that contains status of the specified recorders.
 	ConfigurationRecordersStatus []*ConfigurationRecorderStatus `type:"list"`
 
-	metadataDescribeConfigurationRecorderStatusOutput `json:"-", xml:"-"`
+	metadataDescribeConfigurationRecorderStatusOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeConfigurationRecorderStatusOutput struct {
@@ -706,7 +706,7 @@ type DescribeConfigurationRecordersInput struct {
 	// A list of configuration recorder names.
 	ConfigurationRecorderNames []*string `type:"list"`
 
-	metadataDescribeConfigurationRecordersInput `json:"-", xml:"-"`
+	metadataDescribeConfigurationRecordersInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeConfigurationRecordersInput struct {
@@ -718,7 +718,7 @@ type DescribeConfigurationRecordersOutput struct {
 	// A list that contains the descriptions of the specified configuration recorders.
 	ConfigurationRecorders []*ConfigurationRecorder `type:"list"`
 
-	metadataDescribeConfigurationRecordersOutput `json:"-", xml:"-"`
+	metadataDescribeConfigurationRecordersOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeConfigurationRecordersOutput struct {
@@ -730,7 +730,7 @@ type DescribeDeliveryChannelStatusInput struct {
 	// A list of delivery channel names.
 	DeliveryChannelNames []*string `type:"list"`
 
-	metadataDescribeDeliveryChannelStatusInput `json:"-", xml:"-"`
+	metadataDescribeDeliveryChannelStatusInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeDeliveryChannelStatusInput struct {
@@ -742,7 +742,7 @@ type DescribeDeliveryChannelStatusOutput struct {
 	// A list that contains the status of a specified delivery channel.
 	DeliveryChannelsStatus []*DeliveryChannelStatus `type:"list"`
 
-	metadataDescribeDeliveryChannelStatusOutput `json:"-", xml:"-"`
+	metadataDescribeDeliveryChannelStatusOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeDeliveryChannelStatusOutput struct {
@@ -754,7 +754,7 @@ type DescribeDeliveryChannelsInput struct {
 	// A list of delivery channel names.
 	DeliveryChannelNames []*string `type:"list"`
 
-	metadataDescribeDeliveryChannelsInput `json:"-", xml:"-"`
+	metadataDescribeDeliveryChannelsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeDeliveryChannelsInput struct {
@@ -766,7 +766,7 @@ type DescribeDeliveryChannelsOutput struct {
 	// A list that contains the descriptions of the specified delivery channel.
 	DeliveryChannels []*DeliveryChannel `type:"list"`
 
-	metadataDescribeDeliveryChannelsOutput `json:"-", xml:"-"`
+	metadataDescribeDeliveryChannelsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeDeliveryChannelsOutput struct {
@@ -801,7 +801,7 @@ type GetResourceConfigHistoryInput struct {
 	// The resource type.
 	ResourceType *string `locationName:"resourceType" type:"string" required:"true"`
 
-	metadataGetResourceConfigHistoryInput `json:"-", xml:"-"`
+	metadataGetResourceConfigHistoryInput `json:"-" xml:"-"`
 }
 
 type metadataGetResourceConfigHistoryInput struct {
@@ -816,7 +816,7 @@ type GetResourceConfigHistoryOutput struct {
 	// A token used for pagination of results.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataGetResourceConfigHistoryOutput `json:"-", xml:"-"`
+	metadataGetResourceConfigHistoryOutput `json:"-" xml:"-"`
 }
 
 type metadataGetResourceConfigHistoryOutput struct {
@@ -829,7 +829,7 @@ type PutConfigurationRecorderInput struct {
 	// made to the resources.
 	ConfigurationRecorder *ConfigurationRecorder `type:"structure" required:"true"`
 
-	metadataPutConfigurationRecorderInput `json:"-", xml:"-"`
+	metadataPutConfigurationRecorderInput `json:"-" xml:"-"`
 }
 
 type metadataPutConfigurationRecorderInput struct {
@@ -837,7 +837,7 @@ type metadataPutConfigurationRecorderInput struct {
 }
 
 type PutConfigurationRecorderOutput struct {
-	metadataPutConfigurationRecorderOutput `json:"-", xml:"-"`
+	metadataPutConfigurationRecorderOutput `json:"-" xml:"-"`
 }
 
 type metadataPutConfigurationRecorderOutput struct {
@@ -850,7 +850,7 @@ type PutDeliveryChannelInput struct {
 	// information to an Amazon S3 bucket, and to an Amazon SNS topic.
 	DeliveryChannel *DeliveryChannel `type:"structure" required:"true"`
 
-	metadataPutDeliveryChannelInput `json:"-", xml:"-"`
+	metadataPutDeliveryChannelInput `json:"-" xml:"-"`
 }
 
 type metadataPutDeliveryChannelInput struct {
@@ -858,7 +858,7 @@ type metadataPutDeliveryChannelInput struct {
 }
 
 type PutDeliveryChannelOutput struct {
-	metadataPutDeliveryChannelOutput `json:"-", xml:"-"`
+	metadataPutDeliveryChannelOutput `json:"-" xml:"-"`
 }
 
 type metadataPutDeliveryChannelOutput struct {
@@ -876,7 +876,7 @@ type Relationship struct {
 	// The resource type of the related resource.
 	ResourceType *string `locationName:"resourceType" type:"string"`
 
-	metadataRelationship `json:"-", xml:"-"`
+	metadataRelationship `json:"-" xml:"-"`
 }
 
 type metadataRelationship struct {
@@ -889,7 +889,7 @@ type StartConfigurationRecorderInput struct {
 	// to the resources.
 	ConfigurationRecorderName *string `type:"string" required:"true"`
 
-	metadataStartConfigurationRecorderInput `json:"-", xml:"-"`
+	metadataStartConfigurationRecorderInput `json:"-" xml:"-"`
 }
 
 type metadataStartConfigurationRecorderInput struct {
@@ -897,7 +897,7 @@ type metadataStartConfigurationRecorderInput struct {
 }
 
 type StartConfigurationRecorderOutput struct {
-	metadataStartConfigurationRecorderOutput `json:"-", xml:"-"`
+	metadataStartConfigurationRecorderOutput `json:"-" xml:"-"`
 }
 
 type metadataStartConfigurationRecorderOutput struct {
@@ -910,7 +910,7 @@ type StopConfigurationRecorderInput struct {
 	// to the resources.
 	ConfigurationRecorderName *string `type:"string" required:"true"`
 
-	metadataStopConfigurationRecorderInput `json:"-", xml:"-"`
+	metadataStopConfigurationRecorderInput `json:"-" xml:"-"`
 }
 
 type metadataStopConfigurationRecorderInput struct {
@@ -918,7 +918,7 @@ type metadataStopConfigurationRecorderInput struct {
 }
 
 type StopConfigurationRecorderOutput struct {
-	metadataStopConfigurationRecorderOutput `json:"-", xml:"-"`
+	metadataStopConfigurationRecorderOutput `json:"-" xml:"-"`
 }
 
 type metadataStopConfigurationRecorderOutput struct {

--- a/service/datapipeline/api.go
+++ b/service/datapipeline/api.go
@@ -694,7 +694,7 @@ type ActivatePipelineInput struct {
 	// The identifier of the pipeline to activate.
 	PipelineID *string `locationName:"pipelineId" type:"string" required:"true"`
 
-	metadataActivatePipelineInput `json:"-", xml:"-"`
+	metadataActivatePipelineInput `json:"-" xml:"-"`
 }
 
 type metadataActivatePipelineInput struct {
@@ -703,7 +703,7 @@ type metadataActivatePipelineInput struct {
 
 // Contains the output from the ActivatePipeline action.
 type ActivatePipelineOutput struct {
-	metadataActivatePipelineOutput `json:"-", xml:"-"`
+	metadataActivatePipelineOutput `json:"-" xml:"-"`
 }
 
 type metadataActivatePipelineOutput struct {
@@ -718,7 +718,7 @@ type AddTagsInput struct {
 	// The tags as key/value pairs to add to the pipeline.
 	Tags []*Tag `locationName:"tags" type:"list" required:"true"`
 
-	metadataAddTagsInput `json:"-", xml:"-"`
+	metadataAddTagsInput `json:"-" xml:"-"`
 }
 
 type metadataAddTagsInput struct {
@@ -727,7 +727,7 @@ type metadataAddTagsInput struct {
 
 // The response from the AddTags action.
 type AddTagsOutput struct {
-	metadataAddTagsOutput `json:"-", xml:"-"`
+	metadataAddTagsOutput `json:"-" xml:"-"`
 }
 
 type metadataAddTagsOutput struct {
@@ -763,7 +763,7 @@ type CreatePipelineInput struct {
 	// is scoped to the AWS account or IAM user credentials.
 	UniqueID *string `locationName:"uniqueId" type:"string" required:"true"`
 
-	metadataCreatePipelineInput `json:"-", xml:"-"`
+	metadataCreatePipelineInput `json:"-" xml:"-"`
 }
 
 type metadataCreatePipelineInput struct {
@@ -776,7 +776,7 @@ type CreatePipelineOutput struct {
 	// is a string of the form: df-06372391ZG65EXAMPLE.
 	PipelineID *string `locationName:"pipelineId" type:"string" required:"true"`
 
-	metadataCreatePipelineOutput `json:"-", xml:"-"`
+	metadataCreatePipelineOutput `json:"-" xml:"-"`
 }
 
 type metadataCreatePipelineOutput struct {
@@ -788,7 +788,7 @@ type DeletePipelineInput struct {
 	// The identifier of the pipeline to be deleted.
 	PipelineID *string `locationName:"pipelineId" type:"string" required:"true"`
 
-	metadataDeletePipelineInput `json:"-", xml:"-"`
+	metadataDeletePipelineInput `json:"-" xml:"-"`
 }
 
 type metadataDeletePipelineInput struct {
@@ -796,7 +796,7 @@ type metadataDeletePipelineInput struct {
 }
 
 type DeletePipelineOutput struct {
-	metadataDeletePipelineOutput `json:"-", xml:"-"`
+	metadataDeletePipelineOutput `json:"-" xml:"-"`
 }
 
 type metadataDeletePipelineOutput struct {
@@ -824,7 +824,7 @@ type DescribeObjectsInput struct {
 	// Identifier of the pipeline that contains the object definitions.
 	PipelineID *string `locationName:"pipelineId" type:"string" required:"true"`
 
-	metadataDescribeObjectsInput `json:"-", xml:"-"`
+	metadataDescribeObjectsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeObjectsInput struct {
@@ -843,7 +843,7 @@ type DescribeObjectsOutput struct {
 	// An array of object definitions that are returned by the call to DescribeObjects.
 	PipelineObjects []*PipelineObject `locationName:"pipelineObjects" type:"list" required:"true"`
 
-	metadataDescribeObjectsOutput `json:"-", xml:"-"`
+	metadataDescribeObjectsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeObjectsOutput struct {
@@ -857,7 +857,7 @@ type DescribePipelinesInput struct {
 	// by calling ListPipelines.
 	PipelineIDs []*string `locationName:"pipelineIds" type:"list" required:"true"`
 
-	metadataDescribePipelinesInput `json:"-", xml:"-"`
+	metadataDescribePipelinesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribePipelinesInput struct {
@@ -869,7 +869,7 @@ type DescribePipelinesOutput struct {
 	// An array of descriptions returned for the specified pipelines.
 	PipelineDescriptionList []*PipelineDescription `locationName:"pipelineDescriptionList" type:"list" required:"true"`
 
-	metadataDescribePipelinesOutput `json:"-", xml:"-"`
+	metadataDescribePipelinesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribePipelinesOutput struct {
@@ -887,7 +887,7 @@ type EvaluateExpressionInput struct {
 	// The identifier of the pipeline.
 	PipelineID *string `locationName:"pipelineId" type:"string" required:"true"`
 
-	metadataEvaluateExpressionInput `json:"-", xml:"-"`
+	metadataEvaluateExpressionInput `json:"-" xml:"-"`
 }
 
 type metadataEvaluateExpressionInput struct {
@@ -899,7 +899,7 @@ type EvaluateExpressionOutput struct {
 	// The evaluated expression.
 	EvaluatedExpression *string `locationName:"evaluatedExpression" type:"string" required:"true"`
 
-	metadataEvaluateExpressionOutput `json:"-", xml:"-"`
+	metadataEvaluateExpressionOutput `json:"-" xml:"-"`
 }
 
 type metadataEvaluateExpressionOutput struct {
@@ -919,7 +919,7 @@ type Field struct {
 	// The field value, expressed as a String.
 	StringValue *string `locationName:"stringValue" type:"string"`
 
-	metadataField `json:"-", xml:"-"`
+	metadataField `json:"-" xml:"-"`
 }
 
 type metadataField struct {
@@ -937,7 +937,7 @@ type GetPipelineDefinitionInput struct {
 	// that was activated.
 	Version *string `locationName:"version" type:"string"`
 
-	metadataGetPipelineDefinitionInput `json:"-", xml:"-"`
+	metadataGetPipelineDefinitionInput `json:"-" xml:"-"`
 }
 
 type metadataGetPipelineDefinitionInput struct {
@@ -955,7 +955,7 @@ type GetPipelineDefinitionOutput struct {
 	// An array of objects defined in the pipeline.
 	PipelineObjects []*PipelineObject `locationName:"pipelineObjects" type:"list"`
 
-	metadataGetPipelineDefinitionOutput `json:"-", xml:"-"`
+	metadataGetPipelineDefinitionOutput `json:"-" xml:"-"`
 }
 
 type metadataGetPipelineDefinitionOutput struct {
@@ -978,7 +978,7 @@ type InstanceIdentity struct {
 	// the information provided in the instance identity document.
 	Signature *string `locationName:"signature" type:"string"`
 
-	metadataInstanceIdentity `json:"-", xml:"-"`
+	metadataInstanceIdentity `json:"-" xml:"-"`
 }
 
 type metadataInstanceIdentity struct {
@@ -993,7 +993,7 @@ type ListPipelinesInput struct {
 	// value from the response to retrieve the next set of results.
 	Marker *string `locationName:"marker" type:"string"`
 
-	metadataListPipelinesInput `json:"-", xml:"-"`
+	metadataListPipelinesInput `json:"-" xml:"-"`
 }
 
 type metadataListPipelinesInput struct {
@@ -1016,7 +1016,7 @@ type ListPipelinesOutput struct {
 	// use these identifiers to call DescribePipelines and GetPipelineDefinition.
 	PipelineIDList []*PipelineIDName `locationName:"pipelineIdList" type:"list" required:"true"`
 
-	metadataListPipelinesOutput `json:"-", xml:"-"`
+	metadataListPipelinesOutput `json:"-" xml:"-"`
 }
 
 type metadataListPipelinesOutput struct {
@@ -1049,7 +1049,7 @@ type Operator struct {
 	// The value that the actual field value will be compared with.
 	Values []*string `locationName:"values" type:"list"`
 
-	metadataOperator `json:"-", xml:"-"`
+	metadataOperator `json:"-" xml:"-"`
 }
 
 type metadataOperator struct {
@@ -1064,7 +1064,7 @@ type ParameterAttribute struct {
 	// The field value, expressed as a String.
 	StringValue *string `locationName:"stringValue" type:"string" required:"true"`
 
-	metadataParameterAttribute `json:"-", xml:"-"`
+	metadataParameterAttribute `json:"-" xml:"-"`
 }
 
 type metadataParameterAttribute struct {
@@ -1079,7 +1079,7 @@ type ParameterObject struct {
 	// Identifier of the parameter object.
 	ID *string `locationName:"id" type:"string" required:"true"`
 
-	metadataParameterObject `json:"-", xml:"-"`
+	metadataParameterObject `json:"-" xml:"-"`
 }
 
 type metadataParameterObject struct {
@@ -1094,7 +1094,7 @@ type ParameterValue struct {
 	// The field value, expressed as a String.
 	StringValue *string `locationName:"stringValue" type:"string" required:"true"`
 
-	metadataParameterValue `json:"-", xml:"-"`
+	metadataParameterValue `json:"-" xml:"-"`
 }
 
 type metadataParameterValue struct {
@@ -1123,7 +1123,7 @@ type PipelineDescription struct {
 	// in the AWS Data Pipeline Developer Guide.
 	Tags []*Tag `locationName:"tags" type:"list"`
 
-	metadataPipelineDescription `json:"-", xml:"-"`
+	metadataPipelineDescription `json:"-" xml:"-"`
 }
 
 type metadataPipelineDescription struct {
@@ -1139,7 +1139,7 @@ type PipelineIDName struct {
 	// Name of the pipeline.
 	Name *string `locationName:"name" type:"string"`
 
-	metadataPipelineIDName `json:"-", xml:"-"`
+	metadataPipelineIDName `json:"-" xml:"-"`
 }
 
 type metadataPipelineIDName struct {
@@ -1159,7 +1159,7 @@ type PipelineObject struct {
 	// Name of the object.
 	Name *string `locationName:"name" type:"string" required:"true"`
 
-	metadataPipelineObject `json:"-", xml:"-"`
+	metadataPipelineObject `json:"-" xml:"-"`
 }
 
 type metadataPipelineObject struct {
@@ -1186,7 +1186,7 @@ type PollForTaskInput struct {
 	// string must be an exact, case-sensitive, match.
 	WorkerGroup *string `locationName:"workerGroup" type:"string" required:"true"`
 
-	metadataPollForTaskInput `json:"-", xml:"-"`
+	metadataPollForTaskInput `json:"-" xml:"-"`
 }
 
 type metadataPollForTaskInput struct {
@@ -1202,7 +1202,7 @@ type PollForTaskOutput struct {
 	// calls to ReportTaskProgress and SetTaskStatus.
 	TaskObject *TaskObject `locationName:"taskObject" type:"structure"`
 
-	metadataPollForTaskOutput `json:"-", xml:"-"`
+	metadataPollForTaskOutput `json:"-" xml:"-"`
 }
 
 type metadataPollForTaskOutput struct {
@@ -1224,7 +1224,7 @@ type PutPipelineDefinitionInput struct {
 	// definition.
 	PipelineObjects []*PipelineObject `locationName:"pipelineObjects" type:"list" required:"true"`
 
-	metadataPutPipelineDefinitionInput `json:"-", xml:"-"`
+	metadataPutPipelineDefinitionInput `json:"-" xml:"-"`
 }
 
 type metadataPutPipelineDefinitionInput struct {
@@ -1246,7 +1246,7 @@ type PutPipelineDefinitionOutput struct {
 	// in pipelineObjects.
 	ValidationWarnings []*ValidationWarning `locationName:"validationWarnings" type:"list"`
 
-	metadataPutPipelineDefinitionOutput `json:"-", xml:"-"`
+	metadataPutPipelineDefinitionOutput `json:"-" xml:"-"`
 }
 
 type metadataPutPipelineDefinitionOutput struct {
@@ -1259,7 +1259,7 @@ type Query struct {
 	// selectors to match the query.
 	Selectors []*Selector `locationName:"selectors" type:"list"`
 
-	metadataQuery `json:"-", xml:"-"`
+	metadataQuery `json:"-" xml:"-"`
 }
 
 type metadataQuery struct {
@@ -1291,7 +1291,7 @@ type QueryObjectsInput struct {
 	// values: COMPONENT, INSTANCE, ATTEMPT.
 	Sphere *string `locationName:"sphere" type:"string" required:"true"`
 
-	metadataQueryObjectsInput `json:"-", xml:"-"`
+	metadataQueryObjectsInput `json:"-" xml:"-"`
 }
 
 type metadataQueryObjectsInput struct {
@@ -1312,7 +1312,7 @@ type QueryObjectsOutput struct {
 	// the marker value from the response to retrieve the next set of results.
 	Marker *string `locationName:"marker" type:"string"`
 
-	metadataQueryObjectsOutput `json:"-", xml:"-"`
+	metadataQueryObjectsOutput `json:"-" xml:"-"`
 }
 
 type metadataQueryObjectsOutput struct {
@@ -1327,7 +1327,7 @@ type RemoveTagsInput struct {
 	// The keys of the tags you wish to remove.
 	TagKeys []*string `locationName:"tagKeys" type:"list" required:"true"`
 
-	metadataRemoveTagsInput `json:"-", xml:"-"`
+	metadataRemoveTagsInput `json:"-" xml:"-"`
 }
 
 type metadataRemoveTagsInput struct {
@@ -1336,7 +1336,7 @@ type metadataRemoveTagsInput struct {
 
 // The result of the RemoveTags action.
 type RemoveTagsOutput struct {
-	metadataRemoveTagsOutput `json:"-", xml:"-"`
+	metadataRemoveTagsOutput `json:"-" xml:"-"`
 }
 
 type metadataRemoveTagsOutput struct {
@@ -1354,7 +1354,7 @@ type ReportTaskProgressInput struct {
 	// action.
 	TaskID *string `locationName:"taskId" type:"string" required:"true"`
 
-	metadataReportTaskProgressInput `json:"-", xml:"-"`
+	metadataReportTaskProgressInput `json:"-" xml:"-"`
 }
 
 type metadataReportTaskProgressInput struct {
@@ -1367,7 +1367,7 @@ type ReportTaskProgressOutput struct {
 	// task runner does not need to call SetTaskStatus for canceled tasks.
 	Canceled *bool `locationName:"canceled" type:"boolean" required:"true"`
 
-	metadataReportTaskProgressOutput `json:"-", xml:"-"`
+	metadataReportTaskProgressOutput `json:"-" xml:"-"`
 }
 
 type metadataReportTaskProgressOutput struct {
@@ -1393,7 +1393,7 @@ type ReportTaskRunnerHeartbeatInput struct {
 	// the string must be an exact, case-sensitive, match.
 	WorkerGroup *string `locationName:"workerGroup" type:"string"`
 
-	metadataReportTaskRunnerHeartbeatInput `json:"-", xml:"-"`
+	metadataReportTaskRunnerHeartbeatInput `json:"-" xml:"-"`
 }
 
 type metadataReportTaskRunnerHeartbeatInput struct {
@@ -1406,7 +1406,7 @@ type ReportTaskRunnerHeartbeatOutput struct {
 	// task runner that called ReportTaskRunnerHeartbeat should terminate.
 	Terminate *bool `locationName:"terminate" type:"boolean" required:"true"`
 
-	metadataReportTaskRunnerHeartbeatOutput `json:"-", xml:"-"`
+	metadataReportTaskRunnerHeartbeatOutput `json:"-" xml:"-"`
 }
 
 type metadataReportTaskRunnerHeartbeatOutput struct {
@@ -1426,7 +1426,7 @@ type Selector struct {
 	// value.
 	Operator *Operator `locationName:"operator" type:"structure"`
 
-	metadataSelector `json:"-", xml:"-"`
+	metadataSelector `json:"-" xml:"-"`
 }
 
 type metadataSelector struct {
@@ -1447,7 +1447,7 @@ type SetStatusInput struct {
 	// RERUN, or MARK_FINISHED.
 	Status *string `locationName:"status" type:"string" required:"true"`
 
-	metadataSetStatusInput `json:"-", xml:"-"`
+	metadataSetStatusInput `json:"-" xml:"-"`
 }
 
 type metadataSetStatusInput struct {
@@ -1455,7 +1455,7 @@ type metadataSetStatusInput struct {
 }
 
 type SetStatusOutput struct {
-	metadataSetStatusOutput `json:"-", xml:"-"`
+	metadataSetStatusOutput `json:"-" xml:"-"`
 }
 
 type metadataSetStatusOutput struct {
@@ -1490,7 +1490,7 @@ type SetTaskStatusInput struct {
 	// The FALSE value is used by preconditions.
 	TaskStatus *string `locationName:"taskStatus" type:"string" required:"true"`
 
-	metadataSetTaskStatusInput `json:"-", xml:"-"`
+	metadataSetTaskStatusInput `json:"-" xml:"-"`
 }
 
 type metadataSetTaskStatusInput struct {
@@ -1499,7 +1499,7 @@ type metadataSetTaskStatusInput struct {
 
 // The output from the SetTaskStatus action.
 type SetTaskStatusOutput struct {
-	metadataSetTaskStatusOutput `json:"-", xml:"-"`
+	metadataSetTaskStatusOutput `json:"-" xml:"-"`
 }
 
 type metadataSetTaskStatusOutput struct {
@@ -1522,7 +1522,7 @@ type Tag struct {
 	// in the AWS Data Pipeline Developer Guide.
 	Value *string `locationName:"value" type:"string" required:"true"`
 
-	metadataTag `json:"-", xml:"-"`
+	metadataTag `json:"-" xml:"-"`
 }
 
 type metadataTag struct {
@@ -1546,7 +1546,7 @@ type TaskObject struct {
 	// and ReportTaskProgress actions.
 	TaskID *string `locationName:"taskId" type:"string"`
 
-	metadataTaskObject `json:"-", xml:"-"`
+	metadataTaskObject `json:"-" xml:"-"`
 }
 
 type metadataTaskObject struct {
@@ -1568,7 +1568,7 @@ type ValidatePipelineDefinitionInput struct {
 	// pipeline.
 	PipelineObjects []*PipelineObject `locationName:"pipelineObjects" type:"list" required:"true"`
 
-	metadataValidatePipelineDefinitionInput `json:"-", xml:"-"`
+	metadataValidatePipelineDefinitionInput `json:"-" xml:"-"`
 }
 
 type metadataValidatePipelineDefinitionInput struct {
@@ -1586,7 +1586,7 @@ type ValidatePipelineDefinitionOutput struct {
 	// Lists the validation warnings that were found by ValidatePipelineDefinition.
 	ValidationWarnings []*ValidationWarning `locationName:"validationWarnings" type:"list"`
 
-	metadataValidatePipelineDefinitionOutput `json:"-", xml:"-"`
+	metadataValidatePipelineDefinitionOutput `json:"-" xml:"-"`
 }
 
 type metadataValidatePipelineDefinitionOutput struct {
@@ -1603,7 +1603,7 @@ type ValidationError struct {
 	// The identifier of the object that contains the validation error.
 	ID *string `locationName:"id" type:"string"`
 
-	metadataValidationError `json:"-", xml:"-"`
+	metadataValidationError `json:"-" xml:"-"`
 }
 
 type metadataValidationError struct {
@@ -1620,7 +1620,7 @@ type ValidationWarning struct {
 	// A description of the validation warning.
 	Warnings []*string `locationName:"warnings" type:"list"`
 
-	metadataValidationWarning `json:"-", xml:"-"`
+	metadataValidationWarning `json:"-" xml:"-"`
 }
 
 type metadataValidationWarning struct {

--- a/service/directconnect/api.go
+++ b/service/directconnect/api.go
@@ -762,7 +762,7 @@ type AllocateConnectionOnInterconnectInput struct {
 	// Default: None
 	VLAN *int64 `locationName:"vlan" type:"integer" required:"true"`
 
-	metadataAllocateConnectionOnInterconnectInput `json:"-", xml:"-"`
+	metadataAllocateConnectionOnInterconnectInput `json:"-" xml:"-"`
 }
 
 type metadataAllocateConnectionOnInterconnectInput struct {
@@ -786,7 +786,7 @@ type AllocatePrivateVirtualInterfaceInput struct {
 	// Default: None
 	OwnerAccount *string `locationName:"ownerAccount" type:"string" required:"true"`
 
-	metadataAllocatePrivateVirtualInterfaceInput `json:"-", xml:"-"`
+	metadataAllocatePrivateVirtualInterfaceInput `json:"-" xml:"-"`
 }
 
 type metadataAllocatePrivateVirtualInterfaceInput struct {
@@ -810,7 +810,7 @@ type AllocatePublicVirtualInterfaceInput struct {
 	// Default: None
 	OwnerAccount *string `locationName:"ownerAccount" type:"string" required:"true"`
 
-	metadataAllocatePublicVirtualInterfaceInput `json:"-", xml:"-"`
+	metadataAllocatePublicVirtualInterfaceInput `json:"-" xml:"-"`
 }
 
 type metadataAllocatePublicVirtualInterfaceInput struct {
@@ -826,7 +826,7 @@ type ConfirmConnectionInput struct {
 	// Default: None
 	ConnectionID *string `locationName:"connectionId" type:"string" required:"true"`
 
-	metadataConfirmConnectionInput `json:"-", xml:"-"`
+	metadataConfirmConnectionInput `json:"-" xml:"-"`
 }
 
 type metadataConfirmConnectionInput struct {
@@ -847,7 +847,7 @@ type ConfirmConnectionOutput struct {
 	// the 'Rejected' state if it is deleted by the end customer.
 	ConnectionState *string `locationName:"connectionState" type:"string"`
 
-	metadataConfirmConnectionOutput `json:"-", xml:"-"`
+	metadataConfirmConnectionOutput `json:"-" xml:"-"`
 }
 
 type metadataConfirmConnectionOutput struct {
@@ -872,7 +872,7 @@ type ConfirmPrivateVirtualInterfaceInput struct {
 	// Default: None
 	VirtualInterfaceID *string `locationName:"virtualInterfaceId" type:"string" required:"true"`
 
-	metadataConfirmPrivateVirtualInterfaceInput `json:"-", xml:"-"`
+	metadataConfirmPrivateVirtualInterfaceInput `json:"-" xml:"-"`
 }
 
 type metadataConfirmPrivateVirtualInterfaceInput struct {
@@ -899,7 +899,7 @@ type ConfirmPrivateVirtualInterfaceOutput struct {
 	// the 'Rejected' state.
 	VirtualInterfaceState *string `locationName:"virtualInterfaceState" type:"string"`
 
-	metadataConfirmPrivateVirtualInterfaceOutput `json:"-", xml:"-"`
+	metadataConfirmPrivateVirtualInterfaceOutput `json:"-" xml:"-"`
 }
 
 type metadataConfirmPrivateVirtualInterfaceOutput struct {
@@ -915,7 +915,7 @@ type ConfirmPublicVirtualInterfaceInput struct {
 	// Default: None
 	VirtualInterfaceID *string `locationName:"virtualInterfaceId" type:"string" required:"true"`
 
-	metadataConfirmPublicVirtualInterfaceInput `json:"-", xml:"-"`
+	metadataConfirmPublicVirtualInterfaceInput `json:"-" xml:"-"`
 }
 
 type metadataConfirmPublicVirtualInterfaceInput struct {
@@ -942,7 +942,7 @@ type ConfirmPublicVirtualInterfaceOutput struct {
 	// the 'Rejected' state.
 	VirtualInterfaceState *string `locationName:"virtualInterfaceState" type:"string"`
 
-	metadataConfirmPublicVirtualInterfaceOutput `json:"-", xml:"-"`
+	metadataConfirmPublicVirtualInterfaceOutput `json:"-" xml:"-"`
 }
 
 type metadataConfirmPublicVirtualInterfaceOutput struct {
@@ -1008,7 +1008,7 @@ type Connection struct {
 	// Example: 101
 	VLAN *int64 `locationName:"vlan" type:"integer"`
 
-	metadataConnection `json:"-", xml:"-"`
+	metadataConnection `json:"-" xml:"-"`
 }
 
 type metadataConnection struct {
@@ -1020,7 +1020,7 @@ type Connections struct {
 	// A list of connections.
 	Connections []*Connection `locationName:"connections" type:"list"`
 
-	metadataConnections `json:"-", xml:"-"`
+	metadataConnections `json:"-" xml:"-"`
 }
 
 type metadataConnections struct {
@@ -1050,7 +1050,7 @@ type CreateConnectionInput struct {
 	// Default: None
 	Location *string `locationName:"location" type:"string" required:"true"`
 
-	metadataCreateConnectionInput `json:"-", xml:"-"`
+	metadataCreateConnectionInput `json:"-" xml:"-"`
 }
 
 type metadataCreateConnectionInput struct {
@@ -1082,7 +1082,7 @@ type CreateInterconnectInput struct {
 	// Default: None
 	Location *string `locationName:"location" type:"string" required:"true"`
 
-	metadataCreateInterconnectInput `json:"-", xml:"-"`
+	metadataCreateInterconnectInput `json:"-" xml:"-"`
 }
 
 type metadataCreateInterconnectInput struct {
@@ -1103,7 +1103,7 @@ type CreatePrivateVirtualInterfaceInput struct {
 	// Default: None
 	NewPrivateVirtualInterface *NewPrivateVirtualInterface `locationName:"newPrivateVirtualInterface" type:"structure" required:"true"`
 
-	metadataCreatePrivateVirtualInterfaceInput `json:"-", xml:"-"`
+	metadataCreatePrivateVirtualInterfaceInput `json:"-" xml:"-"`
 }
 
 type metadataCreatePrivateVirtualInterfaceInput struct {
@@ -1124,7 +1124,7 @@ type CreatePublicVirtualInterfaceInput struct {
 	// Default: None
 	NewPublicVirtualInterface *NewPublicVirtualInterface `locationName:"newPublicVirtualInterface" type:"structure" required:"true"`
 
-	metadataCreatePublicVirtualInterfaceInput `json:"-", xml:"-"`
+	metadataCreatePublicVirtualInterfaceInput `json:"-" xml:"-"`
 }
 
 type metadataCreatePublicVirtualInterfaceInput struct {
@@ -1140,7 +1140,7 @@ type DeleteConnectionInput struct {
 	// Default: None
 	ConnectionID *string `locationName:"connectionId" type:"string" required:"true"`
 
-	metadataDeleteConnectionInput `json:"-", xml:"-"`
+	metadataDeleteConnectionInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteConnectionInput struct {
@@ -1154,7 +1154,7 @@ type DeleteInterconnectInput struct {
 	// Example: dxcon-abc123
 	InterconnectID *string `locationName:"interconnectId" type:"string" required:"true"`
 
-	metadataDeleteInterconnectInput `json:"-", xml:"-"`
+	metadataDeleteInterconnectInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteInterconnectInput struct {
@@ -1171,7 +1171,7 @@ type DeleteInterconnectOutput struct {
 	// has been deleted.
 	InterconnectState *string `locationName:"interconnectState" type:"string"`
 
-	metadataDeleteInterconnectOutput `json:"-", xml:"-"`
+	metadataDeleteInterconnectOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteInterconnectOutput struct {
@@ -1187,7 +1187,7 @@ type DeleteVirtualInterfaceInput struct {
 	// Default: None
 	VirtualInterfaceID *string `locationName:"virtualInterfaceId" type:"string" required:"true"`
 
-	metadataDeleteVirtualInterfaceInput `json:"-", xml:"-"`
+	metadataDeleteVirtualInterfaceInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteVirtualInterfaceInput struct {
@@ -1214,7 +1214,7 @@ type DeleteVirtualInterfaceOutput struct {
 	// the 'Rejected' state.
 	VirtualInterfaceState *string `locationName:"virtualInterfaceState" type:"string"`
 
-	metadataDeleteVirtualInterfaceOutput `json:"-", xml:"-"`
+	metadataDeleteVirtualInterfaceOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteVirtualInterfaceOutput struct {
@@ -1230,7 +1230,7 @@ type DescribeConnectionsInput struct {
 	// Default: None
 	ConnectionID *string `locationName:"connectionId" type:"string"`
 
-	metadataDescribeConnectionsInput `json:"-", xml:"-"`
+	metadataDescribeConnectionsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeConnectionsInput struct {
@@ -1246,7 +1246,7 @@ type DescribeConnectionsOnInterconnectInput struct {
 	// Default: None
 	InterconnectID *string `locationName:"interconnectId" type:"string" required:"true"`
 
-	metadataDescribeConnectionsOnInterconnectInput `json:"-", xml:"-"`
+	metadataDescribeConnectionsOnInterconnectInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeConnectionsOnInterconnectInput struct {
@@ -1260,7 +1260,7 @@ type DescribeInterconnectsInput struct {
 	// Example: dxcon-abc123
 	InterconnectID *string `locationName:"interconnectId" type:"string"`
 
-	metadataDescribeInterconnectsInput `json:"-", xml:"-"`
+	metadataDescribeInterconnectsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeInterconnectsInput struct {
@@ -1272,7 +1272,7 @@ type DescribeInterconnectsOutput struct {
 	// A list of interconnects.
 	Interconnects []*Interconnect `locationName:"interconnects" type:"list"`
 
-	metadataDescribeInterconnectsOutput `json:"-", xml:"-"`
+	metadataDescribeInterconnectsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeInterconnectsOutput struct {
@@ -1280,7 +1280,7 @@ type metadataDescribeInterconnectsOutput struct {
 }
 
 type DescribeLocationsInput struct {
-	metadataDescribeLocationsInput `json:"-", xml:"-"`
+	metadataDescribeLocationsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeLocationsInput struct {
@@ -1290,7 +1290,7 @@ type metadataDescribeLocationsInput struct {
 type DescribeLocationsOutput struct {
 	Locations []*Location `locationName:"locations" type:"list"`
 
-	metadataDescribeLocationsOutput `json:"-", xml:"-"`
+	metadataDescribeLocationsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeLocationsOutput struct {
@@ -1298,7 +1298,7 @@ type metadataDescribeLocationsOutput struct {
 }
 
 type DescribeVirtualGatewaysInput struct {
-	metadataDescribeVirtualGatewaysInput `json:"-", xml:"-"`
+	metadataDescribeVirtualGatewaysInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeVirtualGatewaysInput struct {
@@ -1310,7 +1310,7 @@ type DescribeVirtualGatewaysOutput struct {
 	// A list of virtual private gateways.
 	VirtualGateways []*VirtualGateway `locationName:"virtualGateways" type:"list"`
 
-	metadataDescribeVirtualGatewaysOutput `json:"-", xml:"-"`
+	metadataDescribeVirtualGatewaysOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeVirtualGatewaysOutput struct {
@@ -1333,7 +1333,7 @@ type DescribeVirtualInterfacesInput struct {
 	// Default: None
 	VirtualInterfaceID *string `locationName:"virtualInterfaceId" type:"string"`
 
-	metadataDescribeVirtualInterfacesInput `json:"-", xml:"-"`
+	metadataDescribeVirtualInterfacesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeVirtualInterfacesInput struct {
@@ -1345,7 +1345,7 @@ type DescribeVirtualInterfacesOutput struct {
 	// A list of virtual interfaces.
 	VirtualInterfaces []*VirtualInterface `locationName:"virtualInterfaces" type:"list"`
 
-	metadataDescribeVirtualInterfacesOutput `json:"-", xml:"-"`
+	metadataDescribeVirtualInterfacesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeVirtualInterfacesOutput struct {
@@ -1404,7 +1404,7 @@ type Interconnect struct {
 	// Default: None
 	Region *string `locationName:"region" type:"string"`
 
-	metadataInterconnect `json:"-", xml:"-"`
+	metadataInterconnect `json:"-" xml:"-"`
 }
 
 type metadataInterconnect struct {
@@ -1421,7 +1421,7 @@ type Location struct {
 	// partner name and the physical site of the lit building.
 	LocationName *string `locationName:"locationName" type:"string"`
 
-	metadataLocation `json:"-", xml:"-"`
+	metadataLocation `json:"-" xml:"-"`
 }
 
 type metadataLocation struct {
@@ -1466,7 +1466,7 @@ type NewPrivateVirtualInterface struct {
 	// Example: "My VPC"
 	VirtualInterfaceName *string `locationName:"virtualInterfaceName" type:"string" required:"true"`
 
-	metadataNewPrivateVirtualInterface `json:"-", xml:"-"`
+	metadataNewPrivateVirtualInterface `json:"-" xml:"-"`
 }
 
 type metadataNewPrivateVirtualInterface struct {
@@ -1506,7 +1506,7 @@ type NewPrivateVirtualInterfaceAllocation struct {
 	// Example: "My VPC"
 	VirtualInterfaceName *string `locationName:"virtualInterfaceName" type:"string" required:"true"`
 
-	metadataNewPrivateVirtualInterfaceAllocation `json:"-", xml:"-"`
+	metadataNewPrivateVirtualInterfaceAllocation `json:"-" xml:"-"`
 }
 
 type metadataNewPrivateVirtualInterfaceAllocation struct {
@@ -1549,7 +1549,7 @@ type NewPublicVirtualInterface struct {
 	// Example: "My VPC"
 	VirtualInterfaceName *string `locationName:"virtualInterfaceName" type:"string" required:"true"`
 
-	metadataNewPublicVirtualInterface `json:"-", xml:"-"`
+	metadataNewPublicVirtualInterface `json:"-" xml:"-"`
 }
 
 type metadataNewPublicVirtualInterface struct {
@@ -1593,7 +1593,7 @@ type NewPublicVirtualInterfaceAllocation struct {
 	// Example: "My VPC"
 	VirtualInterfaceName *string `locationName:"virtualInterfaceName" type:"string" required:"true"`
 
-	metadataNewPublicVirtualInterfaceAllocation `json:"-", xml:"-"`
+	metadataNewPublicVirtualInterfaceAllocation `json:"-" xml:"-"`
 }
 
 type metadataNewPublicVirtualInterfaceAllocation struct {
@@ -1609,7 +1609,7 @@ type RouteFilterPrefix struct {
 	// Example: 10.10.10.0/24,10.10.11.0/24
 	CIDR *string `locationName:"cidr" type:"string"`
 
-	metadataRouteFilterPrefix `json:"-", xml:"-"`
+	metadataRouteFilterPrefix `json:"-" xml:"-"`
 }
 
 type metadataRouteFilterPrefix struct {
@@ -1635,7 +1635,7 @@ type VirtualGateway struct {
 	// over this gateway.
 	VirtualGatewayState *string `locationName:"virtualGatewayState" type:"string"`
 
-	metadataVirtualGateway `json:"-", xml:"-"`
+	metadataVirtualGateway `json:"-" xml:"-"`
 }
 
 type metadataVirtualGateway struct {
@@ -1735,7 +1735,7 @@ type VirtualInterface struct {
 	// so on.)
 	VirtualInterfaceType *string `locationName:"virtualInterfaceType" type:"string"`
 
-	metadataVirtualInterface `json:"-", xml:"-"`
+	metadataVirtualInterface `json:"-" xml:"-"`
 }
 
 type metadataVirtualInterface struct {

--- a/service/dynamodb/api.go
+++ b/service/dynamodb/api.go
@@ -705,7 +705,7 @@ type AttributeDefinition struct {
 	// The data type for the attribute.
 	AttributeType *string `type:"string" required:"true"`
 
-	metadataAttributeDefinition `json:"-", xml:"-"`
+	metadataAttributeDefinition `json:"-" xml:"-"`
 }
 
 type metadataAttributeDefinition struct {
@@ -750,7 +750,7 @@ type AttributeValue struct {
 	// A String Set data type.
 	SS []*string `type:"list"`
 
-	metadataAttributeValue `json:"-", xml:"-"`
+	metadataAttributeValue `json:"-" xml:"-"`
 }
 
 type metadataAttributeValue struct {
@@ -841,7 +841,7 @@ type AttributeValueUpdate struct {
 	// attribute is a set; duplicate values are not allowed.
 	Value *AttributeValue `type:"structure"`
 
-	metadataAttributeValueUpdate `json:"-", xml:"-"`
+	metadataAttributeValueUpdate `json:"-" xml:"-"`
 }
 
 type metadataAttributeValueUpdate struct {
@@ -879,7 +879,7 @@ type BatchGetItemInput struct {
 	// in the response.
 	ReturnConsumedCapacity *string `type:"string"`
 
-	metadataBatchGetItemInput `json:"-", xml:"-"`
+	metadataBatchGetItemInput `json:"-" xml:"-"`
 }
 
 type metadataBatchGetItemInput struct {
@@ -924,7 +924,7 @@ type BatchGetItemOutput struct {
 	// UnprocessedKeys map.
 	UnprocessedKeys *map[string]*KeysAndAttributes `type:"map"`
 
-	metadataBatchGetItemOutput `json:"-", xml:"-"`
+	metadataBatchGetItemOutput `json:"-" xml:"-"`
 }
 
 type metadataBatchGetItemOutput struct {
@@ -972,7 +972,7 @@ type BatchWriteItemInput struct {
 	// in the response. If set to NONE (the default), no statistics are returned.
 	ReturnItemCollectionMetrics *string `type:"string"`
 
-	metadataBatchWriteItemInput `json:"-", xml:"-"`
+	metadataBatchWriteItemInput `json:"-" xml:"-"`
 }
 
 type metadataBatchWriteItemInput struct {
@@ -1042,7 +1042,7 @@ type BatchWriteItemOutput struct {
 	// empty UnprocessedItems map.
 	UnprocessedItems *map[string][]*WriteRequest `type:"map"`
 
-	metadataBatchWriteItemOutput `json:"-", xml:"-"`
+	metadataBatchWriteItemOutput `json:"-" xml:"-"`
 }
 
 type metadataBatchWriteItemOutput struct {
@@ -1055,7 +1055,7 @@ type Capacity struct {
 	// The total number of capacity units consumed on a table or an index.
 	CapacityUnits *float64 `type:"double"`
 
-	metadataCapacity `json:"-", xml:"-"`
+	metadataCapacity `json:"-" xml:"-"`
 }
 
 type metadataCapacity struct {
@@ -1223,7 +1223,7 @@ type Condition struct {
 	// in the Amazon DynamoDB Developer Guide.
 	ComparisonOperator *string `type:"string" required:"true"`
 
-	metadataCondition `json:"-", xml:"-"`
+	metadataCondition `json:"-" xml:"-"`
 }
 
 type metadataCondition struct {
@@ -1252,7 +1252,7 @@ type ConsumedCapacity struct {
 	// The name of the table that was affected by the operation.
 	TableName *string `type:"string"`
 
-	metadataConsumedCapacity `json:"-", xml:"-"`
+	metadataConsumedCapacity `json:"-" xml:"-"`
 }
 
 type metadataConsumedCapacity struct {
@@ -1280,7 +1280,7 @@ type CreateGlobalSecondaryIndexAction struct {
 	// in the Amazon DynamoDB Developer Guide.
 	ProvisionedThroughput *ProvisionedThroughput `type:"structure" required:"true"`
 
-	metadataCreateGlobalSecondaryIndexAction `json:"-", xml:"-"`
+	metadataCreateGlobalSecondaryIndexAction `json:"-" xml:"-"`
 }
 
 type metadataCreateGlobalSecondaryIndexAction struct {
@@ -1391,7 +1391,7 @@ type CreateTableInput struct {
 	// The name of the table to create.
 	TableName *string `type:"string" required:"true"`
 
-	metadataCreateTableInput `json:"-", xml:"-"`
+	metadataCreateTableInput `json:"-" xml:"-"`
 }
 
 type metadataCreateTableInput struct {
@@ -1403,7 +1403,7 @@ type CreateTableOutput struct {
 	// Represents the properties of a table.
 	TableDescription *TableDescription `type:"structure"`
 
-	metadataCreateTableOutput `json:"-", xml:"-"`
+	metadataCreateTableOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateTableOutput struct {
@@ -1415,7 +1415,7 @@ type DeleteGlobalSecondaryIndexAction struct {
 	// The name of the global secondary index to be deleted.
 	IndexName *string `type:"string" required:"true"`
 
-	metadataDeleteGlobalSecondaryIndexAction `json:"-", xml:"-"`
+	metadataDeleteGlobalSecondaryIndexAction `json:"-" xml:"-"`
 }
 
 type metadataDeleteGlobalSecondaryIndexAction struct {
@@ -1746,7 +1746,7 @@ type DeleteItemInput struct {
 	// The name of the table from which to delete the item.
 	TableName *string `type:"string" required:"true"`
 
-	metadataDeleteItemInput `json:"-", xml:"-"`
+	metadataDeleteItemInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteItemInput struct {
@@ -1789,7 +1789,7 @@ type DeleteItemOutput struct {
 	// precision or accuracy of the estimate.
 	ItemCollectionMetrics *ItemCollectionMetrics `type:"structure"`
 
-	metadataDeleteItemOutput `json:"-", xml:"-"`
+	metadataDeleteItemOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteItemOutput struct {
@@ -1803,7 +1803,7 @@ type DeleteRequest struct {
 	// specified, and their data types must match those of the table's key schema.
 	Key *map[string]*AttributeValue `type:"map" required:"true"`
 
-	metadataDeleteRequest `json:"-", xml:"-"`
+	metadataDeleteRequest `json:"-" xml:"-"`
 }
 
 type metadataDeleteRequest struct {
@@ -1815,7 +1815,7 @@ type DeleteTableInput struct {
 	// The name of the table to delete.
 	TableName *string `type:"string" required:"true"`
 
-	metadataDeleteTableInput `json:"-", xml:"-"`
+	metadataDeleteTableInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteTableInput struct {
@@ -1827,7 +1827,7 @@ type DeleteTableOutput struct {
 	// Represents the properties of a table.
 	TableDescription *TableDescription `type:"structure"`
 
-	metadataDeleteTableOutput `json:"-", xml:"-"`
+	metadataDeleteTableOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteTableOutput struct {
@@ -1839,7 +1839,7 @@ type DescribeTableInput struct {
 	// The name of the table to describe.
 	TableName *string `type:"string" required:"true"`
 
-	metadataDescribeTableInput `json:"-", xml:"-"`
+	metadataDescribeTableInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeTableInput struct {
@@ -1851,7 +1851,7 @@ type DescribeTableOutput struct {
 	// Represents the properties of a table.
 	Table *TableDescription `type:"structure"`
 
-	metadataDescribeTableOutput `json:"-", xml:"-"`
+	metadataDescribeTableOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeTableOutput struct {
@@ -2058,7 +2058,7 @@ type ExpectedAttributeValue struct {
 	// attribute is a set; duplicate values are not allowed.
 	Value *AttributeValue `type:"structure"`
 
-	metadataExpectedAttributeValue `json:"-", xml:"-"`
+	metadataExpectedAttributeValue `json:"-" xml:"-"`
 }
 
 type metadataExpectedAttributeValue struct {
@@ -2153,7 +2153,7 @@ type GetItemInput struct {
 	// The name of the table containing the requested item.
 	TableName *string `type:"string" required:"true"`
 
-	metadataGetItemInput `json:"-", xml:"-"`
+	metadataGetItemInput `json:"-" xml:"-"`
 }
 
 type metadataGetItemInput struct {
@@ -2173,7 +2173,7 @@ type GetItemOutput struct {
 	// A map of attribute names to AttributeValue objects, as specified by AttributesToGet.
 	Item *map[string]*AttributeValue `type:"map"`
 
-	metadataGetItemOutput `json:"-", xml:"-"`
+	metadataGetItemOutput `json:"-" xml:"-"`
 }
 
 type metadataGetItemOutput struct {
@@ -2203,7 +2203,7 @@ type GlobalSecondaryIndex struct {
 	// in the Amazon DynamoDB Developer Guide.
 	ProvisionedThroughput *ProvisionedThroughput `type:"structure" required:"true"`
 
-	metadataGlobalSecondaryIndex `json:"-", xml:"-"`
+	metadataGlobalSecondaryIndex `json:"-" xml:"-"`
 }
 
 type metadataGlobalSecondaryIndex struct {
@@ -2259,7 +2259,7 @@ type GlobalSecondaryIndexDescription struct {
 	// of read and write capacity units, along with data about increases and decreases.
 	ProvisionedThroughput *ProvisionedThroughputDescription `type:"structure"`
 
-	metadataGlobalSecondaryIndexDescription `json:"-", xml:"-"`
+	metadataGlobalSecondaryIndexDescription `json:"-" xml:"-"`
 }
 
 type metadataGlobalSecondaryIndexDescription struct {
@@ -2295,7 +2295,7 @@ type GlobalSecondaryIndexUpdate struct {
 	// throughput settings to be applied to that index.
 	Update *UpdateGlobalSecondaryIndexAction `type:"structure"`
 
-	metadataGlobalSecondaryIndexUpdate `json:"-", xml:"-"`
+	metadataGlobalSecondaryIndexUpdate `json:"-" xml:"-"`
 }
 
 type metadataGlobalSecondaryIndexUpdate struct {
@@ -2322,7 +2322,7 @@ type ItemCollectionMetrics struct {
 	// precision or accuracy of the estimate.
 	SizeEstimateRangeGB []*float64 `type:"list"`
 
-	metadataItemCollectionMetrics `json:"-", xml:"-"`
+	metadataItemCollectionMetrics `json:"-" xml:"-"`
 }
 
 type metadataItemCollectionMetrics struct {
@@ -2343,7 +2343,7 @@ type KeySchemaElement struct {
 	// The attribute data, consisting of the data type and the attribute value itself.
 	KeyType *string `type:"string" required:"true"`
 
-	metadataKeySchemaElement `json:"-", xml:"-"`
+	metadataKeySchemaElement `json:"-" xml:"-"`
 }
 
 type metadataKeySchemaElement struct {
@@ -2419,7 +2419,7 @@ type KeysAndAttributes struct {
 	// in the Amazon DynamoDB Developer Guide.
 	ProjectionExpression *string `type:"string"`
 
-	metadataKeysAndAttributes `json:"-", xml:"-"`
+	metadataKeysAndAttributes `json:"-" xml:"-"`
 }
 
 type metadataKeysAndAttributes struct {
@@ -2437,7 +2437,7 @@ type ListTablesInput struct {
 	// the limit is 100.
 	Limit *int64 `type:"integer"`
 
-	metadataListTablesInput `json:"-", xml:"-"`
+	metadataListTablesInput `json:"-" xml:"-"`
 }
 
 type metadataListTablesInput struct {
@@ -2462,7 +2462,7 @@ type ListTablesOutput struct {
 	// and obtain the next page of results.
 	TableNames []*string `type:"list"`
 
-	metadataListTablesOutput `json:"-", xml:"-"`
+	metadataListTablesOutput `json:"-" xml:"-"`
 }
 
 type metadataListTablesOutput struct {
@@ -2484,7 +2484,7 @@ type LocalSecondaryIndex struct {
 	// attributes, which are automatically projected.
 	Projection *Projection `type:"structure" required:"true"`
 
-	metadataLocalSecondaryIndex `json:"-", xml:"-"`
+	metadataLocalSecondaryIndex `json:"-" xml:"-"`
 }
 
 type metadataLocalSecondaryIndex struct {
@@ -2514,7 +2514,7 @@ type LocalSecondaryIndexDescription struct {
 	// attributes, which are automatically projected.
 	Projection *Projection `type:"structure"`
 
-	metadataLocalSecondaryIndexDescription `json:"-", xml:"-"`
+	metadataLocalSecondaryIndexDescription `json:"-" xml:"-"`
 }
 
 type metadataLocalSecondaryIndexDescription struct {
@@ -2543,7 +2543,7 @@ type Projection struct {
 	//   ALL - All of the table attributes are projected into the index.
 	ProjectionType *string `type:"string"`
 
-	metadataProjection `json:"-", xml:"-"`
+	metadataProjection `json:"-" xml:"-"`
 }
 
 type metadataProjection struct {
@@ -2569,7 +2569,7 @@ type ProvisionedThroughput struct {
 	// in the Amazon DynamoDB Developer Guide.
 	WriteCapacityUnits *int64 `type:"long" required:"true"`
 
-	metadataProvisionedThroughput `json:"-", xml:"-"`
+	metadataProvisionedThroughput `json:"-" xml:"-"`
 }
 
 type metadataProvisionedThroughput struct {
@@ -2601,7 +2601,7 @@ type ProvisionedThroughputDescription struct {
 	// a ThrottlingException.
 	WriteCapacityUnits *int64 `type:"long"`
 
-	metadataProvisionedThroughputDescription `json:"-", xml:"-"`
+	metadataProvisionedThroughputDescription `json:"-" xml:"-"`
 }
 
 type metadataProvisionedThroughputDescription struct {
@@ -2944,7 +2944,7 @@ type PutItemInput struct {
 	// The name of the table to contain the item.
 	TableName *string `type:"string" required:"true"`
 
-	metadataPutItemInput `json:"-", xml:"-"`
+	metadataPutItemInput `json:"-" xml:"-"`
 }
 
 type metadataPutItemInput struct {
@@ -2987,7 +2987,7 @@ type PutItemOutput struct {
 	// precision or accuracy of the estimate.
 	ItemCollectionMetrics *ItemCollectionMetrics `type:"structure"`
 
-	metadataPutItemOutput `json:"-", xml:"-"`
+	metadataPutItemOutput `json:"-" xml:"-"`
 }
 
 type metadataPutItemOutput struct {
@@ -3003,7 +3003,7 @@ type PutRequest struct {
 	// key schema for the table, their types must match the index key schema.
 	Item *map[string]*AttributeValue `type:"map" required:"true"`
 
-	metadataPutRequest `json:"-", xml:"-"`
+	metadataPutRequest `json:"-" xml:"-"`
 }
 
 type metadataPutRequest struct {
@@ -3386,7 +3386,7 @@ type QueryInput struct {
 	// The name of the table containing the requested items.
 	TableName *string `type:"string" required:"true"`
 
-	metadataQueryInput `json:"-", xml:"-"`
+	metadataQueryInput `json:"-" xml:"-"`
 }
 
 type metadataQueryInput struct {
@@ -3438,7 +3438,7 @@ type QueryOutput struct {
 	// as Count.
 	ScannedCount *int64 `type:"integer"`
 
-	metadataQueryOutput `json:"-", xml:"-"`
+	metadataQueryOutput `json:"-" xml:"-"`
 }
 
 type metadataQueryOutput struct {
@@ -3696,7 +3696,7 @@ type ScanInput struct {
 	// If you specify TotalSegments, you must also specify Segment.
 	TotalSegments *int64 `type:"integer"`
 
-	metadataScanInput `json:"-", xml:"-"`
+	metadataScanInput `json:"-" xml:"-"`
 }
 
 type metadataScanInput struct {
@@ -3747,7 +3747,7 @@ type ScanOutput struct {
 	// as Count.
 	ScannedCount *int64 `type:"integer"`
 
-	metadataScanOutput `json:"-", xml:"-"`
+	metadataScanOutput `json:"-" xml:"-"`
 }
 
 type metadataScanOutput struct {
@@ -3912,7 +3912,7 @@ type TableDescription struct {
 	//   ACTIVE - The table is ready for use.
 	TableStatus *string `type:"string"`
 
-	metadataTableDescription `json:"-", xml:"-"`
+	metadataTableDescription `json:"-" xml:"-"`
 }
 
 type metadataTableDescription struct {
@@ -3933,7 +3933,7 @@ type UpdateGlobalSecondaryIndexAction struct {
 	// in the Amazon DynamoDB Developer Guide.
 	ProvisionedThroughput *ProvisionedThroughput `type:"structure" required:"true"`
 
-	metadataUpdateGlobalSecondaryIndexAction `json:"-", xml:"-"`
+	metadataUpdateGlobalSecondaryIndexAction `json:"-" xml:"-"`
 }
 
 type metadataUpdateGlobalSecondaryIndexAction struct {
@@ -4433,7 +4433,7 @@ type UpdateItemInput struct {
 	// in the Amazon DynamoDB Developer Guide.
 	UpdateExpression *string `type:"string"`
 
-	metadataUpdateItemInput `json:"-", xml:"-"`
+	metadataUpdateItemInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateItemInput struct {
@@ -4461,7 +4461,7 @@ type UpdateItemOutput struct {
 	// returned in the response.
 	ItemCollectionMetrics *ItemCollectionMetrics `type:"structure"`
 
-	metadataUpdateItemOutput `json:"-", xml:"-"`
+	metadataUpdateItemOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateItemOutput struct {
@@ -4497,7 +4497,7 @@ type UpdateTableInput struct {
 	// The name of the table to be updated.
 	TableName *string `type:"string" required:"true"`
 
-	metadataUpdateTableInput `json:"-", xml:"-"`
+	metadataUpdateTableInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateTableInput struct {
@@ -4509,7 +4509,7 @@ type UpdateTableOutput struct {
 	// Represents the properties of a table.
 	TableDescription *TableDescription `type:"structure"`
 
-	metadataUpdateTableOutput `json:"-", xml:"-"`
+	metadataUpdateTableOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateTableOutput struct {
@@ -4527,7 +4527,7 @@ type WriteRequest struct {
 	// A request to perform a PutItem operation.
 	PutRequest *PutRequest `type:"structure"`
 
-	metadataWriteRequest `json:"-", xml:"-"`
+	metadataWriteRequest `json:"-" xml:"-"`
 }
 
 type metadataWriteRequest struct {

--- a/service/ec2/api.go
+++ b/service/ec2/api.go
@@ -6688,7 +6688,7 @@ type AcceptVPCPeeringConnectionInput struct {
 	// The ID of the VPC peering connection.
 	VPCPeeringConnectionID *string `locationName:"vpcPeeringConnectionId" type:"string"`
 
-	metadataAcceptVPCPeeringConnectionInput `json:"-", xml:"-"`
+	metadataAcceptVPCPeeringConnectionInput `json:"-" xml:"-"`
 }
 
 type metadataAcceptVPCPeeringConnectionInput struct {
@@ -6699,7 +6699,7 @@ type AcceptVPCPeeringConnectionOutput struct {
 	// Information about the VPC peering connection.
 	VPCPeeringConnection *VPCPeeringConnection `locationName:"vpcPeeringConnection" type:"structure"`
 
-	metadataAcceptVPCPeeringConnectionOutput `json:"-", xml:"-"`
+	metadataAcceptVPCPeeringConnectionOutput `json:"-" xml:"-"`
 }
 
 type metadataAcceptVPCPeeringConnectionOutput struct {
@@ -6714,7 +6714,7 @@ type AccountAttribute struct {
 	// One or more values for the account attribute.
 	AttributeValues []*AccountAttributeValue `locationName:"attributeValueSet" locationNameList:"item" type:"list"`
 
-	metadataAccountAttribute `json:"-", xml:"-"`
+	metadataAccountAttribute `json:"-" xml:"-"`
 }
 
 type metadataAccountAttribute struct {
@@ -6726,7 +6726,7 @@ type AccountAttributeValue struct {
 	// The value of the attribute.
 	AttributeValue *string `locationName:"attributeValue" type:"string"`
 
-	metadataAccountAttributeValue `json:"-", xml:"-"`
+	metadataAccountAttributeValue `json:"-" xml:"-"`
 }
 
 type metadataAccountAttributeValue struct {
@@ -6761,7 +6761,7 @@ type Address struct {
 	// The Elastic IP address.
 	PublicIP *string `locationName:"publicIp" type:"string"`
 
-	metadataAddress `json:"-", xml:"-"`
+	metadataAddress `json:"-" xml:"-"`
 }
 
 type metadataAddress struct {
@@ -6776,7 +6776,7 @@ type AllocateAddressInput struct {
 
 	DryRun *bool `locationName:"dryRun" type:"boolean"`
 
-	metadataAllocateAddressInput `json:"-", xml:"-"`
+	metadataAllocateAddressInput `json:"-" xml:"-"`
 }
 
 type metadataAllocateAddressInput struct {
@@ -6795,7 +6795,7 @@ type AllocateAddressOutput struct {
 	// The Elastic IP address.
 	PublicIP *string `locationName:"publicIp" type:"string"`
 
-	metadataAllocateAddressOutput `json:"-", xml:"-"`
+	metadataAllocateAddressOutput `json:"-" xml:"-"`
 }
 
 type metadataAllocateAddressOutput struct {
@@ -6822,7 +6822,7 @@ type AssignPrivateIPAddressesInput struct {
 	// You can't specify this parameter when also specifying private IP addresses.
 	SecondaryPrivateIPAddressCount *int64 `locationName:"secondaryPrivateIpAddressCount" type:"integer"`
 
-	metadataAssignPrivateIPAddressesInput `json:"-", xml:"-"`
+	metadataAssignPrivateIPAddressesInput `json:"-" xml:"-"`
 }
 
 type metadataAssignPrivateIPAddressesInput struct {
@@ -6830,7 +6830,7 @@ type metadataAssignPrivateIPAddressesInput struct {
 }
 
 type AssignPrivateIPAddressesOutput struct {
-	metadataAssignPrivateIPAddressesOutput `json:"-", xml:"-"`
+	metadataAssignPrivateIPAddressesOutput `json:"-" xml:"-"`
 }
 
 type metadataAssignPrivateIPAddressesOutput struct {
@@ -6868,7 +6868,7 @@ type AssociateAddressInput struct {
 	// The Elastic IP address. This is required for EC2-Classic.
 	PublicIP *string `locationName:"PublicIp" type:"string"`
 
-	metadataAssociateAddressInput `json:"-", xml:"-"`
+	metadataAssociateAddressInput `json:"-" xml:"-"`
 }
 
 type metadataAssociateAddressInput struct {
@@ -6880,7 +6880,7 @@ type AssociateAddressOutput struct {
 	// with an instance.
 	AssociationID *string `locationName:"associationId" type:"string"`
 
-	metadataAssociateAddressOutput `json:"-", xml:"-"`
+	metadataAssociateAddressOutput `json:"-" xml:"-"`
 }
 
 type metadataAssociateAddressOutput struct {
@@ -6897,7 +6897,7 @@ type AssociateDHCPOptionsInput struct {
 	// The ID of the VPC.
 	VPCID *string `locationName:"VpcId" type:"string" required:"true"`
 
-	metadataAssociateDHCPOptionsInput `json:"-", xml:"-"`
+	metadataAssociateDHCPOptionsInput `json:"-" xml:"-"`
 }
 
 type metadataAssociateDHCPOptionsInput struct {
@@ -6905,7 +6905,7 @@ type metadataAssociateDHCPOptionsInput struct {
 }
 
 type AssociateDHCPOptionsOutput struct {
-	metadataAssociateDHCPOptionsOutput `json:"-", xml:"-"`
+	metadataAssociateDHCPOptionsOutput `json:"-" xml:"-"`
 }
 
 type metadataAssociateDHCPOptionsOutput struct {
@@ -6921,7 +6921,7 @@ type AssociateRouteTableInput struct {
 	// The ID of the subnet.
 	SubnetID *string `locationName:"subnetId" type:"string" required:"true"`
 
-	metadataAssociateRouteTableInput `json:"-", xml:"-"`
+	metadataAssociateRouteTableInput `json:"-" xml:"-"`
 }
 
 type metadataAssociateRouteTableInput struct {
@@ -6932,7 +6932,7 @@ type AssociateRouteTableOutput struct {
 	// The route table association ID (needed to disassociate the route table).
 	AssociationID *string `locationName:"associationId" type:"string"`
 
-	metadataAssociateRouteTableOutput `json:"-", xml:"-"`
+	metadataAssociateRouteTableOutput `json:"-" xml:"-"`
 }
 
 type metadataAssociateRouteTableOutput struct {
@@ -6952,7 +6952,7 @@ type AttachClassicLinkVPCInput struct {
 	// The ID of a ClassicLink-enabled VPC.
 	VPCID *string `locationName:"vpcId" type:"string" required:"true"`
 
-	metadataAttachClassicLinkVPCInput `json:"-", xml:"-"`
+	metadataAttachClassicLinkVPCInput `json:"-" xml:"-"`
 }
 
 type metadataAttachClassicLinkVPCInput struct {
@@ -6963,7 +6963,7 @@ type AttachClassicLinkVPCOutput struct {
 	// Returns true if the request succeeds; otherwise, it returns an error.
 	Return *bool `locationName:"return" type:"boolean"`
 
-	metadataAttachClassicLinkVPCOutput `json:"-", xml:"-"`
+	metadataAttachClassicLinkVPCOutput `json:"-" xml:"-"`
 }
 
 type metadataAttachClassicLinkVPCOutput struct {
@@ -6979,7 +6979,7 @@ type AttachInternetGatewayInput struct {
 	// The ID of the VPC.
 	VPCID *string `locationName:"vpcId" type:"string" required:"true"`
 
-	metadataAttachInternetGatewayInput `json:"-", xml:"-"`
+	metadataAttachInternetGatewayInput `json:"-" xml:"-"`
 }
 
 type metadataAttachInternetGatewayInput struct {
@@ -6987,7 +6987,7 @@ type metadataAttachInternetGatewayInput struct {
 }
 
 type AttachInternetGatewayOutput struct {
-	metadataAttachInternetGatewayOutput `json:"-", xml:"-"`
+	metadataAttachInternetGatewayOutput `json:"-" xml:"-"`
 }
 
 type metadataAttachInternetGatewayOutput struct {
@@ -7006,7 +7006,7 @@ type AttachNetworkInterfaceInput struct {
 	// The ID of the network interface.
 	NetworkInterfaceID *string `locationName:"networkInterfaceId" type:"string" required:"true"`
 
-	metadataAttachNetworkInterfaceInput `json:"-", xml:"-"`
+	metadataAttachNetworkInterfaceInput `json:"-" xml:"-"`
 }
 
 type metadataAttachNetworkInterfaceInput struct {
@@ -7017,7 +7017,7 @@ type AttachNetworkInterfaceOutput struct {
 	// The ID of the network interface attachment.
 	AttachmentID *string `locationName:"attachmentId" type:"string"`
 
-	metadataAttachNetworkInterfaceOutput `json:"-", xml:"-"`
+	metadataAttachNetworkInterfaceOutput `json:"-" xml:"-"`
 }
 
 type metadataAttachNetworkInterfaceOutput struct {
@@ -7033,7 +7033,7 @@ type AttachVPNGatewayInput struct {
 	// The ID of the virtual private gateway.
 	VPNGatewayID *string `locationName:"VpnGatewayId" type:"string" required:"true"`
 
-	metadataAttachVPNGatewayInput `json:"-", xml:"-"`
+	metadataAttachVPNGatewayInput `json:"-" xml:"-"`
 }
 
 type metadataAttachVPNGatewayInput struct {
@@ -7044,7 +7044,7 @@ type AttachVPNGatewayOutput struct {
 	// Information about the attachment.
 	VPCAttachment *VPCAttachment `locationName:"attachment" type:"structure"`
 
-	metadataAttachVPNGatewayOutput `json:"-", xml:"-"`
+	metadataAttachVPNGatewayOutput `json:"-" xml:"-"`
 }
 
 type metadataAttachVPNGatewayOutput struct {
@@ -7064,7 +7064,7 @@ type AttachVolumeInput struct {
 	// same Availability Zone.
 	VolumeID *string `locationName:"VolumeId" type:"string" required:"true"`
 
-	metadataAttachVolumeInput `json:"-", xml:"-"`
+	metadataAttachVolumeInput `json:"-" xml:"-"`
 }
 
 type metadataAttachVolumeInput struct {
@@ -7076,7 +7076,7 @@ type AttributeBooleanValue struct {
 	// Valid values are true or false.
 	Value *bool `locationName:"value" type:"boolean"`
 
-	metadataAttributeBooleanValue `json:"-", xml:"-"`
+	metadataAttributeBooleanValue `json:"-" xml:"-"`
 }
 
 type metadataAttributeBooleanValue struct {
@@ -7088,7 +7088,7 @@ type AttributeValue struct {
 	// Valid values are case-sensitive and vary by action.
 	Value *string `locationName:"value" type:"string"`
 
-	metadataAttributeValue `json:"-", xml:"-"`
+	metadataAttributeValue `json:"-" xml:"-"`
 }
 
 type metadataAttributeValue struct {
@@ -7129,7 +7129,7 @@ type AuthorizeSecurityGroupEgressInput struct {
 	// For the ICMP code number, use -1 to specify all ICMP codes for the ICMP type.
 	ToPort *int64 `locationName:"toPort" type:"integer"`
 
-	metadataAuthorizeSecurityGroupEgressInput `json:"-", xml:"-"`
+	metadataAuthorizeSecurityGroupEgressInput `json:"-" xml:"-"`
 }
 
 type metadataAuthorizeSecurityGroupEgressInput struct {
@@ -7137,7 +7137,7 @@ type metadataAuthorizeSecurityGroupEgressInput struct {
 }
 
 type AuthorizeSecurityGroupEgressOutput struct {
-	metadataAuthorizeSecurityGroupEgressOutput `json:"-", xml:"-"`
+	metadataAuthorizeSecurityGroupEgressOutput `json:"-" xml:"-"`
 }
 
 type metadataAuthorizeSecurityGroupEgressOutput struct {
@@ -7181,7 +7181,7 @@ type AuthorizeSecurityGroupIngressInput struct {
 	// For the ICMP code number, use -1 to specify all ICMP codes for the ICMP type.
 	ToPort *int64 `type:"integer"`
 
-	metadataAuthorizeSecurityGroupIngressInput `json:"-", xml:"-"`
+	metadataAuthorizeSecurityGroupIngressInput `json:"-" xml:"-"`
 }
 
 type metadataAuthorizeSecurityGroupIngressInput struct {
@@ -7189,7 +7189,7 @@ type metadataAuthorizeSecurityGroupIngressInput struct {
 }
 
 type AuthorizeSecurityGroupIngressOutput struct {
-	metadataAuthorizeSecurityGroupIngressOutput `json:"-", xml:"-"`
+	metadataAuthorizeSecurityGroupIngressOutput `json:"-" xml:"-"`
 }
 
 type metadataAuthorizeSecurityGroupIngressOutput struct {
@@ -7210,7 +7210,7 @@ type AvailabilityZone struct {
 	// The name of the Availability Zone.
 	ZoneName *string `locationName:"zoneName" type:"string"`
 
-	metadataAvailabilityZone `json:"-", xml:"-"`
+	metadataAvailabilityZone `json:"-" xml:"-"`
 }
 
 type metadataAvailabilityZone struct {
@@ -7222,7 +7222,7 @@ type AvailabilityZoneMessage struct {
 	// The message about the Availability Zone.
 	Message *string `locationName:"message" type:"string"`
 
-	metadataAvailabilityZoneMessage `json:"-", xml:"-"`
+	metadataAvailabilityZoneMessage `json:"-" xml:"-"`
 }
 
 type metadataAvailabilityZoneMessage struct {
@@ -7232,7 +7232,7 @@ type metadataAvailabilityZoneMessage struct {
 type BlobAttributeValue struct {
 	Value []byte `locationName:"value" type:"blob"`
 
-	metadataBlobAttributeValue `json:"-", xml:"-"`
+	metadataBlobAttributeValue `json:"-" xml:"-"`
 }
 
 type metadataBlobAttributeValue struct {
@@ -7264,7 +7264,7 @@ type BlockDeviceMapping struct {
 	// for the AMI.
 	VirtualName *string `locationName:"virtualName" type:"string"`
 
-	metadataBlockDeviceMapping `json:"-", xml:"-"`
+	metadataBlockDeviceMapping `json:"-" xml:"-"`
 }
 
 type metadataBlockDeviceMapping struct {
@@ -7288,7 +7288,7 @@ type BundleInstanceInput struct {
 	// a bucket that belongs to someone else, Amazon EC2 returns an error.
 	Storage *Storage `type:"structure" required:"true"`
 
-	metadataBundleInstanceInput `json:"-", xml:"-"`
+	metadataBundleInstanceInput `json:"-" xml:"-"`
 }
 
 type metadataBundleInstanceInput struct {
@@ -7299,7 +7299,7 @@ type BundleInstanceOutput struct {
 	// Information about the bundle task.
 	BundleTask *BundleTask `locationName:"bundleInstanceTask" type:"structure"`
 
-	metadataBundleInstanceOutput `json:"-", xml:"-"`
+	metadataBundleInstanceOutput `json:"-" xml:"-"`
 }
 
 type metadataBundleInstanceOutput struct {
@@ -7332,7 +7332,7 @@ type BundleTask struct {
 	// The time of the most recent update for the task.
 	UpdateTime *time.Time `locationName:"updateTime" type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataBundleTask `json:"-", xml:"-"`
+	metadataBundleTask `json:"-" xml:"-"`
 }
 
 type metadataBundleTask struct {
@@ -7347,7 +7347,7 @@ type BundleTaskError struct {
 	// The error message.
 	Message *string `locationName:"message" type:"string"`
 
-	metadataBundleTaskError `json:"-", xml:"-"`
+	metadataBundleTaskError `json:"-" xml:"-"`
 }
 
 type metadataBundleTaskError struct {
@@ -7360,7 +7360,7 @@ type CancelBundleTaskInput struct {
 
 	DryRun *bool `locationName:"dryRun" type:"boolean"`
 
-	metadataCancelBundleTaskInput `json:"-", xml:"-"`
+	metadataCancelBundleTaskInput `json:"-" xml:"-"`
 }
 
 type metadataCancelBundleTaskInput struct {
@@ -7371,7 +7371,7 @@ type CancelBundleTaskOutput struct {
 	// The bundle task.
 	BundleTask *BundleTask `locationName:"bundleInstanceTask" type:"structure"`
 
-	metadataCancelBundleTaskOutput `json:"-", xml:"-"`
+	metadataCancelBundleTaskOutput `json:"-" xml:"-"`
 }
 
 type metadataCancelBundleTaskOutput struct {
@@ -7386,7 +7386,7 @@ type CancelConversionTaskInput struct {
 
 	ReasonMessage *string `locationName:"reasonMessage" type:"string"`
 
-	metadataCancelConversionTaskInput `json:"-", xml:"-"`
+	metadataCancelConversionTaskInput `json:"-" xml:"-"`
 }
 
 type metadataCancelConversionTaskInput struct {
@@ -7394,7 +7394,7 @@ type metadataCancelConversionTaskInput struct {
 }
 
 type CancelConversionTaskOutput struct {
-	metadataCancelConversionTaskOutput `json:"-", xml:"-"`
+	metadataCancelConversionTaskOutput `json:"-" xml:"-"`
 }
 
 type metadataCancelConversionTaskOutput struct {
@@ -7405,7 +7405,7 @@ type CancelExportTaskInput struct {
 	// The ID of the export task. This is the ID returned by CreateInstanceExportTask.
 	ExportTaskID *string `locationName:"exportTaskId" type:"string" required:"true"`
 
-	metadataCancelExportTaskInput `json:"-", xml:"-"`
+	metadataCancelExportTaskInput `json:"-" xml:"-"`
 }
 
 type metadataCancelExportTaskInput struct {
@@ -7413,7 +7413,7 @@ type metadataCancelExportTaskInput struct {
 }
 
 type CancelExportTaskOutput struct {
-	metadataCancelExportTaskOutput `json:"-", xml:"-"`
+	metadataCancelExportTaskOutput `json:"-" xml:"-"`
 }
 
 type metadataCancelExportTaskOutput struct {
@@ -7429,7 +7429,7 @@ type CancelImportTaskInput struct {
 	// The ID of the ImportImage or ImportSnapshot task to be cancelled.
 	ImportTaskID *string `locationName:"ImportTaskId" type:"string"`
 
-	metadataCancelImportTaskInput `json:"-", xml:"-"`
+	metadataCancelImportTaskInput `json:"-" xml:"-"`
 }
 
 type metadataCancelImportTaskInput struct {
@@ -7446,7 +7446,7 @@ type CancelImportTaskOutput struct {
 	// The current state of the ImportImage or ImportSnapshot task being canceled.
 	State *string `locationName:"state" type:"string"`
 
-	metadataCancelImportTaskOutput `json:"-", xml:"-"`
+	metadataCancelImportTaskOutput `json:"-" xml:"-"`
 }
 
 type metadataCancelImportTaskOutput struct {
@@ -7457,7 +7457,7 @@ type CancelReservedInstancesListingInput struct {
 	// The ID of the Reserved Instance listing.
 	ReservedInstancesListingID *string `locationName:"reservedInstancesListingId" type:"string" required:"true"`
 
-	metadataCancelReservedInstancesListingInput `json:"-", xml:"-"`
+	metadataCancelReservedInstancesListingInput `json:"-" xml:"-"`
 }
 
 type metadataCancelReservedInstancesListingInput struct {
@@ -7468,7 +7468,7 @@ type CancelReservedInstancesListingOutput struct {
 	// The Reserved Instance listing.
 	ReservedInstancesListings []*ReservedInstancesListing `locationName:"reservedInstancesListingsSet" locationNameList:"item" type:"list"`
 
-	metadataCancelReservedInstancesListingOutput `json:"-", xml:"-"`
+	metadataCancelReservedInstancesListingOutput `json:"-" xml:"-"`
 }
 
 type metadataCancelReservedInstancesListingOutput struct {
@@ -7481,7 +7481,7 @@ type CancelSpotInstanceRequestsInput struct {
 	// One or more Spot Instance request IDs.
 	SpotInstanceRequestIDs []*string `locationName:"SpotInstanceRequestId" locationNameList:"SpotInstanceRequestId" type:"list" required:"true"`
 
-	metadataCancelSpotInstanceRequestsInput `json:"-", xml:"-"`
+	metadataCancelSpotInstanceRequestsInput `json:"-" xml:"-"`
 }
 
 type metadataCancelSpotInstanceRequestsInput struct {
@@ -7492,7 +7492,7 @@ type CancelSpotInstanceRequestsOutput struct {
 	// One or more Spot Instance requests.
 	CancelledSpotInstanceRequests []*CancelledSpotInstanceRequest `locationName:"spotInstanceRequestSet" locationNameList:"item" type:"list"`
 
-	metadataCancelSpotInstanceRequestsOutput `json:"-", xml:"-"`
+	metadataCancelSpotInstanceRequestsOutput `json:"-" xml:"-"`
 }
 
 type metadataCancelSpotInstanceRequestsOutput struct {
@@ -7507,7 +7507,7 @@ type CancelledSpotInstanceRequest struct {
 	// The state of the Spot Instance request.
 	State *string `locationName:"state" type:"string"`
 
-	metadataCancelledSpotInstanceRequest `json:"-", xml:"-"`
+	metadataCancelledSpotInstanceRequest `json:"-" xml:"-"`
 }
 
 type metadataCancelledSpotInstanceRequest struct {
@@ -7528,7 +7528,7 @@ type ClassicLinkInstance struct {
 	// The ID of the VPC.
 	VPCID *string `locationName:"vpcId" type:"string"`
 
-	metadataClassicLinkInstance `json:"-", xml:"-"`
+	metadataClassicLinkInstance `json:"-" xml:"-"`
 }
 
 type metadataClassicLinkInstance struct {
@@ -7549,7 +7549,7 @@ type ClientData struct {
 	// The time that the disk upload starts.
 	UploadStart *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataClientData `json:"-", xml:"-"`
+	metadataClientData `json:"-" xml:"-"`
 }
 
 type metadataClientData struct {
@@ -7565,7 +7565,7 @@ type ConfirmProductInstanceInput struct {
 	// The product code. This must be a product code that you own.
 	ProductCode *string `type:"string" required:"true"`
 
-	metadataConfirmProductInstanceInput `json:"-", xml:"-"`
+	metadataConfirmProductInstanceInput `json:"-" xml:"-"`
 }
 
 type metadataConfirmProductInstanceInput struct {
@@ -7577,7 +7577,7 @@ type ConfirmProductInstanceOutput struct {
 	// code is attached to the instance.
 	OwnerID *string `locationName:"ownerId" type:"string"`
 
-	metadataConfirmProductInstanceOutput `json:"-", xml:"-"`
+	metadataConfirmProductInstanceOutput `json:"-" xml:"-"`
 }
 
 type metadataConfirmProductInstanceOutput struct {
@@ -7609,7 +7609,7 @@ type ConversionTask struct {
 
 	Tags []*Tag `locationName:"tagSet" locationNameList:"item" type:"list"`
 
-	metadataConversionTask `json:"-", xml:"-"`
+	metadataConversionTask `json:"-" xml:"-"`
 }
 
 type metadataConversionTask struct {
@@ -7636,7 +7636,7 @@ type CopyImageInput struct {
 	// The name of the region that contains the AMI to copy.
 	SourceRegion *string `type:"string" required:"true"`
 
-	metadataCopyImageInput `json:"-", xml:"-"`
+	metadataCopyImageInput `json:"-" xml:"-"`
 }
 
 type metadataCopyImageInput struct {
@@ -7647,7 +7647,7 @@ type CopyImageOutput struct {
 	// The ID of the new AMI.
 	ImageID *string `locationName:"imageId" type:"string"`
 
-	metadataCopyImageOutput `json:"-", xml:"-"`
+	metadataCopyImageOutput `json:"-" xml:"-"`
 }
 
 type metadataCopyImageOutput struct {
@@ -7690,7 +7690,7 @@ type CopySnapshotInput struct {
 	// The ID of the Amazon EBS snapshot to copy.
 	SourceSnapshotID *string `locationName:"SourceSnapshotId" type:"string" required:"true"`
 
-	metadataCopySnapshotInput `json:"-", xml:"-"`
+	metadataCopySnapshotInput `json:"-" xml:"-"`
 }
 
 type metadataCopySnapshotInput struct {
@@ -7701,7 +7701,7 @@ type CopySnapshotOutput struct {
 	// The ID of the new snapshot.
 	SnapshotID *string `locationName:"snapshotId" type:"string"`
 
-	metadataCopySnapshotOutput `json:"-", xml:"-"`
+	metadataCopySnapshotOutput `json:"-" xml:"-"`
 }
 
 type metadataCopySnapshotOutput struct {
@@ -7723,7 +7723,7 @@ type CreateCustomerGatewayInput struct {
 	// The type of VPN connection that this customer gateway supports (ipsec.1).
 	Type *string `type:"string" required:"true"`
 
-	metadataCreateCustomerGatewayInput `json:"-", xml:"-"`
+	metadataCreateCustomerGatewayInput `json:"-" xml:"-"`
 }
 
 type metadataCreateCustomerGatewayInput struct {
@@ -7734,7 +7734,7 @@ type CreateCustomerGatewayOutput struct {
 	// Information about the customer gateway.
 	CustomerGateway *CustomerGateway `locationName:"customerGateway" type:"structure"`
 
-	metadataCreateCustomerGatewayOutput `json:"-", xml:"-"`
+	metadataCreateCustomerGatewayOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateCustomerGatewayOutput struct {
@@ -7747,7 +7747,7 @@ type CreateDHCPOptionsInput struct {
 
 	DryRun *bool `locationName:"dryRun" type:"boolean"`
 
-	metadataCreateDHCPOptionsInput `json:"-", xml:"-"`
+	metadataCreateDHCPOptionsInput `json:"-" xml:"-"`
 }
 
 type metadataCreateDHCPOptionsInput struct {
@@ -7758,7 +7758,7 @@ type CreateDHCPOptionsOutput struct {
 	// A set of DHCP options.
 	DHCPOptions *DHCPOptions `locationName:"dhcpOptions" type:"structure"`
 
-	metadataCreateDHCPOptionsOutput `json:"-", xml:"-"`
+	metadataCreateDHCPOptionsOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateDHCPOptionsOutput struct {
@@ -7791,7 +7791,7 @@ type CreateImageInput struct {
 	// system integrity on the created image can't be guaranteed.
 	NoReboot *bool `locationName:"noReboot" type:"boolean"`
 
-	metadataCreateImageInput `json:"-", xml:"-"`
+	metadataCreateImageInput `json:"-" xml:"-"`
 }
 
 type metadataCreateImageInput struct {
@@ -7802,7 +7802,7 @@ type CreateImageOutput struct {
 	// The ID of the new AMI.
 	ImageID *string `locationName:"imageId" type:"string"`
 
-	metadataCreateImageOutput `json:"-", xml:"-"`
+	metadataCreateImageOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateImageOutput struct {
@@ -7822,7 +7822,7 @@ type CreateInstanceExportTaskInput struct {
 	// The target virtualization environment.
 	TargetEnvironment *string `locationName:"targetEnvironment" type:"string"`
 
-	metadataCreateInstanceExportTaskInput `json:"-", xml:"-"`
+	metadataCreateInstanceExportTaskInput `json:"-" xml:"-"`
 }
 
 type metadataCreateInstanceExportTaskInput struct {
@@ -7833,7 +7833,7 @@ type CreateInstanceExportTaskOutput struct {
 	// Describes an export task.
 	ExportTask *ExportTask `locationName:"exportTask" type:"structure"`
 
-	metadataCreateInstanceExportTaskOutput `json:"-", xml:"-"`
+	metadataCreateInstanceExportTaskOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateInstanceExportTaskOutput struct {
@@ -7843,7 +7843,7 @@ type metadataCreateInstanceExportTaskOutput struct {
 type CreateInternetGatewayInput struct {
 	DryRun *bool `locationName:"dryRun" type:"boolean"`
 
-	metadataCreateInternetGatewayInput `json:"-", xml:"-"`
+	metadataCreateInternetGatewayInput `json:"-" xml:"-"`
 }
 
 type metadataCreateInternetGatewayInput struct {
@@ -7854,7 +7854,7 @@ type CreateInternetGatewayOutput struct {
 	// Information about the Internet gateway.
 	InternetGateway *InternetGateway `locationName:"internetGateway" type:"structure"`
 
-	metadataCreateInternetGatewayOutput `json:"-", xml:"-"`
+	metadataCreateInternetGatewayOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateInternetGatewayOutput struct {
@@ -7869,7 +7869,7 @@ type CreateKeyPairInput struct {
 	// Constraints: Up to 255 ASCII characters
 	KeyName *string `type:"string" required:"true"`
 
-	metadataCreateKeyPairInput `json:"-", xml:"-"`
+	metadataCreateKeyPairInput `json:"-" xml:"-"`
 }
 
 type metadataCreateKeyPairInput struct {
@@ -7887,7 +7887,7 @@ type CreateKeyPairOutput struct {
 	// The name of the key pair.
 	KeyName *string `locationName:"keyName" type:"string"`
 
-	metadataCreateKeyPairOutput `json:"-", xml:"-"`
+	metadataCreateKeyPairOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateKeyPairOutput struct {
@@ -7926,7 +7926,7 @@ type CreateNetworkACLEntryInput struct {
 	// Constraints: Positive integer from 1 to 32766
 	RuleNumber *int64 `locationName:"ruleNumber" type:"integer" required:"true"`
 
-	metadataCreateNetworkACLEntryInput `json:"-", xml:"-"`
+	metadataCreateNetworkACLEntryInput `json:"-" xml:"-"`
 }
 
 type metadataCreateNetworkACLEntryInput struct {
@@ -7934,7 +7934,7 @@ type metadataCreateNetworkACLEntryInput struct {
 }
 
 type CreateNetworkACLEntryOutput struct {
-	metadataCreateNetworkACLEntryOutput `json:"-", xml:"-"`
+	metadataCreateNetworkACLEntryOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateNetworkACLEntryOutput struct {
@@ -7947,7 +7947,7 @@ type CreateNetworkACLInput struct {
 	// The ID of the VPC.
 	VPCID *string `locationName:"vpcId" type:"string" required:"true"`
 
-	metadataCreateNetworkACLInput `json:"-", xml:"-"`
+	metadataCreateNetworkACLInput `json:"-" xml:"-"`
 }
 
 type metadataCreateNetworkACLInput struct {
@@ -7958,7 +7958,7 @@ type CreateNetworkACLOutput struct {
 	// Information about the network ACL.
 	NetworkACL *NetworkACL `locationName:"networkAcl" type:"structure"`
 
-	metadataCreateNetworkACLOutput `json:"-", xml:"-"`
+	metadataCreateNetworkACLOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateNetworkACLOutput struct {
@@ -7997,7 +7997,7 @@ type CreateNetworkInterfaceInput struct {
 	// The ID of the subnet to associate with the network interface.
 	SubnetID *string `locationName:"subnetId" type:"string" required:"true"`
 
-	metadataCreateNetworkInterfaceInput `json:"-", xml:"-"`
+	metadataCreateNetworkInterfaceInput `json:"-" xml:"-"`
 }
 
 type metadataCreateNetworkInterfaceInput struct {
@@ -8008,7 +8008,7 @@ type CreateNetworkInterfaceOutput struct {
 	// Information about the network interface.
 	NetworkInterface *NetworkInterface `locationName:"networkInterface" type:"structure"`
 
-	metadataCreateNetworkInterfaceOutput `json:"-", xml:"-"`
+	metadataCreateNetworkInterfaceOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateNetworkInterfaceOutput struct {
@@ -8026,7 +8026,7 @@ type CreatePlacementGroupInput struct {
 	// The placement strategy.
 	Strategy *string `locationName:"strategy" type:"string" required:"true"`
 
-	metadataCreatePlacementGroupInput `json:"-", xml:"-"`
+	metadataCreatePlacementGroupInput `json:"-" xml:"-"`
 }
 
 type metadataCreatePlacementGroupInput struct {
@@ -8034,7 +8034,7 @@ type metadataCreatePlacementGroupInput struct {
 }
 
 type CreatePlacementGroupOutput struct {
-	metadataCreatePlacementGroupOutput `json:"-", xml:"-"`
+	metadataCreatePlacementGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataCreatePlacementGroupOutput struct {
@@ -8060,7 +8060,7 @@ type CreateReservedInstancesListingInput struct {
 	// The ID of the active Reserved Instance.
 	ReservedInstancesID *string `locationName:"reservedInstancesId" type:"string" required:"true"`
 
-	metadataCreateReservedInstancesListingInput `json:"-", xml:"-"`
+	metadataCreateReservedInstancesListingInput `json:"-" xml:"-"`
 }
 
 type metadataCreateReservedInstancesListingInput struct {
@@ -8071,7 +8071,7 @@ type CreateReservedInstancesListingOutput struct {
 	// Information about the Reserved Instances listing.
 	ReservedInstancesListings []*ReservedInstancesListing `locationName:"reservedInstancesListingsSet" locationNameList:"item" type:"list"`
 
-	metadataCreateReservedInstancesListingOutput `json:"-", xml:"-"`
+	metadataCreateReservedInstancesListingOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateReservedInstancesListingOutput struct {
@@ -8102,7 +8102,7 @@ type CreateRouteInput struct {
 	// The ID of a VPC peering connection.
 	VPCPeeringConnectionID *string `locationName:"vpcPeeringConnectionId" type:"string"`
 
-	metadataCreateRouteInput `json:"-", xml:"-"`
+	metadataCreateRouteInput `json:"-" xml:"-"`
 }
 
 type metadataCreateRouteInput struct {
@@ -8110,7 +8110,7 @@ type metadataCreateRouteInput struct {
 }
 
 type CreateRouteOutput struct {
-	metadataCreateRouteOutput `json:"-", xml:"-"`
+	metadataCreateRouteOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateRouteOutput struct {
@@ -8123,7 +8123,7 @@ type CreateRouteTableInput struct {
 	// The ID of the VPC.
 	VPCID *string `locationName:"vpcId" type:"string" required:"true"`
 
-	metadataCreateRouteTableInput `json:"-", xml:"-"`
+	metadataCreateRouteTableInput `json:"-" xml:"-"`
 }
 
 type metadataCreateRouteTableInput struct {
@@ -8134,7 +8134,7 @@ type CreateRouteTableOutput struct {
 	// Information about the route table.
 	RouteTable *RouteTable `locationName:"routeTable" type:"structure"`
 
-	metadataCreateRouteTableOutput `json:"-", xml:"-"`
+	metadataCreateRouteTableOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateRouteTableOutput struct {
@@ -8165,7 +8165,7 @@ type CreateSecurityGroupInput struct {
 	// [EC2-VPC] The ID of the VPC. Required for EC2-VPC.
 	VPCID *string `locationName:"VpcId" type:"string"`
 
-	metadataCreateSecurityGroupInput `json:"-", xml:"-"`
+	metadataCreateSecurityGroupInput `json:"-" xml:"-"`
 }
 
 type metadataCreateSecurityGroupInput struct {
@@ -8176,7 +8176,7 @@ type CreateSecurityGroupOutput struct {
 	// The ID of the security group.
 	GroupID *string `locationName:"groupId" type:"string"`
 
-	metadataCreateSecurityGroupOutput `json:"-", xml:"-"`
+	metadataCreateSecurityGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateSecurityGroupOutput struct {
@@ -8192,7 +8192,7 @@ type CreateSnapshotInput struct {
 	// The ID of the Amazon EBS volume.
 	VolumeID *string `locationName:"VolumeId" type:"string" required:"true"`
 
-	metadataCreateSnapshotInput `json:"-", xml:"-"`
+	metadataCreateSnapshotInput `json:"-" xml:"-"`
 }
 
 type metadataCreateSnapshotInput struct {
@@ -8208,7 +8208,7 @@ type CreateSpotDatafeedSubscriptionInput struct {
 	// A prefix for the data feed file names.
 	Prefix *string `locationName:"prefix" type:"string"`
 
-	metadataCreateSpotDatafeedSubscriptionInput `json:"-", xml:"-"`
+	metadataCreateSpotDatafeedSubscriptionInput `json:"-" xml:"-"`
 }
 
 type metadataCreateSpotDatafeedSubscriptionInput struct {
@@ -8219,7 +8219,7 @@ type CreateSpotDatafeedSubscriptionOutput struct {
 	// The Spot Instance data feed subscription.
 	SpotDatafeedSubscription *SpotDatafeedSubscription `locationName:"spotDatafeedSubscription" type:"structure"`
 
-	metadataCreateSpotDatafeedSubscriptionOutput `json:"-", xml:"-"`
+	metadataCreateSpotDatafeedSubscriptionOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateSpotDatafeedSubscriptionOutput struct {
@@ -8240,7 +8240,7 @@ type CreateSubnetInput struct {
 	// The ID of the VPC.
 	VPCID *string `locationName:"VpcId" type:"string" required:"true"`
 
-	metadataCreateSubnetInput `json:"-", xml:"-"`
+	metadataCreateSubnetInput `json:"-" xml:"-"`
 }
 
 type metadataCreateSubnetInput struct {
@@ -8251,7 +8251,7 @@ type CreateSubnetOutput struct {
 	// Information about the subnet.
 	Subnet *Subnet `locationName:"subnet" type:"structure"`
 
-	metadataCreateSubnetOutput `json:"-", xml:"-"`
+	metadataCreateSubnetOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateSubnetOutput struct {
@@ -8269,7 +8269,7 @@ type CreateTagsInput struct {
 	// the value to an empty string.
 	Tags []*Tag `locationName:"Tag" locationNameList:"item" type:"list" required:"true"`
 
-	metadataCreateTagsInput `json:"-", xml:"-"`
+	metadataCreateTagsInput `json:"-" xml:"-"`
 }
 
 type metadataCreateTagsInput struct {
@@ -8277,7 +8277,7 @@ type metadataCreateTagsInput struct {
 }
 
 type CreateTagsOutput struct {
-	metadataCreateTagsOutput `json:"-", xml:"-"`
+	metadataCreateTagsOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateTagsOutput struct {
@@ -8299,7 +8299,7 @@ type CreateVPCInput struct {
 	// Default: default
 	InstanceTenancy *string `locationName:"instanceTenancy" type:"string"`
 
-	metadataCreateVPCInput `json:"-", xml:"-"`
+	metadataCreateVPCInput `json:"-" xml:"-"`
 }
 
 type metadataCreateVPCInput struct {
@@ -8310,7 +8310,7 @@ type CreateVPCOutput struct {
 	// Information about the VPC.
 	VPC *VPC `locationName:"vpc" type:"structure"`
 
-	metadataCreateVPCOutput `json:"-", xml:"-"`
+	metadataCreateVPCOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateVPCOutput struct {
@@ -8331,7 +8331,7 @@ type CreateVPCPeeringConnectionInput struct {
 	// The ID of the requester VPC.
 	VPCID *string `locationName:"vpcId" type:"string"`
 
-	metadataCreateVPCPeeringConnectionInput `json:"-", xml:"-"`
+	metadataCreateVPCPeeringConnectionInput `json:"-" xml:"-"`
 }
 
 type metadataCreateVPCPeeringConnectionInput struct {
@@ -8342,7 +8342,7 @@ type CreateVPCPeeringConnectionOutput struct {
 	// Information about the VPC peering connection.
 	VPCPeeringConnection *VPCPeeringConnection `locationName:"vpcPeeringConnection" type:"structure"`
 
-	metadataCreateVPCPeeringConnectionOutput `json:"-", xml:"-"`
+	metadataCreateVPCPeeringConnectionOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateVPCPeeringConnectionOutput struct {
@@ -8368,7 +8368,7 @@ type CreateVPNConnectionInput struct {
 	// The ID of the virtual private gateway.
 	VPNGatewayID *string `locationName:"VpnGatewayId" type:"string" required:"true"`
 
-	metadataCreateVPNConnectionInput `json:"-", xml:"-"`
+	metadataCreateVPNConnectionInput `json:"-" xml:"-"`
 }
 
 type metadataCreateVPNConnectionInput struct {
@@ -8379,7 +8379,7 @@ type CreateVPNConnectionOutput struct {
 	// Information about the VPN connection.
 	VPNConnection *VPNConnection `locationName:"vpnConnection" type:"structure"`
 
-	metadataCreateVPNConnectionOutput `json:"-", xml:"-"`
+	metadataCreateVPNConnectionOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateVPNConnectionOutput struct {
@@ -8393,7 +8393,7 @@ type CreateVPNConnectionRouteInput struct {
 	// The ID of the VPN connection.
 	VPNConnectionID *string `locationName:"VpnConnectionId" type:"string" required:"true"`
 
-	metadataCreateVPNConnectionRouteInput `json:"-", xml:"-"`
+	metadataCreateVPNConnectionRouteInput `json:"-" xml:"-"`
 }
 
 type metadataCreateVPNConnectionRouteInput struct {
@@ -8401,7 +8401,7 @@ type metadataCreateVPNConnectionRouteInput struct {
 }
 
 type CreateVPNConnectionRouteOutput struct {
-	metadataCreateVPNConnectionRouteOutput `json:"-", xml:"-"`
+	metadataCreateVPNConnectionRouteOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateVPNConnectionRouteOutput struct {
@@ -8417,7 +8417,7 @@ type CreateVPNGatewayInput struct {
 	// The type of VPN connection this virtual private gateway supports.
 	Type *string `type:"string" required:"true"`
 
-	metadataCreateVPNGatewayInput `json:"-", xml:"-"`
+	metadataCreateVPNGatewayInput `json:"-" xml:"-"`
 }
 
 type metadataCreateVPNGatewayInput struct {
@@ -8428,7 +8428,7 @@ type CreateVPNGatewayOutput struct {
 	// Information about the virtual private gateway.
 	VPNGateway *VPNGateway `locationName:"vpnGateway" type:"structure"`
 
-	metadataCreateVPNGatewayOutput `json:"-", xml:"-"`
+	metadataCreateVPNGatewayOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateVPNGatewayOutput struct {
@@ -8485,7 +8485,7 @@ type CreateVolumeInput struct {
 	// Default: standard
 	VolumeType *string `type:"string"`
 
-	metadataCreateVolumeInput `json:"-", xml:"-"`
+	metadataCreateVolumeInput `json:"-" xml:"-"`
 }
 
 type metadataCreateVolumeInput struct {
@@ -8501,7 +8501,7 @@ type CreateVolumePermission struct {
 	// list of create volume permissions.
 	UserID *string `locationName:"userId" type:"string"`
 
-	metadataCreateVolumePermission `json:"-", xml:"-"`
+	metadataCreateVolumePermission `json:"-" xml:"-"`
 }
 
 type metadataCreateVolumePermission struct {
@@ -8517,7 +8517,7 @@ type CreateVolumePermissionModifications struct {
 	// volume permissions.
 	Remove []*CreateVolumePermission `locationNameList:"item" type:"list"`
 
-	metadataCreateVolumePermissionModifications `json:"-", xml:"-"`
+	metadataCreateVolumePermissionModifications `json:"-" xml:"-"`
 }
 
 type metadataCreateVolumePermissionModifications struct {
@@ -8546,7 +8546,7 @@ type CustomerGateway struct {
 	// The type of VPN connection the customer gateway supports (ipsec.1).
 	Type *string `locationName:"type" type:"string"`
 
-	metadataCustomerGateway `json:"-", xml:"-"`
+	metadataCustomerGateway `json:"-" xml:"-"`
 }
 
 type metadataCustomerGateway struct {
@@ -8561,7 +8561,7 @@ type DHCPConfiguration struct {
 	// One or more values for the DHCP option.
 	Values []*AttributeValue `locationName:"valueSet" locationNameList:"item" type:"list"`
 
-	metadataDHCPConfiguration `json:"-", xml:"-"`
+	metadataDHCPConfiguration `json:"-" xml:"-"`
 }
 
 type metadataDHCPConfiguration struct {
@@ -8579,7 +8579,7 @@ type DHCPOptions struct {
 	// Any tags assigned to the DHCP options set.
 	Tags []*Tag `locationName:"tagSet" locationNameList:"item" type:"list"`
 
-	metadataDHCPOptions `json:"-", xml:"-"`
+	metadataDHCPOptions `json:"-" xml:"-"`
 }
 
 type metadataDHCPOptions struct {
@@ -8592,7 +8592,7 @@ type DeleteCustomerGatewayInput struct {
 
 	DryRun *bool `locationName:"dryRun" type:"boolean"`
 
-	metadataDeleteCustomerGatewayInput `json:"-", xml:"-"`
+	metadataDeleteCustomerGatewayInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteCustomerGatewayInput struct {
@@ -8600,7 +8600,7 @@ type metadataDeleteCustomerGatewayInput struct {
 }
 
 type DeleteCustomerGatewayOutput struct {
-	metadataDeleteCustomerGatewayOutput `json:"-", xml:"-"`
+	metadataDeleteCustomerGatewayOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteCustomerGatewayOutput struct {
@@ -8613,7 +8613,7 @@ type DeleteDHCPOptionsInput struct {
 
 	DryRun *bool `locationName:"dryRun" type:"boolean"`
 
-	metadataDeleteDHCPOptionsInput `json:"-", xml:"-"`
+	metadataDeleteDHCPOptionsInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteDHCPOptionsInput struct {
@@ -8621,7 +8621,7 @@ type metadataDeleteDHCPOptionsInput struct {
 }
 
 type DeleteDHCPOptionsOutput struct {
-	metadataDeleteDHCPOptionsOutput `json:"-", xml:"-"`
+	metadataDeleteDHCPOptionsOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteDHCPOptionsOutput struct {
@@ -8634,7 +8634,7 @@ type DeleteInternetGatewayInput struct {
 	// The ID of the Internet gateway.
 	InternetGatewayID *string `locationName:"internetGatewayId" type:"string" required:"true"`
 
-	metadataDeleteInternetGatewayInput `json:"-", xml:"-"`
+	metadataDeleteInternetGatewayInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteInternetGatewayInput struct {
@@ -8642,7 +8642,7 @@ type metadataDeleteInternetGatewayInput struct {
 }
 
 type DeleteInternetGatewayOutput struct {
-	metadataDeleteInternetGatewayOutput `json:"-", xml:"-"`
+	metadataDeleteInternetGatewayOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteInternetGatewayOutput struct {
@@ -8655,7 +8655,7 @@ type DeleteKeyPairInput struct {
 	// The name of the key pair.
 	KeyName *string `type:"string" required:"true"`
 
-	metadataDeleteKeyPairInput `json:"-", xml:"-"`
+	metadataDeleteKeyPairInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteKeyPairInput struct {
@@ -8663,7 +8663,7 @@ type metadataDeleteKeyPairInput struct {
 }
 
 type DeleteKeyPairOutput struct {
-	metadataDeleteKeyPairOutput `json:"-", xml:"-"`
+	metadataDeleteKeyPairOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteKeyPairOutput struct {
@@ -8682,7 +8682,7 @@ type DeleteNetworkACLEntryInput struct {
 	// The rule number of the entry to delete.
 	RuleNumber *int64 `locationName:"ruleNumber" type:"integer" required:"true"`
 
-	metadataDeleteNetworkACLEntryInput `json:"-", xml:"-"`
+	metadataDeleteNetworkACLEntryInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteNetworkACLEntryInput struct {
@@ -8690,7 +8690,7 @@ type metadataDeleteNetworkACLEntryInput struct {
 }
 
 type DeleteNetworkACLEntryOutput struct {
-	metadataDeleteNetworkACLEntryOutput `json:"-", xml:"-"`
+	metadataDeleteNetworkACLEntryOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteNetworkACLEntryOutput struct {
@@ -8703,7 +8703,7 @@ type DeleteNetworkACLInput struct {
 	// The ID of the network ACL.
 	NetworkACLID *string `locationName:"networkAclId" type:"string" required:"true"`
 
-	metadataDeleteNetworkACLInput `json:"-", xml:"-"`
+	metadataDeleteNetworkACLInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteNetworkACLInput struct {
@@ -8711,7 +8711,7 @@ type metadataDeleteNetworkACLInput struct {
 }
 
 type DeleteNetworkACLOutput struct {
-	metadataDeleteNetworkACLOutput `json:"-", xml:"-"`
+	metadataDeleteNetworkACLOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteNetworkACLOutput struct {
@@ -8724,7 +8724,7 @@ type DeleteNetworkInterfaceInput struct {
 	// The ID of the network interface.
 	NetworkInterfaceID *string `locationName:"networkInterfaceId" type:"string" required:"true"`
 
-	metadataDeleteNetworkInterfaceInput `json:"-", xml:"-"`
+	metadataDeleteNetworkInterfaceInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteNetworkInterfaceInput struct {
@@ -8732,7 +8732,7 @@ type metadataDeleteNetworkInterfaceInput struct {
 }
 
 type DeleteNetworkInterfaceOutput struct {
-	metadataDeleteNetworkInterfaceOutput `json:"-", xml:"-"`
+	metadataDeleteNetworkInterfaceOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteNetworkInterfaceOutput struct {
@@ -8745,7 +8745,7 @@ type DeletePlacementGroupInput struct {
 	// The name of the placement group.
 	GroupName *string `locationName:"groupName" type:"string" required:"true"`
 
-	metadataDeletePlacementGroupInput `json:"-", xml:"-"`
+	metadataDeletePlacementGroupInput `json:"-" xml:"-"`
 }
 
 type metadataDeletePlacementGroupInput struct {
@@ -8753,7 +8753,7 @@ type metadataDeletePlacementGroupInput struct {
 }
 
 type DeletePlacementGroupOutput struct {
-	metadataDeletePlacementGroupOutput `json:"-", xml:"-"`
+	metadataDeletePlacementGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataDeletePlacementGroupOutput struct {
@@ -8770,7 +8770,7 @@ type DeleteRouteInput struct {
 	// The ID of the route table.
 	RouteTableID *string `locationName:"routeTableId" type:"string" required:"true"`
 
-	metadataDeleteRouteInput `json:"-", xml:"-"`
+	metadataDeleteRouteInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteRouteInput struct {
@@ -8778,7 +8778,7 @@ type metadataDeleteRouteInput struct {
 }
 
 type DeleteRouteOutput struct {
-	metadataDeleteRouteOutput `json:"-", xml:"-"`
+	metadataDeleteRouteOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteRouteOutput struct {
@@ -8791,7 +8791,7 @@ type DeleteRouteTableInput struct {
 	// The ID of the route table.
 	RouteTableID *string `locationName:"routeTableId" type:"string" required:"true"`
 
-	metadataDeleteRouteTableInput `json:"-", xml:"-"`
+	metadataDeleteRouteTableInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteRouteTableInput struct {
@@ -8799,7 +8799,7 @@ type metadataDeleteRouteTableInput struct {
 }
 
 type DeleteRouteTableOutput struct {
-	metadataDeleteRouteTableOutput `json:"-", xml:"-"`
+	metadataDeleteRouteTableOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteRouteTableOutput struct {
@@ -8816,7 +8816,7 @@ type DeleteSecurityGroupInput struct {
 	// either the security group name or the security group ID.
 	GroupName *string `type:"string"`
 
-	metadataDeleteSecurityGroupInput `json:"-", xml:"-"`
+	metadataDeleteSecurityGroupInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteSecurityGroupInput struct {
@@ -8824,7 +8824,7 @@ type metadataDeleteSecurityGroupInput struct {
 }
 
 type DeleteSecurityGroupOutput struct {
-	metadataDeleteSecurityGroupOutput `json:"-", xml:"-"`
+	metadataDeleteSecurityGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteSecurityGroupOutput struct {
@@ -8837,7 +8837,7 @@ type DeleteSnapshotInput struct {
 	// The ID of the Amazon EBS snapshot.
 	SnapshotID *string `locationName:"SnapshotId" type:"string" required:"true"`
 
-	metadataDeleteSnapshotInput `json:"-", xml:"-"`
+	metadataDeleteSnapshotInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteSnapshotInput struct {
@@ -8845,7 +8845,7 @@ type metadataDeleteSnapshotInput struct {
 }
 
 type DeleteSnapshotOutput struct {
-	metadataDeleteSnapshotOutput `json:"-", xml:"-"`
+	metadataDeleteSnapshotOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteSnapshotOutput struct {
@@ -8855,7 +8855,7 @@ type metadataDeleteSnapshotOutput struct {
 type DeleteSpotDatafeedSubscriptionInput struct {
 	DryRun *bool `locationName:"dryRun" type:"boolean"`
 
-	metadataDeleteSpotDatafeedSubscriptionInput `json:"-", xml:"-"`
+	metadataDeleteSpotDatafeedSubscriptionInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteSpotDatafeedSubscriptionInput struct {
@@ -8863,7 +8863,7 @@ type metadataDeleteSpotDatafeedSubscriptionInput struct {
 }
 
 type DeleteSpotDatafeedSubscriptionOutput struct {
-	metadataDeleteSpotDatafeedSubscriptionOutput `json:"-", xml:"-"`
+	metadataDeleteSpotDatafeedSubscriptionOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteSpotDatafeedSubscriptionOutput struct {
@@ -8876,7 +8876,7 @@ type DeleteSubnetInput struct {
 	// The ID of the subnet.
 	SubnetID *string `locationName:"SubnetId" type:"string" required:"true"`
 
-	metadataDeleteSubnetInput `json:"-", xml:"-"`
+	metadataDeleteSubnetInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteSubnetInput struct {
@@ -8884,7 +8884,7 @@ type metadataDeleteSubnetInput struct {
 }
 
 type DeleteSubnetOutput struct {
-	metadataDeleteSubnetOutput `json:"-", xml:"-"`
+	metadataDeleteSubnetOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteSubnetOutput struct {
@@ -8903,7 +8903,7 @@ type DeleteTagsInput struct {
 	// string as the value, we delete the key only if its value is an empty string.
 	Tags []*Tag `locationName:"tag" locationNameList:"item" type:"list"`
 
-	metadataDeleteTagsInput `json:"-", xml:"-"`
+	metadataDeleteTagsInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteTagsInput struct {
@@ -8911,7 +8911,7 @@ type metadataDeleteTagsInput struct {
 }
 
 type DeleteTagsOutput struct {
-	metadataDeleteTagsOutput `json:"-", xml:"-"`
+	metadataDeleteTagsOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteTagsOutput struct {
@@ -8924,7 +8924,7 @@ type DeleteVPCInput struct {
 	// The ID of the VPC.
 	VPCID *string `locationName:"VpcId" type:"string" required:"true"`
 
-	metadataDeleteVPCInput `json:"-", xml:"-"`
+	metadataDeleteVPCInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteVPCInput struct {
@@ -8932,7 +8932,7 @@ type metadataDeleteVPCInput struct {
 }
 
 type DeleteVPCOutput struct {
-	metadataDeleteVPCOutput `json:"-", xml:"-"`
+	metadataDeleteVPCOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteVPCOutput struct {
@@ -8945,7 +8945,7 @@ type DeleteVPCPeeringConnectionInput struct {
 	// The ID of the VPC peering connection.
 	VPCPeeringConnectionID *string `locationName:"vpcPeeringConnectionId" type:"string" required:"true"`
 
-	metadataDeleteVPCPeeringConnectionInput `json:"-", xml:"-"`
+	metadataDeleteVPCPeeringConnectionInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteVPCPeeringConnectionInput struct {
@@ -8956,7 +8956,7 @@ type DeleteVPCPeeringConnectionOutput struct {
 	// Returns true if the request succeeds; otherwise, it returns an error.
 	Return *bool `locationName:"return" type:"boolean"`
 
-	metadataDeleteVPCPeeringConnectionOutput `json:"-", xml:"-"`
+	metadataDeleteVPCPeeringConnectionOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteVPCPeeringConnectionOutput struct {
@@ -8969,7 +8969,7 @@ type DeleteVPNConnectionInput struct {
 	// The ID of the VPN connection.
 	VPNConnectionID *string `locationName:"VpnConnectionId" type:"string" required:"true"`
 
-	metadataDeleteVPNConnectionInput `json:"-", xml:"-"`
+	metadataDeleteVPNConnectionInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteVPNConnectionInput struct {
@@ -8977,7 +8977,7 @@ type metadataDeleteVPNConnectionInput struct {
 }
 
 type DeleteVPNConnectionOutput struct {
-	metadataDeleteVPNConnectionOutput `json:"-", xml:"-"`
+	metadataDeleteVPNConnectionOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteVPNConnectionOutput struct {
@@ -8991,7 +8991,7 @@ type DeleteVPNConnectionRouteInput struct {
 	// The ID of the VPN connection.
 	VPNConnectionID *string `locationName:"VpnConnectionId" type:"string" required:"true"`
 
-	metadataDeleteVPNConnectionRouteInput `json:"-", xml:"-"`
+	metadataDeleteVPNConnectionRouteInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteVPNConnectionRouteInput struct {
@@ -8999,7 +8999,7 @@ type metadataDeleteVPNConnectionRouteInput struct {
 }
 
 type DeleteVPNConnectionRouteOutput struct {
-	metadataDeleteVPNConnectionRouteOutput `json:"-", xml:"-"`
+	metadataDeleteVPNConnectionRouteOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteVPNConnectionRouteOutput struct {
@@ -9012,7 +9012,7 @@ type DeleteVPNGatewayInput struct {
 	// The ID of the virtual private gateway.
 	VPNGatewayID *string `locationName:"VpnGatewayId" type:"string" required:"true"`
 
-	metadataDeleteVPNGatewayInput `json:"-", xml:"-"`
+	metadataDeleteVPNGatewayInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteVPNGatewayInput struct {
@@ -9020,7 +9020,7 @@ type metadataDeleteVPNGatewayInput struct {
 }
 
 type DeleteVPNGatewayOutput struct {
-	metadataDeleteVPNGatewayOutput `json:"-", xml:"-"`
+	metadataDeleteVPNGatewayOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteVPNGatewayOutput struct {
@@ -9033,7 +9033,7 @@ type DeleteVolumeInput struct {
 	// The ID of the volume.
 	VolumeID *string `locationName:"VolumeId" type:"string" required:"true"`
 
-	metadataDeleteVolumeInput `json:"-", xml:"-"`
+	metadataDeleteVolumeInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteVolumeInput struct {
@@ -9041,7 +9041,7 @@ type metadataDeleteVolumeInput struct {
 }
 
 type DeleteVolumeOutput struct {
-	metadataDeleteVolumeOutput `json:"-", xml:"-"`
+	metadataDeleteVolumeOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteVolumeOutput struct {
@@ -9054,7 +9054,7 @@ type DeregisterImageInput struct {
 	// The ID of the AMI.
 	ImageID *string `locationName:"ImageId" type:"string" required:"true"`
 
-	metadataDeregisterImageInput `json:"-", xml:"-"`
+	metadataDeregisterImageInput `json:"-" xml:"-"`
 }
 
 type metadataDeregisterImageInput struct {
@@ -9062,7 +9062,7 @@ type metadataDeregisterImageInput struct {
 }
 
 type DeregisterImageOutput struct {
-	metadataDeregisterImageOutput `json:"-", xml:"-"`
+	metadataDeregisterImageOutput `json:"-" xml:"-"`
 }
 
 type metadataDeregisterImageOutput struct {
@@ -9075,7 +9075,7 @@ type DescribeAccountAttributesInput struct {
 
 	DryRun *bool `locationName:"dryRun" type:"boolean"`
 
-	metadataDescribeAccountAttributesInput `json:"-", xml:"-"`
+	metadataDescribeAccountAttributesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeAccountAttributesInput struct {
@@ -9086,7 +9086,7 @@ type DescribeAccountAttributesOutput struct {
 	// Information about one or more account attributes.
 	AccountAttributes []*AccountAttribute `locationName:"accountAttributeSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeAccountAttributesOutput `json:"-", xml:"-"`
+	metadataDescribeAccountAttributesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeAccountAttributesOutput struct {
@@ -9129,7 +9129,7 @@ type DescribeAddressesInput struct {
 	// Default: Describes all your Elastic IP addresses.
 	PublicIPs []*string `locationName:"PublicIp" locationNameList:"PublicIp" type:"list"`
 
-	metadataDescribeAddressesInput `json:"-", xml:"-"`
+	metadataDescribeAddressesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeAddressesInput struct {
@@ -9140,7 +9140,7 @@ type DescribeAddressesOutput struct {
 	// Information about one or more Elastic IP addresses.
 	Addresses []*Address `locationName:"addressesSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeAddressesOutput `json:"-", xml:"-"`
+	metadataDescribeAddressesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeAddressesOutput struct {
@@ -9165,7 +9165,7 @@ type DescribeAvailabilityZonesInput struct {
 	// The names of one or more Availability Zones.
 	ZoneNames []*string `locationName:"ZoneName" locationNameList:"ZoneName" type:"list"`
 
-	metadataDescribeAvailabilityZonesInput `json:"-", xml:"-"`
+	metadataDescribeAvailabilityZonesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeAvailabilityZonesInput struct {
@@ -9176,7 +9176,7 @@ type DescribeAvailabilityZonesOutput struct {
 	// Information about one or more Availability Zones.
 	AvailabilityZones []*AvailabilityZone `locationName:"availabilityZoneInfo" locationNameList:"item" type:"list"`
 
-	metadataDescribeAvailabilityZonesOutput `json:"-", xml:"-"`
+	metadataDescribeAvailabilityZonesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeAvailabilityZonesOutput struct {
@@ -9216,7 +9216,7 @@ type DescribeBundleTasksInput struct {
 	//   update-time - The time of the most recent update for the task.
 	Filters []*Filter `locationName:"Filter" locationNameList:"Filter" type:"list"`
 
-	metadataDescribeBundleTasksInput `json:"-", xml:"-"`
+	metadataDescribeBundleTasksInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeBundleTasksInput struct {
@@ -9227,7 +9227,7 @@ type DescribeBundleTasksOutput struct {
 	// Information about one or more bundle tasks.
 	BundleTasks []*BundleTask `locationName:"bundleInstanceTasksSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeBundleTasksOutput `json:"-", xml:"-"`
+	metadataDescribeBundleTasksOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeBundleTasksOutput struct {
@@ -9274,7 +9274,7 @@ type DescribeClassicLinkInstancesInput struct {
 	// The token to retrieve the next page of results.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataDescribeClassicLinkInstancesInput `json:"-", xml:"-"`
+	metadataDescribeClassicLinkInstancesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeClassicLinkInstancesInput struct {
@@ -9289,7 +9289,7 @@ type DescribeClassicLinkInstancesOutput struct {
 	// when there are no more results to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataDescribeClassicLinkInstancesOutput `json:"-", xml:"-"`
+	metadataDescribeClassicLinkInstancesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeClassicLinkInstancesOutput struct {
@@ -9304,7 +9304,7 @@ type DescribeConversionTasksInput struct {
 
 	Filters []*Filter `locationName:"filter" locationNameList:"Filter" type:"list"`
 
-	metadataDescribeConversionTasksInput `json:"-", xml:"-"`
+	metadataDescribeConversionTasksInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeConversionTasksInput struct {
@@ -9314,7 +9314,7 @@ type metadataDescribeConversionTasksInput struct {
 type DescribeConversionTasksOutput struct {
 	ConversionTasks []*ConversionTask `locationName:"conversionTasks" locationNameList:"item" type:"list"`
 
-	metadataDescribeConversionTasksOutput `json:"-", xml:"-"`
+	metadataDescribeConversionTasksOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeConversionTasksOutput struct {
@@ -9358,7 +9358,7 @@ type DescribeCustomerGatewaysInput struct {
 	// independent of the tag-key filter.
 	Filters []*Filter `locationName:"Filter" locationNameList:"Filter" type:"list"`
 
-	metadataDescribeCustomerGatewaysInput `json:"-", xml:"-"`
+	metadataDescribeCustomerGatewaysInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeCustomerGatewaysInput struct {
@@ -9369,7 +9369,7 @@ type DescribeCustomerGatewaysOutput struct {
 	// Information about one or more customer gateways.
 	CustomerGateways []*CustomerGateway `locationName:"customerGatewaySet" locationNameList:"item" type:"list"`
 
-	metadataDescribeCustomerGatewaysOutput `json:"-", xml:"-"`
+	metadataDescribeCustomerGatewaysOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeCustomerGatewaysOutput struct {
@@ -9405,7 +9405,7 @@ type DescribeDHCPOptionsInput struct {
 	// independent of the tag-key filter.
 	Filters []*Filter `locationName:"Filter" locationNameList:"Filter" type:"list"`
 
-	metadataDescribeDHCPOptionsInput `json:"-", xml:"-"`
+	metadataDescribeDHCPOptionsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeDHCPOptionsInput struct {
@@ -9416,7 +9416,7 @@ type DescribeDHCPOptionsOutput struct {
 	// Information about one or more DHCP options sets.
 	DHCPOptions []*DHCPOptions `locationName:"dhcpOptionsSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeDHCPOptionsOutput `json:"-", xml:"-"`
+	metadataDescribeDHCPOptionsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeDHCPOptionsOutput struct {
@@ -9427,7 +9427,7 @@ type DescribeExportTasksInput struct {
 	// One or more export task IDs.
 	ExportTaskIDs []*string `locationName:"exportTaskId" locationNameList:"ExportTaskId" type:"list"`
 
-	metadataDescribeExportTasksInput `json:"-", xml:"-"`
+	metadataDescribeExportTasksInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeExportTasksInput struct {
@@ -9437,7 +9437,7 @@ type metadataDescribeExportTasksInput struct {
 type DescribeExportTasksOutput struct {
 	ExportTasks []*ExportTask `locationName:"exportTaskSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeExportTasksOutput `json:"-", xml:"-"`
+	metadataDescribeExportTasksOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeExportTasksOutput struct {
@@ -9457,7 +9457,7 @@ type DescribeImageAttributeInput struct {
 	// The ID of the AMI.
 	ImageID *string `locationName:"ImageId" type:"string" required:"true"`
 
-	metadataDescribeImageAttributeInput `json:"-", xml:"-"`
+	metadataDescribeImageAttributeInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeImageAttributeInput struct {
@@ -9490,7 +9490,7 @@ type DescribeImageAttributeOutput struct {
 	// The value to use for a resource attribute.
 	SRIOVNetSupport *AttributeValue `locationName:"sriovNetSupport" type:"structure"`
 
-	metadataDescribeImageAttributeOutput `json:"-", xml:"-"`
+	metadataDescribeImageAttributeOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeImageAttributeOutput struct {
@@ -9587,7 +9587,7 @@ type DescribeImagesInput struct {
 	// you have launch permissions, regardless of ownership.
 	Owners []*string `locationName:"Owner" locationNameList:"Owner" type:"list"`
 
-	metadataDescribeImagesInput `json:"-", xml:"-"`
+	metadataDescribeImagesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeImagesInput struct {
@@ -9598,7 +9598,7 @@ type DescribeImagesOutput struct {
 	// Information about one or more images.
 	Images []*Image `locationName:"imagesSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeImagesOutput `json:"-", xml:"-"`
+	metadataDescribeImagesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeImagesOutput struct {
@@ -9620,7 +9620,7 @@ type DescribeImportImageTasksInput struct {
 	// The token to get the next page of paginated describe requests.
 	NextToken *string `type:"string"`
 
-	metadataDescribeImportImageTasksInput `json:"-", xml:"-"`
+	metadataDescribeImportImageTasksInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeImportImageTasksInput struct {
@@ -9635,7 +9635,7 @@ type DescribeImportImageTasksOutput struct {
 	// The token to get the next page of paginated describe requests.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataDescribeImportImageTasksOutput `json:"-", xml:"-"`
+	metadataDescribeImportImageTasksOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeImportImageTasksOutput struct {
@@ -9657,7 +9657,7 @@ type DescribeImportSnapshotTasksInput struct {
 	// The token to get to the next page of paginated describe requests.
 	NextToken *string `type:"string"`
 
-	metadataDescribeImportSnapshotTasksInput `json:"-", xml:"-"`
+	metadataDescribeImportSnapshotTasksInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeImportSnapshotTasksInput struct {
@@ -9672,7 +9672,7 @@ type DescribeImportSnapshotTasksOutput struct {
 	// The token to get to the next page of paginated describe requests.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataDescribeImportSnapshotTasksOutput `json:"-", xml:"-"`
+	metadataDescribeImportSnapshotTasksOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeImportSnapshotTasksOutput struct {
@@ -9688,7 +9688,7 @@ type DescribeInstanceAttributeInput struct {
 	// The ID of the instance.
 	InstanceID *string `locationName:"instanceId" type:"string" required:"true"`
 
-	metadataDescribeInstanceAttributeInput `json:"-", xml:"-"`
+	metadataDescribeInstanceAttributeInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeInstanceAttributeInput struct {
@@ -9743,7 +9743,7 @@ type DescribeInstanceAttributeOutput struct {
 	// The Base64-encoded MIME user data.
 	UserData *AttributeValue `locationName:"userData" type:"structure"`
 
-	metadataDescribeInstanceAttributeOutput `json:"-", xml:"-"`
+	metadataDescribeInstanceAttributeOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeInstanceAttributeOutput struct {
@@ -9814,7 +9814,7 @@ type DescribeInstanceStatusInput struct {
 	// The token to retrieve the next page of results.
 	NextToken *string `type:"string"`
 
-	metadataDescribeInstanceStatusInput `json:"-", xml:"-"`
+	metadataDescribeInstanceStatusInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeInstanceStatusInput struct {
@@ -9829,7 +9829,7 @@ type DescribeInstanceStatusOutput struct {
 	// when there are no more results to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataDescribeInstanceStatusOutput `json:"-", xml:"-"`
+	metadataDescribeInstanceStatusOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeInstanceStatusOutput struct {
@@ -10080,7 +10080,7 @@ type DescribeInstancesInput struct {
 	// The token to request the next page of results.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataDescribeInstancesInput `json:"-", xml:"-"`
+	metadataDescribeInstancesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeInstancesInput struct {
@@ -10095,7 +10095,7 @@ type DescribeInstancesOutput struct {
 	// One or more reservations.
 	Reservations []*Reservation `locationName:"reservationSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeInstancesOutput `json:"-", xml:"-"`
+	metadataDescribeInstancesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeInstancesOutput struct {
@@ -10132,7 +10132,7 @@ type DescribeInternetGatewaysInput struct {
 	// Default: Describes all your Internet gateways.
 	InternetGatewayIDs []*string `locationName:"internetGatewayId" locationNameList:"item" type:"list"`
 
-	metadataDescribeInternetGatewaysInput `json:"-", xml:"-"`
+	metadataDescribeInternetGatewaysInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeInternetGatewaysInput struct {
@@ -10143,7 +10143,7 @@ type DescribeInternetGatewaysOutput struct {
 	// Information about one or more Internet gateways.
 	InternetGateways []*InternetGateway `locationName:"internetGatewaySet" locationNameList:"item" type:"list"`
 
-	metadataDescribeInternetGatewaysOutput `json:"-", xml:"-"`
+	metadataDescribeInternetGatewaysOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeInternetGatewaysOutput struct {
@@ -10165,7 +10165,7 @@ type DescribeKeyPairsInput struct {
 	// Default: Describes all your key pairs.
 	KeyNames []*string `locationName:"KeyName" locationNameList:"KeyName" type:"list"`
 
-	metadataDescribeKeyPairsInput `json:"-", xml:"-"`
+	metadataDescribeKeyPairsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeKeyPairsInput struct {
@@ -10176,7 +10176,7 @@ type DescribeKeyPairsOutput struct {
 	// Information about one or more key pairs.
 	KeyPairs []*KeyPairInfo `locationName:"keySet" locationNameList:"item" type:"list"`
 
-	metadataDescribeKeyPairsOutput `json:"-", xml:"-"`
+	metadataDescribeKeyPairsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeKeyPairsOutput struct {
@@ -10240,7 +10240,7 @@ type DescribeNetworkACLsInput struct {
 	// Default: Describes all your network ACLs.
 	NetworkACLIDs []*string `locationName:"NetworkAclId" locationNameList:"item" type:"list"`
 
-	metadataDescribeNetworkACLsInput `json:"-", xml:"-"`
+	metadataDescribeNetworkACLsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeNetworkACLsInput struct {
@@ -10251,7 +10251,7 @@ type DescribeNetworkACLsOutput struct {
 	// Information about one or more network ACLs.
 	NetworkACLs []*NetworkACL `locationName:"networkAclSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeNetworkACLsOutput `json:"-", xml:"-"`
+	metadataDescribeNetworkACLsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeNetworkACLsOutput struct {
@@ -10267,7 +10267,7 @@ type DescribeNetworkInterfaceAttributeInput struct {
 	// The ID of the network interface.
 	NetworkInterfaceID *string `locationName:"networkInterfaceId" type:"string" required:"true"`
 
-	metadataDescribeNetworkInterfaceAttributeInput `json:"-", xml:"-"`
+	metadataDescribeNetworkInterfaceAttributeInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeNetworkInterfaceAttributeInput struct {
@@ -10290,7 +10290,7 @@ type DescribeNetworkInterfaceAttributeOutput struct {
 	// Indicates whether source/destination checking is enabled.
 	SourceDestCheck *AttributeBooleanValue `locationName:"sourceDestCheck" type:"structure"`
 
-	metadataDescribeNetworkInterfaceAttributeOutput `json:"-", xml:"-"`
+	metadataDescribeNetworkInterfaceAttributeOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeNetworkInterfaceAttributeOutput struct {
@@ -10406,7 +10406,7 @@ type DescribeNetworkInterfacesInput struct {
 	// Default: Describes all your network interfaces.
 	NetworkInterfaceIDs []*string `locationName:"NetworkInterfaceId" locationNameList:"item" type:"list"`
 
-	metadataDescribeNetworkInterfacesInput `json:"-", xml:"-"`
+	metadataDescribeNetworkInterfacesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeNetworkInterfacesInput struct {
@@ -10417,7 +10417,7 @@ type DescribeNetworkInterfacesOutput struct {
 	// Information about one or more network interfaces.
 	NetworkInterfaces []*NetworkInterface `locationName:"networkInterfaceSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeNetworkInterfacesOutput `json:"-", xml:"-"`
+	metadataDescribeNetworkInterfacesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeNetworkInterfacesOutput struct {
@@ -10442,7 +10442,7 @@ type DescribePlacementGroupsInput struct {
 	// Default: Describes all your placement groups, or only those otherwise specified.
 	GroupNames []*string `locationName:"groupName" type:"list"`
 
-	metadataDescribePlacementGroupsInput `json:"-", xml:"-"`
+	metadataDescribePlacementGroupsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribePlacementGroupsInput struct {
@@ -10453,7 +10453,7 @@ type DescribePlacementGroupsOutput struct {
 	// One or more placement groups.
 	PlacementGroups []*PlacementGroup `locationName:"placementGroupSet" locationNameList:"item" type:"list"`
 
-	metadataDescribePlacementGroupsOutput `json:"-", xml:"-"`
+	metadataDescribePlacementGroupsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribePlacementGroupsOutput struct {
@@ -10473,7 +10473,7 @@ type DescribeRegionsInput struct {
 	// The names of one or more regions.
 	RegionNames []*string `locationName:"RegionName" locationNameList:"RegionName" type:"list"`
 
-	metadataDescribeRegionsInput `json:"-", xml:"-"`
+	metadataDescribeRegionsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeRegionsInput struct {
@@ -10484,7 +10484,7 @@ type DescribeRegionsOutput struct {
 	// Information about one or more regions.
 	Regions []*Region `locationName:"regionInfo" locationNameList:"item" type:"list"`
 
-	metadataDescribeRegionsOutput `json:"-", xml:"-"`
+	metadataDescribeRegionsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeRegionsOutput struct {
@@ -10548,7 +10548,7 @@ type DescribeReservedInstancesInput struct {
 	// specified.
 	ReservedInstancesIDs []*string `locationName:"ReservedInstancesId" locationNameList:"ReservedInstancesId" type:"list"`
 
-	metadataDescribeReservedInstancesInput `json:"-", xml:"-"`
+	metadataDescribeReservedInstancesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeReservedInstancesInput struct {
@@ -10574,7 +10574,7 @@ type DescribeReservedInstancesListingsInput struct {
 	// One or more Reserved Instance Listing IDs.
 	ReservedInstancesListingID *string `locationName:"reservedInstancesListingId" type:"string"`
 
-	metadataDescribeReservedInstancesListingsInput `json:"-", xml:"-"`
+	metadataDescribeReservedInstancesListingsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeReservedInstancesListingsInput struct {
@@ -10585,7 +10585,7 @@ type DescribeReservedInstancesListingsOutput struct {
 	// Information about the Reserved Instance listing.
 	ReservedInstancesListings []*ReservedInstancesListing `locationName:"reservedInstancesListingsSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeReservedInstancesListingsOutput `json:"-", xml:"-"`
+	metadataDescribeReservedInstancesListingsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeReservedInstancesListingsOutput struct {
@@ -10635,7 +10635,7 @@ type DescribeReservedInstancesModificationsInput struct {
 	// IDs for the submitted modification request.
 	ReservedInstancesModificationIDs []*string `locationName:"ReservedInstancesModificationId" locationNameList:"ReservedInstancesModificationId" type:"list"`
 
-	metadataDescribeReservedInstancesModificationsInput `json:"-", xml:"-"`
+	metadataDescribeReservedInstancesModificationsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeReservedInstancesModificationsInput struct {
@@ -10650,7 +10650,7 @@ type DescribeReservedInstancesModificationsOutput struct {
 	// The Reserved Instance modification information.
 	ReservedInstancesModifications []*ReservedInstancesModification `locationName:"reservedInstancesModificationsSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeReservedInstancesModificationsOutput `json:"-", xml:"-"`
+	metadataDescribeReservedInstancesModificationsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeReservedInstancesModificationsOutput struct {
@@ -10742,7 +10742,7 @@ type DescribeReservedInstancesOfferingsInput struct {
 	// One or more Reserved Instances offering IDs.
 	ReservedInstancesOfferingIDs []*string `locationName:"ReservedInstancesOfferingId" type:"list"`
 
-	metadataDescribeReservedInstancesOfferingsInput `json:"-", xml:"-"`
+	metadataDescribeReservedInstancesOfferingsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeReservedInstancesOfferingsInput struct {
@@ -10757,7 +10757,7 @@ type DescribeReservedInstancesOfferingsOutput struct {
 	// A list of Reserved Instances offerings.
 	ReservedInstancesOfferings []*ReservedInstancesOffering `locationName:"reservedInstancesOfferingsSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeReservedInstancesOfferingsOutput `json:"-", xml:"-"`
+	metadataDescribeReservedInstancesOfferingsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeReservedInstancesOfferingsOutput struct {
@@ -10768,7 +10768,7 @@ type DescribeReservedInstancesOutput struct {
 	// A list of Reserved Instances.
 	ReservedInstances []*ReservedInstances `locationName:"reservedInstancesSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeReservedInstancesOutput `json:"-", xml:"-"`
+	metadataDescribeReservedInstancesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeReservedInstancesOutput struct {
@@ -10835,7 +10835,7 @@ type DescribeRouteTablesInput struct {
 	// Default: Describes all your route tables.
 	RouteTableIDs []*string `locationName:"RouteTableId" locationNameList:"item" type:"list"`
 
-	metadataDescribeRouteTablesInput `json:"-", xml:"-"`
+	metadataDescribeRouteTablesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeRouteTablesInput struct {
@@ -10846,7 +10846,7 @@ type DescribeRouteTablesOutput struct {
 	// Information about one or more route tables.
 	RouteTables []*RouteTable `locationName:"routeTableSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeRouteTablesOutput `json:"-", xml:"-"`
+	metadataDescribeRouteTablesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeRouteTablesOutput struct {
@@ -10907,7 +10907,7 @@ type DescribeSecurityGroupsInput struct {
 	// Default: Describes all your security groups.
 	GroupNames []*string `locationName:"GroupName" locationNameList:"GroupName" type:"list"`
 
-	metadataDescribeSecurityGroupsInput `json:"-", xml:"-"`
+	metadataDescribeSecurityGroupsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeSecurityGroupsInput struct {
@@ -10918,7 +10918,7 @@ type DescribeSecurityGroupsOutput struct {
 	// Information about one or more security groups.
 	SecurityGroups []*SecurityGroup `locationName:"securityGroupInfo" locationNameList:"item" type:"list"`
 
-	metadataDescribeSecurityGroupsOutput `json:"-", xml:"-"`
+	metadataDescribeSecurityGroupsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeSecurityGroupsOutput struct {
@@ -10934,7 +10934,7 @@ type DescribeSnapshotAttributeInput struct {
 	// The ID of the Amazon EBS snapshot.
 	SnapshotID *string `locationName:"SnapshotId" type:"string" required:"true"`
 
-	metadataDescribeSnapshotAttributeInput `json:"-", xml:"-"`
+	metadataDescribeSnapshotAttributeInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeSnapshotAttributeInput struct {
@@ -10951,7 +10951,7 @@ type DescribeSnapshotAttributeOutput struct {
 	// The ID of the Amazon EBS snapshot.
 	SnapshotID *string `locationName:"snapshotId" type:"string"`
 
-	metadataDescribeSnapshotAttributeOutput `json:"-", xml:"-"`
+	metadataDescribeSnapshotAttributeOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeSnapshotAttributeOutput struct {
@@ -11026,7 +11026,7 @@ type DescribeSnapshotsInput struct {
 	// Default: Describes snapshots for which you have launch permissions.
 	SnapshotIDs []*string `locationName:"SnapshotId" locationNameList:"SnapshotId" type:"list"`
 
-	metadataDescribeSnapshotsInput `json:"-", xml:"-"`
+	metadataDescribeSnapshotsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeSnapshotsInput struct {
@@ -11042,7 +11042,7 @@ type DescribeSnapshotsOutput struct {
 
 	Snapshots []*Snapshot `locationName:"snapshotSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeSnapshotsOutput `json:"-", xml:"-"`
+	metadataDescribeSnapshotsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeSnapshotsOutput struct {
@@ -11052,7 +11052,7 @@ type metadataDescribeSnapshotsOutput struct {
 type DescribeSpotDatafeedSubscriptionInput struct {
 	DryRun *bool `locationName:"dryRun" type:"boolean"`
 
-	metadataDescribeSpotDatafeedSubscriptionInput `json:"-", xml:"-"`
+	metadataDescribeSpotDatafeedSubscriptionInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeSpotDatafeedSubscriptionInput struct {
@@ -11063,7 +11063,7 @@ type DescribeSpotDatafeedSubscriptionOutput struct {
 	// The Spot Instance data feed subscription.
 	SpotDatafeedSubscription *SpotDatafeedSubscription `locationName:"spotDatafeedSubscription" type:"structure"`
 
-	metadataDescribeSpotDatafeedSubscriptionOutput `json:"-", xml:"-"`
+	metadataDescribeSpotDatafeedSubscriptionOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeSpotDatafeedSubscriptionOutput struct {
@@ -11186,7 +11186,7 @@ type DescribeSpotInstanceRequestsInput struct {
 	// One or more Spot Instance request IDs.
 	SpotInstanceRequestIDs []*string `locationName:"SpotInstanceRequestId" locationNameList:"SpotInstanceRequestId" type:"list"`
 
-	metadataDescribeSpotInstanceRequestsInput `json:"-", xml:"-"`
+	metadataDescribeSpotInstanceRequestsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeSpotInstanceRequestsInput struct {
@@ -11197,7 +11197,7 @@ type DescribeSpotInstanceRequestsOutput struct {
 	// One or more Spot Instance requests.
 	SpotInstanceRequests []*SpotInstanceRequest `locationName:"spotInstanceRequestSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeSpotInstanceRequestsOutput `json:"-", xml:"-"`
+	metadataDescribeSpotInstanceRequestsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeSpotInstanceRequestsOutput struct {
@@ -11252,7 +11252,7 @@ type DescribeSpotPriceHistoryInput struct {
 	// the price history data.
 	StartTime *time.Time `locationName:"startTime" type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataDescribeSpotPriceHistoryInput `json:"-", xml:"-"`
+	metadataDescribeSpotPriceHistoryInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeSpotPriceHistoryInput struct {
@@ -11267,7 +11267,7 @@ type DescribeSpotPriceHistoryOutput struct {
 	// The historical Spot Prices.
 	SpotPriceHistory []*SpotPrice `locationName:"spotPriceHistorySet" locationNameList:"item" type:"list"`
 
-	metadataDescribeSpotPriceHistoryOutput `json:"-", xml:"-"`
+	metadataDescribeSpotPriceHistoryOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeSpotPriceHistoryOutput struct {
@@ -11316,7 +11316,7 @@ type DescribeSubnetsInput struct {
 	// Default: Describes all your subnets.
 	SubnetIDs []*string `locationName:"SubnetId" locationNameList:"SubnetId" type:"list"`
 
-	metadataDescribeSubnetsInput `json:"-", xml:"-"`
+	metadataDescribeSubnetsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeSubnetsInput struct {
@@ -11327,7 +11327,7 @@ type DescribeSubnetsOutput struct {
 	// Information about one or more subnets.
 	Subnets []*Subnet `locationName:"subnetSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeSubnetsOutput `json:"-", xml:"-"`
+	metadataDescribeSubnetsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeSubnetsOutput struct {
@@ -11361,7 +11361,7 @@ type DescribeTagsInput struct {
 	// The token to retrieve the next page of results.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataDescribeTagsInput `json:"-", xml:"-"`
+	metadataDescribeTagsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeTagsInput struct {
@@ -11376,7 +11376,7 @@ type DescribeTagsOutput struct {
 	// A list of tags.
 	Tags []*TagDescription `locationName:"tagSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeTagsOutput `json:"-", xml:"-"`
+	metadataDescribeTagsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeTagsOutput struct {
@@ -11392,7 +11392,7 @@ type DescribeVPCAttributeInput struct {
 	// The ID of the VPC.
 	VPCID *string `locationName:"VpcId" type:"string" required:"true"`
 
-	metadataDescribeVPCAttributeInput `json:"-", xml:"-"`
+	metadataDescribeVPCAttributeInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeVPCAttributeInput struct {
@@ -11413,7 +11413,7 @@ type DescribeVPCAttributeOutput struct {
 	// The ID of the VPC.
 	VPCID *string `locationName:"vpcId" type:"string"`
 
-	metadataDescribeVPCAttributeOutput `json:"-", xml:"-"`
+	metadataDescribeVPCAttributeOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeVPCAttributeOutput struct {
@@ -11444,7 +11444,7 @@ type DescribeVPCClassicLinkInput struct {
 	// One or more VPCs for which you want to describe the ClassicLink status.
 	VPCIDs []*string `locationName:"VpcId" locationNameList:"VpcId" type:"list"`
 
-	metadataDescribeVPCClassicLinkInput `json:"-", xml:"-"`
+	metadataDescribeVPCClassicLinkInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeVPCClassicLinkInput struct {
@@ -11455,7 +11455,7 @@ type DescribeVPCClassicLinkOutput struct {
 	// The ClassicLink status of one or more VPCs.
 	VPCs []*VPCClassicLink `locationName:"vpcSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeVPCClassicLinkOutput `json:"-", xml:"-"`
+	metadataDescribeVPCClassicLinkOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeVPCClassicLinkOutput struct {
@@ -11509,7 +11509,7 @@ type DescribeVPCPeeringConnectionsInput struct {
 	// Default: Describes all your VPC peering connections.
 	VPCPeeringConnectionIDs []*string `locationName:"VpcPeeringConnectionId" locationNameList:"item" type:"list"`
 
-	metadataDescribeVPCPeeringConnectionsInput `json:"-", xml:"-"`
+	metadataDescribeVPCPeeringConnectionsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeVPCPeeringConnectionsInput struct {
@@ -11520,7 +11520,7 @@ type DescribeVPCPeeringConnectionsOutput struct {
 	// Information about the VPC peering connections.
 	VPCPeeringConnections []*VPCPeeringConnection `locationName:"vpcPeeringConnectionSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeVPCPeeringConnectionsOutput `json:"-", xml:"-"`
+	metadataDescribeVPCPeeringConnectionsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeVPCPeeringConnectionsOutput struct {
@@ -11562,7 +11562,7 @@ type DescribeVPCsInput struct {
 	// Default: Describes all your VPCs.
 	VPCIDs []*string `locationName:"VpcId" locationNameList:"VpcId" type:"list"`
 
-	metadataDescribeVPCsInput `json:"-", xml:"-"`
+	metadataDescribeVPCsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeVPCsInput struct {
@@ -11573,7 +11573,7 @@ type DescribeVPCsOutput struct {
 	// Information about one or more VPCs.
 	VPCs []*VPC `locationName:"vpcSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeVPCsOutput `json:"-", xml:"-"`
+	metadataDescribeVPCsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeVPCsOutput struct {
@@ -11630,7 +11630,7 @@ type DescribeVPNConnectionsInput struct {
 	// Default: Describes your VPN connections.
 	VPNConnectionIDs []*string `locationName:"VpnConnectionId" locationNameList:"VpnConnectionId" type:"list"`
 
-	metadataDescribeVPNConnectionsInput `json:"-", xml:"-"`
+	metadataDescribeVPNConnectionsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeVPNConnectionsInput struct {
@@ -11641,7 +11641,7 @@ type DescribeVPNConnectionsOutput struct {
 	// Information about one or more VPN connections.
 	VPNConnections []*VPNConnection `locationName:"vpnConnectionSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeVPNConnectionsOutput `json:"-", xml:"-"`
+	metadataDescribeVPNConnectionsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeVPNConnectionsOutput struct {
@@ -11686,7 +11686,7 @@ type DescribeVPNGatewaysInput struct {
 	// Default: Describes all your virtual private gateways.
 	VPNGatewayIDs []*string `locationName:"VpnGatewayId" locationNameList:"VpnGatewayId" type:"list"`
 
-	metadataDescribeVPNGatewaysInput `json:"-", xml:"-"`
+	metadataDescribeVPNGatewaysInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeVPNGatewaysInput struct {
@@ -11697,7 +11697,7 @@ type DescribeVPNGatewaysOutput struct {
 	// Information about one or more virtual private gateways.
 	VPNGateways []*VPNGateway `locationName:"vpnGatewaySet" locationNameList:"item" type:"list"`
 
-	metadataDescribeVPNGatewaysOutput `json:"-", xml:"-"`
+	metadataDescribeVPNGatewaysOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeVPNGatewaysOutput struct {
@@ -11713,7 +11713,7 @@ type DescribeVolumeAttributeInput struct {
 	// The ID of the volume.
 	VolumeID *string `locationName:"VolumeId" type:"string" required:"true"`
 
-	metadataDescribeVolumeAttributeInput `json:"-", xml:"-"`
+	metadataDescribeVolumeAttributeInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeVolumeAttributeInput struct {
@@ -11730,7 +11730,7 @@ type DescribeVolumeAttributeOutput struct {
 	// The ID of the volume.
 	VolumeID *string `locationName:"volumeId" type:"string"`
 
-	metadataDescribeVolumeAttributeOutput `json:"-", xml:"-"`
+	metadataDescribeVolumeAttributeOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeVolumeAttributeOutput struct {
@@ -11794,7 +11794,7 @@ type DescribeVolumeStatusInput struct {
 	// Default: Describes all your volumes.
 	VolumeIDs []*string `locationName:"VolumeId" locationNameList:"VolumeId" type:"list"`
 
-	metadataDescribeVolumeStatusInput `json:"-", xml:"-"`
+	metadataDescribeVolumeStatusInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeVolumeStatusInput struct {
@@ -11809,7 +11809,7 @@ type DescribeVolumeStatusOutput struct {
 	// A list of volumes.
 	VolumeStatuses []*VolumeStatusItem `locationName:"volumeStatusSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeVolumeStatusOutput `json:"-", xml:"-"`
+	metadataDescribeVolumeStatusOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeVolumeStatusOutput struct {
@@ -11887,7 +11887,7 @@ type DescribeVolumesInput struct {
 	// One or more volume IDs.
 	VolumeIDs []*string `locationName:"VolumeId" locationNameList:"VolumeId" type:"list"`
 
-	metadataDescribeVolumesInput `json:"-", xml:"-"`
+	metadataDescribeVolumesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeVolumesInput struct {
@@ -11903,7 +11903,7 @@ type DescribeVolumesOutput struct {
 
 	Volumes []*Volume `locationName:"volumeSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeVolumesOutput `json:"-", xml:"-"`
+	metadataDescribeVolumesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeVolumesOutput struct {
@@ -11919,7 +11919,7 @@ type DetachClassicLinkVPCInput struct {
 	// The ID of the VPC to which the instance is linked.
 	VPCID *string `locationName:"vpcId" type:"string" required:"true"`
 
-	metadataDetachClassicLinkVPCInput `json:"-", xml:"-"`
+	metadataDetachClassicLinkVPCInput `json:"-" xml:"-"`
 }
 
 type metadataDetachClassicLinkVPCInput struct {
@@ -11930,7 +11930,7 @@ type DetachClassicLinkVPCOutput struct {
 	// Returns true if the request succeeds; otherwise, it returns an error.
 	Return *bool `locationName:"return" type:"boolean"`
 
-	metadataDetachClassicLinkVPCOutput `json:"-", xml:"-"`
+	metadataDetachClassicLinkVPCOutput `json:"-" xml:"-"`
 }
 
 type metadataDetachClassicLinkVPCOutput struct {
@@ -11946,7 +11946,7 @@ type DetachInternetGatewayInput struct {
 	// The ID of the VPC.
 	VPCID *string `locationName:"vpcId" type:"string" required:"true"`
 
-	metadataDetachInternetGatewayInput `json:"-", xml:"-"`
+	metadataDetachInternetGatewayInput `json:"-" xml:"-"`
 }
 
 type metadataDetachInternetGatewayInput struct {
@@ -11954,7 +11954,7 @@ type metadataDetachInternetGatewayInput struct {
 }
 
 type DetachInternetGatewayOutput struct {
-	metadataDetachInternetGatewayOutput `json:"-", xml:"-"`
+	metadataDetachInternetGatewayOutput `json:"-" xml:"-"`
 }
 
 type metadataDetachInternetGatewayOutput struct {
@@ -11970,7 +11970,7 @@ type DetachNetworkInterfaceInput struct {
 	// Specifies whether to force a detachment.
 	Force *bool `locationName:"force" type:"boolean"`
 
-	metadataDetachNetworkInterfaceInput `json:"-", xml:"-"`
+	metadataDetachNetworkInterfaceInput `json:"-" xml:"-"`
 }
 
 type metadataDetachNetworkInterfaceInput struct {
@@ -11978,7 +11978,7 @@ type metadataDetachNetworkInterfaceInput struct {
 }
 
 type DetachNetworkInterfaceOutput struct {
-	metadataDetachNetworkInterfaceOutput `json:"-", xml:"-"`
+	metadataDetachNetworkInterfaceOutput `json:"-" xml:"-"`
 }
 
 type metadataDetachNetworkInterfaceOutput struct {
@@ -11994,7 +11994,7 @@ type DetachVPNGatewayInput struct {
 	// The ID of the virtual private gateway.
 	VPNGatewayID *string `locationName:"VpnGatewayId" type:"string" required:"true"`
 
-	metadataDetachVPNGatewayInput `json:"-", xml:"-"`
+	metadataDetachVPNGatewayInput `json:"-" xml:"-"`
 }
 
 type metadataDetachVPNGatewayInput struct {
@@ -12002,7 +12002,7 @@ type metadataDetachVPNGatewayInput struct {
 }
 
 type DetachVPNGatewayOutput struct {
-	metadataDetachVPNGatewayOutput `json:"-", xml:"-"`
+	metadataDetachVPNGatewayOutput `json:"-" xml:"-"`
 }
 
 type metadataDetachVPNGatewayOutput struct {
@@ -12030,7 +12030,7 @@ type DetachVolumeInput struct {
 	// The ID of the volume.
 	VolumeID *string `locationName:"VolumeId" type:"string" required:"true"`
 
-	metadataDetachVolumeInput `json:"-", xml:"-"`
+	metadataDetachVolumeInput `json:"-" xml:"-"`
 }
 
 type metadataDetachVolumeInput struct {
@@ -12044,7 +12044,7 @@ type DisableVGWRoutePropagationInput struct {
 	// The ID of the route table.
 	RouteTableID *string `locationName:"RouteTableId" type:"string" required:"true"`
 
-	metadataDisableVGWRoutePropagationInput `json:"-", xml:"-"`
+	metadataDisableVGWRoutePropagationInput `json:"-" xml:"-"`
 }
 
 type metadataDisableVGWRoutePropagationInput struct {
@@ -12052,7 +12052,7 @@ type metadataDisableVGWRoutePropagationInput struct {
 }
 
 type DisableVGWRoutePropagationOutput struct {
-	metadataDisableVGWRoutePropagationOutput `json:"-", xml:"-"`
+	metadataDisableVGWRoutePropagationOutput `json:"-" xml:"-"`
 }
 
 type metadataDisableVGWRoutePropagationOutput struct {
@@ -12065,7 +12065,7 @@ type DisableVPCClassicLinkInput struct {
 	// The ID of the VPC.
 	VPCID *string `locationName:"vpcId" type:"string" required:"true"`
 
-	metadataDisableVPCClassicLinkInput `json:"-", xml:"-"`
+	metadataDisableVPCClassicLinkInput `json:"-" xml:"-"`
 }
 
 type metadataDisableVPCClassicLinkInput struct {
@@ -12076,7 +12076,7 @@ type DisableVPCClassicLinkOutput struct {
 	// Returns true if the request succeeds; otherwise, it returns an error.
 	Return *bool `locationName:"return" type:"boolean"`
 
-	metadataDisableVPCClassicLinkOutput `json:"-", xml:"-"`
+	metadataDisableVPCClassicLinkOutput `json:"-" xml:"-"`
 }
 
 type metadataDisableVPCClassicLinkOutput struct {
@@ -12092,7 +12092,7 @@ type DisassociateAddressInput struct {
 	// [EC2-Classic] The Elastic IP address. Required for EC2-Classic.
 	PublicIP *string `locationName:"PublicIp" type:"string"`
 
-	metadataDisassociateAddressInput `json:"-", xml:"-"`
+	metadataDisassociateAddressInput `json:"-" xml:"-"`
 }
 
 type metadataDisassociateAddressInput struct {
@@ -12100,7 +12100,7 @@ type metadataDisassociateAddressInput struct {
 }
 
 type DisassociateAddressOutput struct {
-	metadataDisassociateAddressOutput `json:"-", xml:"-"`
+	metadataDisassociateAddressOutput `json:"-" xml:"-"`
 }
 
 type metadataDisassociateAddressOutput struct {
@@ -12114,7 +12114,7 @@ type DisassociateRouteTableInput struct {
 
 	DryRun *bool `locationName:"dryRun" type:"boolean"`
 
-	metadataDisassociateRouteTableInput `json:"-", xml:"-"`
+	metadataDisassociateRouteTableInput `json:"-" xml:"-"`
 }
 
 type metadataDisassociateRouteTableInput struct {
@@ -12122,7 +12122,7 @@ type metadataDisassociateRouteTableInput struct {
 }
 
 type DisassociateRouteTableOutput struct {
-	metadataDisassociateRouteTableOutput `json:"-", xml:"-"`
+	metadataDisassociateRouteTableOutput `json:"-" xml:"-"`
 }
 
 type metadataDisassociateRouteTableOutput struct {
@@ -12138,7 +12138,7 @@ type DiskImage struct {
 	// Describes an Amazon EBS volume.
 	Volume *VolumeDetail `type:"structure"`
 
-	metadataDiskImage `json:"-", xml:"-"`
+	metadataDiskImage `json:"-" xml:"-"`
 }
 
 type metadataDiskImage struct {
@@ -12162,7 +12162,7 @@ type DiskImageDescription struct {
 	// The size of the disk image.
 	Size *int64 `locationName:"size" type:"long" required:"true"`
 
-	metadataDiskImageDescription `json:"-", xml:"-"`
+	metadataDiskImageDescription `json:"-" xml:"-"`
 }
 
 type metadataDiskImageDescription struct {
@@ -12182,7 +12182,7 @@ type DiskImageDetail struct {
 	// topic in the Amazon Simple Storage Service Developer Guide.
 	ImportManifestURL *string `locationName:"importManifestUrl" type:"string" required:"true"`
 
-	metadataDiskImageDetail `json:"-", xml:"-"`
+	metadataDiskImageDetail `json:"-" xml:"-"`
 }
 
 type metadataDiskImageDetail struct {
@@ -12196,7 +12196,7 @@ type DiskImageVolumeDescription struct {
 	// The size of the volume.
 	Size *int64 `locationName:"size" type:"long"`
 
-	metadataDiskImageVolumeDescription `json:"-", xml:"-"`
+	metadataDiskImageVolumeDescription `json:"-" xml:"-"`
 }
 
 type metadataDiskImageVolumeDescription struct {
@@ -12246,7 +12246,7 @@ type EBSBlockDevice struct {
 	// Default: standard
 	VolumeType *string `locationName:"volumeType" type:"string"`
 
-	metadataEBSBlockDevice `json:"-", xml:"-"`
+	metadataEBSBlockDevice `json:"-" xml:"-"`
 }
 
 type metadataEBSBlockDevice struct {
@@ -12268,7 +12268,7 @@ type EBSInstanceBlockDevice struct {
 	// The ID of the Amazon EBS volume.
 	VolumeID *string `locationName:"volumeId" type:"string"`
 
-	metadataEBSInstanceBlockDevice `json:"-", xml:"-"`
+	metadataEBSInstanceBlockDevice `json:"-" xml:"-"`
 }
 
 type metadataEBSInstanceBlockDevice struct {
@@ -12282,7 +12282,7 @@ type EBSInstanceBlockDeviceSpecification struct {
 	// The ID of the Amazon EBS volume.
 	VolumeID *string `locationName:"volumeId" type:"string"`
 
-	metadataEBSInstanceBlockDeviceSpecification `json:"-", xml:"-"`
+	metadataEBSInstanceBlockDeviceSpecification `json:"-" xml:"-"`
 }
 
 type metadataEBSInstanceBlockDeviceSpecification struct {
@@ -12296,7 +12296,7 @@ type EnableVGWRoutePropagationInput struct {
 	// The ID of the route table.
 	RouteTableID *string `locationName:"RouteTableId" type:"string" required:"true"`
 
-	metadataEnableVGWRoutePropagationInput `json:"-", xml:"-"`
+	metadataEnableVGWRoutePropagationInput `json:"-" xml:"-"`
 }
 
 type metadataEnableVGWRoutePropagationInput struct {
@@ -12304,7 +12304,7 @@ type metadataEnableVGWRoutePropagationInput struct {
 }
 
 type EnableVGWRoutePropagationOutput struct {
-	metadataEnableVGWRoutePropagationOutput `json:"-", xml:"-"`
+	metadataEnableVGWRoutePropagationOutput `json:"-" xml:"-"`
 }
 
 type metadataEnableVGWRoutePropagationOutput struct {
@@ -12317,7 +12317,7 @@ type EnableVPCClassicLinkInput struct {
 	// The ID of the VPC.
 	VPCID *string `locationName:"vpcId" type:"string" required:"true"`
 
-	metadataEnableVPCClassicLinkInput `json:"-", xml:"-"`
+	metadataEnableVPCClassicLinkInput `json:"-" xml:"-"`
 }
 
 type metadataEnableVPCClassicLinkInput struct {
@@ -12328,7 +12328,7 @@ type EnableVPCClassicLinkOutput struct {
 	// Returns true if the request succeeds; otherwise, it returns an error.
 	Return *bool `locationName:"return" type:"boolean"`
 
-	metadataEnableVPCClassicLinkOutput `json:"-", xml:"-"`
+	metadataEnableVPCClassicLinkOutput `json:"-" xml:"-"`
 }
 
 type metadataEnableVPCClassicLinkOutput struct {
@@ -12341,7 +12341,7 @@ type EnableVolumeIOInput struct {
 	// The ID of the volume.
 	VolumeID *string `locationName:"volumeId" type:"string" required:"true"`
 
-	metadataEnableVolumeIOInput `json:"-", xml:"-"`
+	metadataEnableVolumeIOInput `json:"-" xml:"-"`
 }
 
 type metadataEnableVolumeIOInput struct {
@@ -12349,7 +12349,7 @@ type metadataEnableVolumeIOInput struct {
 }
 
 type EnableVolumeIOOutput struct {
-	metadataEnableVolumeIOOutput `json:"-", xml:"-"`
+	metadataEnableVolumeIOOutput `json:"-" xml:"-"`
 }
 
 type metadataEnableVolumeIOOutput struct {
@@ -12375,7 +12375,7 @@ type ExportTask struct {
 	// The status message related to the export task.
 	StatusMessage *string `locationName:"statusMessage" type:"string"`
 
-	metadataExportTask `json:"-", xml:"-"`
+	metadataExportTask `json:"-" xml:"-"`
 }
 
 type metadataExportTask struct {
@@ -12396,7 +12396,7 @@ type ExportToS3Task struct {
 
 	S3Key *string `locationName:"s3Key" type:"string"`
 
-	metadataExportToS3Task `json:"-", xml:"-"`
+	metadataExportToS3Task `json:"-" xml:"-"`
 }
 
 type metadataExportToS3Task struct {
@@ -12414,7 +12414,7 @@ type ExportToS3TaskSpecification struct {
 	// key s3prefix + exportTaskId + '.' + diskImageFormat.
 	S3Prefix *string `locationName:"s3Prefix" type:"string"`
 
-	metadataExportToS3TaskSpecification `json:"-", xml:"-"`
+	metadataExportToS3TaskSpecification `json:"-" xml:"-"`
 }
 
 type metadataExportToS3TaskSpecification struct {
@@ -12431,7 +12431,7 @@ type Filter struct {
 	// One or more filter values. Filter values are case-sensitive.
 	Values []*string `locationName:"Value" locationNameList:"item" type:"list"`
 
-	metadataFilter `json:"-", xml:"-"`
+	metadataFilter `json:"-" xml:"-"`
 }
 
 type metadataFilter struct {
@@ -12444,7 +12444,7 @@ type GetConsoleOutputInput struct {
 	// The ID of the instance.
 	InstanceID *string `locationName:"InstanceId" type:"string" required:"true"`
 
-	metadataGetConsoleOutputInput `json:"-", xml:"-"`
+	metadataGetConsoleOutputInput `json:"-" xml:"-"`
 }
 
 type metadataGetConsoleOutputInput struct {
@@ -12461,7 +12461,7 @@ type GetConsoleOutputOutput struct {
 	// The time the output was last updated.
 	Timestamp *time.Time `locationName:"timestamp" type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataGetConsoleOutputOutput `json:"-", xml:"-"`
+	metadataGetConsoleOutputOutput `json:"-" xml:"-"`
 }
 
 type metadataGetConsoleOutputOutput struct {
@@ -12474,7 +12474,7 @@ type GetPasswordDataInput struct {
 	// The ID of the Windows instance.
 	InstanceID *string `locationName:"InstanceId" type:"string" required:"true"`
 
-	metadataGetPasswordDataInput `json:"-", xml:"-"`
+	metadataGetPasswordDataInput `json:"-" xml:"-"`
 }
 
 type metadataGetPasswordDataInput struct {
@@ -12491,7 +12491,7 @@ type GetPasswordDataOutput struct {
 	// The time the data was last updated.
 	Timestamp *time.Time `locationName:"timestamp" type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataGetPasswordDataOutput `json:"-", xml:"-"`
+	metadataGetPasswordDataOutput `json:"-" xml:"-"`
 }
 
 type metadataGetPasswordDataOutput struct {
@@ -12506,7 +12506,7 @@ type GroupIdentifier struct {
 	// The name of the security group.
 	GroupName *string `locationName:"groupName" type:"string"`
 
-	metadataGroupIdentifier `json:"-", xml:"-"`
+	metadataGroupIdentifier `json:"-" xml:"-"`
 }
 
 type metadataGroupIdentifier struct {
@@ -12521,7 +12521,7 @@ type IAMInstanceProfile struct {
 	// The ID of the instance profile.
 	ID *string `locationName:"id" type:"string"`
 
-	metadataIAMInstanceProfile `json:"-", xml:"-"`
+	metadataIAMInstanceProfile `json:"-" xml:"-"`
 }
 
 type metadataIAMInstanceProfile struct {
@@ -12536,7 +12536,7 @@ type IAMInstanceProfileSpecification struct {
 	// The name of the instance profile.
 	Name *string `locationName:"name" type:"string"`
 
-	metadataIAMInstanceProfileSpecification `json:"-", xml:"-"`
+	metadataIAMInstanceProfileSpecification `json:"-" xml:"-"`
 }
 
 type metadataIAMInstanceProfileSpecification struct {
@@ -12551,7 +12551,7 @@ type ICMPTypeCode struct {
 	// The ICMP code. A value of -1 means all codes for the specified ICMP type.
 	Type *int64 `locationName:"type" type:"integer"`
 
-	metadataICMPTypeCode `json:"-", xml:"-"`
+	metadataICMPTypeCode `json:"-" xml:"-"`
 }
 
 type metadataICMPTypeCode struct {
@@ -12584,7 +12584,7 @@ type IPPermission struct {
 	// One or more security group and AWS account ID pairs.
 	UserIDGroupPairs []*UserIDGroupPair `locationName:"groups" locationNameList:"item" type:"list"`
 
-	metadataIPPermission `json:"-", xml:"-"`
+	metadataIPPermission `json:"-" xml:"-"`
 }
 
 type metadataIPPermission struct {
@@ -12597,7 +12597,7 @@ type IPRange struct {
 	// group, not both.
 	CIDRIP *string `locationName:"cidrIp" type:"string"`
 
-	metadataIPRange `json:"-", xml:"-"`
+	metadataIPRange `json:"-" xml:"-"`
 }
 
 type metadataIPRange struct {
@@ -12682,7 +12682,7 @@ type Image struct {
 	// The type of virtualization of the AMI.
 	VirtualizationType *string `locationName:"virtualizationType" type:"string"`
 
-	metadataImage `json:"-", xml:"-"`
+	metadataImage `json:"-" xml:"-"`
 }
 
 type metadataImage struct {
@@ -12710,7 +12710,7 @@ type ImageDiskContainer struct {
 	// User's Amazon S3 bucket details used to access the image.
 	UserBucket *UserBucket `type:"structure"`
 
-	metadataImageDiskContainer `json:"-", xml:"-"`
+	metadataImageDiskContainer `json:"-" xml:"-"`
 }
 
 type metadataImageDiskContainer struct {
@@ -12755,7 +12755,7 @@ type ImportImageInput struct {
 	// (optional).
 	RoleName *string `type:"string"`
 
-	metadataImportImageInput `json:"-", xml:"-"`
+	metadataImportImageInput `json:"-" xml:"-"`
 }
 
 type metadataImportImageInput struct {
@@ -12795,7 +12795,7 @@ type ImportImageOutput struct {
 	// A detailed status message of the import task.
 	StatusMessage *string `locationName:"statusMessage" type:"string"`
 
-	metadataImportImageOutput `json:"-", xml:"-"`
+	metadataImportImageOutput `json:"-" xml:"-"`
 }
 
 type metadataImportImageOutput struct {
@@ -12835,7 +12835,7 @@ type ImportImageTask struct {
 	// A descriptive status message for the ImportImage task.
 	StatusMessage *string `locationName:"statusMessage" type:"string"`
 
-	metadataImportImageTask `json:"-", xml:"-"`
+	metadataImportImageTask `json:"-" xml:"-"`
 }
 
 type metadataImportImageTask struct {
@@ -12855,7 +12855,7 @@ type ImportInstanceInput struct {
 	// The instance operating system.
 	Platform *string `locationName:"platform" type:"string" required:"true"`
 
-	metadataImportInstanceInput `json:"-", xml:"-"`
+	metadataImportInstanceInput `json:"-" xml:"-"`
 }
 
 type metadataImportInstanceInput struct {
@@ -12902,7 +12902,7 @@ type ImportInstanceLaunchSpecification struct {
 	// User data to be made available to the instance.
 	UserData *UserData `locationName:"userData" type:"structure"`
 
-	metadataImportInstanceLaunchSpecification `json:"-", xml:"-"`
+	metadataImportInstanceLaunchSpecification `json:"-" xml:"-"`
 }
 
 type metadataImportInstanceLaunchSpecification struct {
@@ -12913,7 +12913,7 @@ type ImportInstanceOutput struct {
 	// Describes a conversion task.
 	ConversionTask *ConversionTask `locationName:"conversionTask" type:"structure"`
 
-	metadataImportInstanceOutput `json:"-", xml:"-"`
+	metadataImportInstanceOutput `json:"-" xml:"-"`
 }
 
 type metadataImportInstanceOutput struct {
@@ -12930,7 +12930,7 @@ type ImportInstanceTaskDetails struct {
 
 	Volumes []*ImportInstanceVolumeDetailItem `locationName:"volumes" locationNameList:"item" type:"list" required:"true"`
 
-	metadataImportInstanceTaskDetails `json:"-", xml:"-"`
+	metadataImportInstanceTaskDetails `json:"-" xml:"-"`
 }
 
 type metadataImportInstanceTaskDetails struct {
@@ -12959,7 +12959,7 @@ type ImportInstanceVolumeDetailItem struct {
 	// The volume.
 	Volume *DiskImageVolumeDescription `locationName:"volume" type:"structure" required:"true"`
 
-	metadataImportInstanceVolumeDetailItem `json:"-", xml:"-"`
+	metadataImportInstanceVolumeDetailItem `json:"-" xml:"-"`
 }
 
 type metadataImportInstanceVolumeDetailItem struct {
@@ -12976,7 +12976,7 @@ type ImportKeyPairInput struct {
 	// it to AWS.
 	PublicKeyMaterial []byte `locationName:"publicKeyMaterial" type:"blob" required:"true"`
 
-	metadataImportKeyPairInput `json:"-", xml:"-"`
+	metadataImportKeyPairInput `json:"-" xml:"-"`
 }
 
 type metadataImportKeyPairInput struct {
@@ -12990,7 +12990,7 @@ type ImportKeyPairOutput struct {
 	// The key pair name you provided.
 	KeyName *string `locationName:"keyName" type:"string"`
 
-	metadataImportKeyPairOutput `json:"-", xml:"-"`
+	metadataImportKeyPairOutput `json:"-" xml:"-"`
 }
 
 type metadataImportKeyPairOutput struct {
@@ -13016,7 +13016,7 @@ type ImportSnapshotInput struct {
 	// (optional).
 	RoleName *string `type:"string"`
 
-	metadataImportSnapshotInput `json:"-", xml:"-"`
+	metadataImportSnapshotInput `json:"-" xml:"-"`
 }
 
 type metadataImportSnapshotInput struct {
@@ -13033,7 +13033,7 @@ type ImportSnapshotOutput struct {
 	// Details about the import snapshot task.
 	SnapshotTaskDetail *SnapshotTaskDetail `locationName:"snapshotTaskDetail" type:"structure"`
 
-	metadataImportSnapshotOutput `json:"-", xml:"-"`
+	metadataImportSnapshotOutput `json:"-" xml:"-"`
 }
 
 type metadataImportSnapshotOutput struct {
@@ -13050,7 +13050,7 @@ type ImportSnapshotTask struct {
 	// Details about the import snapshot task.
 	SnapshotTaskDetail *SnapshotTaskDetail `locationName:"snapshotTaskDetail" type:"structure"`
 
-	metadataImportSnapshotTask `json:"-", xml:"-"`
+	metadataImportSnapshotTask `json:"-" xml:"-"`
 }
 
 type metadataImportSnapshotTask struct {
@@ -13071,7 +13071,7 @@ type ImportVolumeInput struct {
 	// Describes an Amazon EBS volume.
 	Volume *VolumeDetail `locationName:"volume" type:"structure" required:"true"`
 
-	metadataImportVolumeInput `json:"-", xml:"-"`
+	metadataImportVolumeInput `json:"-" xml:"-"`
 }
 
 type metadataImportVolumeInput struct {
@@ -13082,7 +13082,7 @@ type ImportVolumeOutput struct {
 	// Describes a conversion task.
 	ConversionTask *ConversionTask `locationName:"conversionTask" type:"structure"`
 
-	metadataImportVolumeOutput `json:"-", xml:"-"`
+	metadataImportVolumeOutput `json:"-" xml:"-"`
 }
 
 type metadataImportVolumeOutput struct {
@@ -13106,7 +13106,7 @@ type ImportVolumeTaskDetails struct {
 	// The volume.
 	Volume *DiskImageVolumeDescription `locationName:"volume" type:"structure" required:"true"`
 
-	metadataImportVolumeTaskDetails `json:"-", xml:"-"`
+	metadataImportVolumeTaskDetails `json:"-" xml:"-"`
 }
 
 type metadataImportVolumeTaskDetails struct {
@@ -13241,7 +13241,7 @@ type Instance struct {
 	// The virtualization type of the instance.
 	VirtualizationType *string `locationName:"virtualizationType" type:"string"`
 
-	metadataInstance `json:"-", xml:"-"`
+	metadataInstance `json:"-" xml:"-"`
 }
 
 type metadataInstance struct {
@@ -13257,7 +13257,7 @@ type InstanceBlockDeviceMapping struct {
 	// is launched.
 	EBS *EBSInstanceBlockDevice `locationName:"ebs" type:"structure"`
 
-	metadataInstanceBlockDeviceMapping `json:"-", xml:"-"`
+	metadataInstanceBlockDeviceMapping `json:"-" xml:"-"`
 }
 
 type metadataInstanceBlockDeviceMapping struct {
@@ -13279,7 +13279,7 @@ type InstanceBlockDeviceMappingSpecification struct {
 	// The virtual device name.
 	VirtualName *string `locationName:"virtualName" type:"string"`
 
-	metadataInstanceBlockDeviceMappingSpecification `json:"-", xml:"-"`
+	metadataInstanceBlockDeviceMappingSpecification `json:"-" xml:"-"`
 }
 
 type metadataInstanceBlockDeviceMappingSpecification struct {
@@ -13294,7 +13294,7 @@ type InstanceCount struct {
 	// The states of the listed Reserved Instances.
 	State *string `locationName:"state" type:"string"`
 
-	metadataInstanceCount `json:"-", xml:"-"`
+	metadataInstanceCount `json:"-" xml:"-"`
 }
 
 type metadataInstanceCount struct {
@@ -13309,7 +13309,7 @@ type InstanceExportDetails struct {
 	// The target virtualization environment.
 	TargetEnvironment *string `locationName:"targetEnvironment" type:"string"`
 
-	metadataInstanceExportDetails `json:"-", xml:"-"`
+	metadataInstanceExportDetails `json:"-" xml:"-"`
 }
 
 type metadataInstanceExportDetails struct {
@@ -13324,7 +13324,7 @@ type InstanceMonitoring struct {
 	// The monitoring information.
 	Monitoring *Monitoring `locationName:"monitoring" type:"structure"`
 
-	metadataInstanceMonitoring `json:"-", xml:"-"`
+	metadataInstanceMonitoring `json:"-" xml:"-"`
 }
 
 type metadataInstanceMonitoring struct {
@@ -13376,7 +13376,7 @@ type InstanceNetworkInterface struct {
 	// The ID of the VPC.
 	VPCID *string `locationName:"vpcId" type:"string"`
 
-	metadataInstanceNetworkInterface `json:"-", xml:"-"`
+	metadataInstanceNetworkInterface `json:"-" xml:"-"`
 }
 
 type metadataInstanceNetworkInterface struct {
@@ -13394,7 +13394,7 @@ type InstanceNetworkInterfaceAssociation struct {
 	// The public IP address or Elastic IP address bound to the network interface.
 	PublicIP *string `locationName:"publicIp" type:"string"`
 
-	metadataInstanceNetworkInterfaceAssociation `json:"-", xml:"-"`
+	metadataInstanceNetworkInterfaceAssociation `json:"-" xml:"-"`
 }
 
 type metadataInstanceNetworkInterfaceAssociation struct {
@@ -13418,7 +13418,7 @@ type InstanceNetworkInterfaceAttachment struct {
 	// The attachment state.
 	Status *string `locationName:"status" type:"string"`
 
-	metadataInstanceNetworkInterfaceAttachment `json:"-", xml:"-"`
+	metadataInstanceNetworkInterfaceAttachment `json:"-" xml:"-"`
 }
 
 type metadataInstanceNetworkInterfaceAttachment struct {
@@ -13472,7 +13472,7 @@ type InstanceNetworkInterfaceSpecification struct {
 	// creating a network interface when launching an instance.
 	SubnetID *string `locationName:"subnetId" type:"string"`
 
-	metadataInstanceNetworkInterfaceSpecification `json:"-", xml:"-"`
+	metadataInstanceNetworkInterfaceSpecification `json:"-" xml:"-"`
 }
 
 type metadataInstanceNetworkInterfaceSpecification struct {
@@ -13494,7 +13494,7 @@ type InstancePrivateIPAddress struct {
 	// The private IP address of the network interface.
 	PrivateIPAddress *string `locationName:"privateIpAddress" type:"string"`
 
-	metadataInstancePrivateIPAddress `json:"-", xml:"-"`
+	metadataInstancePrivateIPAddress `json:"-" xml:"-"`
 }
 
 type metadataInstancePrivateIPAddress struct {
@@ -13522,7 +13522,7 @@ type InstanceState struct {
 	// The current state of the instance.
 	Name *string `locationName:"name" type:"string"`
 
-	metadataInstanceState `json:"-", xml:"-"`
+	metadataInstanceState `json:"-" xml:"-"`
 }
 
 type metadataInstanceState struct {
@@ -13540,7 +13540,7 @@ type InstanceStateChange struct {
 	// The previous state of the instance.
 	PreviousState *InstanceState `locationName:"previousState" type:"structure"`
 
-	metadataInstanceStateChange `json:"-", xml:"-"`
+	metadataInstanceStateChange `json:"-" xml:"-"`
 }
 
 type metadataInstanceStateChange struct {
@@ -13571,7 +13571,7 @@ type InstanceStatus struct {
 	// problems.
 	SystemStatus *InstanceStatusSummary `locationName:"systemStatus" type:"structure"`
 
-	metadataInstanceStatus `json:"-", xml:"-"`
+	metadataInstanceStatus `json:"-" xml:"-"`
 }
 
 type metadataInstanceStatus struct {
@@ -13590,7 +13590,7 @@ type InstanceStatusDetails struct {
 	// The status.
 	Status *string `locationName:"status" type:"string"`
 
-	metadataInstanceStatusDetails `json:"-", xml:"-"`
+	metadataInstanceStatusDetails `json:"-" xml:"-"`
 }
 
 type metadataInstanceStatusDetails struct {
@@ -13611,7 +13611,7 @@ type InstanceStatusEvent struct {
 	// The earliest scheduled start time for the event.
 	NotBefore *time.Time `locationName:"notBefore" type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataInstanceStatusEvent `json:"-", xml:"-"`
+	metadataInstanceStatusEvent `json:"-" xml:"-"`
 }
 
 type metadataInstanceStatusEvent struct {
@@ -13626,7 +13626,7 @@ type InstanceStatusSummary struct {
 	// The status.
 	Status *string `locationName:"status" type:"string"`
 
-	metadataInstanceStatusSummary `json:"-", xml:"-"`
+	metadataInstanceStatusSummary `json:"-" xml:"-"`
 }
 
 type metadataInstanceStatusSummary struct {
@@ -13644,7 +13644,7 @@ type InternetGateway struct {
 	// Any tags assigned to the Internet gateway.
 	Tags []*Tag `locationName:"tagSet" locationNameList:"item" type:"list"`
 
-	metadataInternetGateway `json:"-", xml:"-"`
+	metadataInternetGateway `json:"-" xml:"-"`
 }
 
 type metadataInternetGateway struct {
@@ -13659,7 +13659,7 @@ type InternetGatewayAttachment struct {
 	// The ID of the VPC.
 	VPCID *string `locationName:"vpcId" type:"string"`
 
-	metadataInternetGatewayAttachment `json:"-", xml:"-"`
+	metadataInternetGatewayAttachment `json:"-" xml:"-"`
 }
 
 type metadataInternetGatewayAttachment struct {
@@ -13677,7 +13677,7 @@ type KeyPairInfo struct {
 	// The name of the key pair.
 	KeyName *string `locationName:"keyName" type:"string"`
 
-	metadataKeyPairInfo `json:"-", xml:"-"`
+	metadataKeyPairInfo `json:"-" xml:"-"`
 }
 
 type metadataKeyPairInfo struct {
@@ -13692,7 +13692,7 @@ type LaunchPermission struct {
 	// The AWS account ID.
 	UserID *string `locationName:"userId" type:"string"`
 
-	metadataLaunchPermission `json:"-", xml:"-"`
+	metadataLaunchPermission `json:"-" xml:"-"`
 }
 
 type metadataLaunchPermission struct {
@@ -13708,7 +13708,7 @@ type LaunchPermissionModifications struct {
 	// AMI.
 	Remove []*LaunchPermission `locationNameList:"item" type:"list"`
 
-	metadataLaunchPermissionModifications `json:"-", xml:"-"`
+	metadataLaunchPermissionModifications `json:"-" xml:"-"`
 }
 
 type metadataLaunchPermissionModifications struct {
@@ -13771,7 +13771,7 @@ type LaunchSpecification struct {
 	// The Base64-encoded MIME user data to make available to the instances.
 	UserData *string `locationName:"userData" type:"string"`
 
-	metadataLaunchSpecification `json:"-", xml:"-"`
+	metadataLaunchSpecification `json:"-" xml:"-"`
 }
 
 type metadataLaunchSpecification struct {
@@ -13812,7 +13812,7 @@ type ModifyImageAttributeInput struct {
 	// the description attribute.
 	Value *string `type:"string"`
 
-	metadataModifyImageAttributeInput `json:"-", xml:"-"`
+	metadataModifyImageAttributeInput `json:"-" xml:"-"`
 }
 
 type metadataModifyImageAttributeInput struct {
@@ -13820,7 +13820,7 @@ type metadataModifyImageAttributeInput struct {
 }
 
 type ModifyImageAttributeOutput struct {
-	metadataModifyImageAttributeOutput `json:"-", xml:"-"`
+	metadataModifyImageAttributeOutput `json:"-" xml:"-"`
 }
 
 type metadataModifyImageAttributeOutput struct {
@@ -13902,7 +13902,7 @@ type ModifyInstanceAttributeInput struct {
 	// disableApiTermination, or intanceInitiateShutdownBehavior attribute.
 	Value *string `locationName:"value" type:"string"`
 
-	metadataModifyInstanceAttributeInput `json:"-", xml:"-"`
+	metadataModifyInstanceAttributeInput `json:"-" xml:"-"`
 }
 
 type metadataModifyInstanceAttributeInput struct {
@@ -13910,7 +13910,7 @@ type metadataModifyInstanceAttributeInput struct {
 }
 
 type ModifyInstanceAttributeOutput struct {
-	metadataModifyInstanceAttributeOutput `json:"-", xml:"-"`
+	metadataModifyInstanceAttributeOutput `json:"-" xml:"-"`
 }
 
 type metadataModifyInstanceAttributeOutput struct {
@@ -13943,7 +13943,7 @@ type ModifyNetworkInterfaceAttributeInput struct {
 	// in the Amazon Virtual Private Cloud User Guide.
 	SourceDestCheck *AttributeBooleanValue `locationName:"sourceDestCheck" type:"structure"`
 
-	metadataModifyNetworkInterfaceAttributeInput `json:"-", xml:"-"`
+	metadataModifyNetworkInterfaceAttributeInput `json:"-" xml:"-"`
 }
 
 type metadataModifyNetworkInterfaceAttributeInput struct {
@@ -13951,7 +13951,7 @@ type metadataModifyNetworkInterfaceAttributeInput struct {
 }
 
 type ModifyNetworkInterfaceAttributeOutput struct {
-	metadataModifyNetworkInterfaceAttributeOutput `json:"-", xml:"-"`
+	metadataModifyNetworkInterfaceAttributeOutput `json:"-" xml:"-"`
 }
 
 type metadataModifyNetworkInterfaceAttributeOutput struct {
@@ -13969,7 +13969,7 @@ type ModifyReservedInstancesInput struct {
 	// The configuration settings for the Reserved Instances to modify.
 	TargetConfigurations []*ReservedInstancesConfiguration `locationName:"ReservedInstancesConfigurationSetItemType" locationNameList:"item" type:"list" required:"true"`
 
-	metadataModifyReservedInstancesInput `json:"-", xml:"-"`
+	metadataModifyReservedInstancesInput `json:"-" xml:"-"`
 }
 
 type metadataModifyReservedInstancesInput struct {
@@ -13980,7 +13980,7 @@ type ModifyReservedInstancesOutput struct {
 	// The ID for the modification.
 	ReservedInstancesModificationID *string `locationName:"reservedInstancesModificationId" type:"string"`
 
-	metadataModifyReservedInstancesOutput `json:"-", xml:"-"`
+	metadataModifyReservedInstancesOutput `json:"-" xml:"-"`
 }
 
 type metadataModifyReservedInstancesOutput struct {
@@ -14008,7 +14008,7 @@ type ModifySnapshotAttributeInput struct {
 	// The account ID to modify for the snapshot.
 	UserIDs []*string `locationName:"UserId" locationNameList:"UserId" type:"list"`
 
-	metadataModifySnapshotAttributeInput `json:"-", xml:"-"`
+	metadataModifySnapshotAttributeInput `json:"-" xml:"-"`
 }
 
 type metadataModifySnapshotAttributeInput struct {
@@ -14016,7 +14016,7 @@ type metadataModifySnapshotAttributeInput struct {
 }
 
 type ModifySnapshotAttributeOutput struct {
-	metadataModifySnapshotAttributeOutput `json:"-", xml:"-"`
+	metadataModifySnapshotAttributeOutput `json:"-" xml:"-"`
 }
 
 type metadataModifySnapshotAttributeOutput struct {
@@ -14031,7 +14031,7 @@ type ModifySubnetAttributeInput struct {
 	// The ID of the subnet.
 	SubnetID *string `locationName:"subnetId" type:"string" required:"true"`
 
-	metadataModifySubnetAttributeInput `json:"-", xml:"-"`
+	metadataModifySubnetAttributeInput `json:"-" xml:"-"`
 }
 
 type metadataModifySubnetAttributeInput struct {
@@ -14039,7 +14039,7 @@ type metadataModifySubnetAttributeInput struct {
 }
 
 type ModifySubnetAttributeOutput struct {
-	metadataModifySubnetAttributeOutput `json:"-", xml:"-"`
+	metadataModifySubnetAttributeOutput `json:"-" xml:"-"`
 }
 
 type metadataModifySubnetAttributeOutput struct {
@@ -14063,7 +14063,7 @@ type ModifyVPCAttributeInput struct {
 	// The ID of the VPC.
 	VPCID *string `locationName:"vpcId" type:"string" required:"true"`
 
-	metadataModifyVPCAttributeInput `json:"-", xml:"-"`
+	metadataModifyVPCAttributeInput `json:"-" xml:"-"`
 }
 
 type metadataModifyVPCAttributeInput struct {
@@ -14071,7 +14071,7 @@ type metadataModifyVPCAttributeInput struct {
 }
 
 type ModifyVPCAttributeOutput struct {
-	metadataModifyVPCAttributeOutput `json:"-", xml:"-"`
+	metadataModifyVPCAttributeOutput `json:"-" xml:"-"`
 }
 
 type metadataModifyVPCAttributeOutput struct {
@@ -14087,7 +14087,7 @@ type ModifyVolumeAttributeInput struct {
 	// The ID of the volume.
 	VolumeID *string `locationName:"VolumeId" type:"string" required:"true"`
 
-	metadataModifyVolumeAttributeInput `json:"-", xml:"-"`
+	metadataModifyVolumeAttributeInput `json:"-" xml:"-"`
 }
 
 type metadataModifyVolumeAttributeInput struct {
@@ -14095,7 +14095,7 @@ type metadataModifyVolumeAttributeInput struct {
 }
 
 type ModifyVolumeAttributeOutput struct {
-	metadataModifyVolumeAttributeOutput `json:"-", xml:"-"`
+	metadataModifyVolumeAttributeOutput `json:"-" xml:"-"`
 }
 
 type metadataModifyVolumeAttributeOutput struct {
@@ -14108,7 +14108,7 @@ type MonitorInstancesInput struct {
 	// One or more instance IDs.
 	InstanceIDs []*string `locationName:"InstanceId" locationNameList:"InstanceId" type:"list" required:"true"`
 
-	metadataMonitorInstancesInput `json:"-", xml:"-"`
+	metadataMonitorInstancesInput `json:"-" xml:"-"`
 }
 
 type metadataMonitorInstancesInput struct {
@@ -14119,7 +14119,7 @@ type MonitorInstancesOutput struct {
 	// Monitoring information for one or more instances.
 	InstanceMonitorings []*InstanceMonitoring `locationName:"instancesSet" locationNameList:"item" type:"list"`
 
-	metadataMonitorInstancesOutput `json:"-", xml:"-"`
+	metadataMonitorInstancesOutput `json:"-" xml:"-"`
 }
 
 type metadataMonitorInstancesOutput struct {
@@ -14131,7 +14131,7 @@ type Monitoring struct {
 	// Indicates whether monitoring is enabled for the instance.
 	State *string `locationName:"state" type:"string"`
 
-	metadataMonitoring `json:"-", xml:"-"`
+	metadataMonitoring `json:"-" xml:"-"`
 }
 
 type metadataMonitoring struct {
@@ -14158,7 +14158,7 @@ type NetworkACL struct {
 	// The ID of the VPC for the network ACL.
 	VPCID *string `locationName:"vpcId" type:"string"`
 
-	metadataNetworkACL `json:"-", xml:"-"`
+	metadataNetworkACL `json:"-" xml:"-"`
 }
 
 type metadataNetworkACL struct {
@@ -14176,7 +14176,7 @@ type NetworkACLAssociation struct {
 	// The ID of the subnet.
 	SubnetID *string `locationName:"subnetId" type:"string"`
 
-	metadataNetworkACLAssociation `json:"-", xml:"-"`
+	metadataNetworkACLAssociation `json:"-" xml:"-"`
 }
 
 type metadataNetworkACLAssociation struct {
@@ -14208,7 +14208,7 @@ type NetworkACLEntry struct {
 	// by rule number.
 	RuleNumber *int64 `locationName:"ruleNumber" type:"integer"`
 
-	metadataNetworkACLEntry `json:"-", xml:"-"`
+	metadataNetworkACLEntry `json:"-" xml:"-"`
 }
 
 type metadataNetworkACLEntry struct {
@@ -14273,7 +14273,7 @@ type NetworkInterface struct {
 	// The ID of the VPC.
 	VPCID *string `locationName:"vpcId" type:"string"`
 
-	metadataNetworkInterface `json:"-", xml:"-"`
+	metadataNetworkInterface `json:"-" xml:"-"`
 }
 
 type metadataNetworkInterface struct {
@@ -14297,7 +14297,7 @@ type NetworkInterfaceAssociation struct {
 	// The address of the Elastic IP address bound to the network interface.
 	PublicIP *string `locationName:"publicIp" type:"string"`
 
-	metadataNetworkInterfaceAssociation `json:"-", xml:"-"`
+	metadataNetworkInterfaceAssociation `json:"-" xml:"-"`
 }
 
 type metadataNetworkInterfaceAssociation struct {
@@ -14327,7 +14327,7 @@ type NetworkInterfaceAttachment struct {
 	// The attachment state.
 	Status *string `locationName:"status" type:"string"`
 
-	metadataNetworkInterfaceAttachment `json:"-", xml:"-"`
+	metadataNetworkInterfaceAttachment `json:"-" xml:"-"`
 }
 
 type metadataNetworkInterfaceAttachment struct {
@@ -14342,7 +14342,7 @@ type NetworkInterfaceAttachmentChanges struct {
 	// Indicates whether the network interface is deleted when the instance is terminated.
 	DeleteOnTermination *bool `locationName:"deleteOnTermination" type:"boolean"`
 
-	metadataNetworkInterfaceAttachmentChanges `json:"-", xml:"-"`
+	metadataNetworkInterfaceAttachmentChanges `json:"-" xml:"-"`
 }
 
 type metadataNetworkInterfaceAttachmentChanges struct {
@@ -14365,7 +14365,7 @@ type NetworkInterfacePrivateIPAddress struct {
 	// The private IP address.
 	PrivateIPAddress *string `locationName:"privateIpAddress" type:"string"`
 
-	metadataNetworkInterfacePrivateIPAddress `json:"-", xml:"-"`
+	metadataNetworkInterfacePrivateIPAddress `json:"-" xml:"-"`
 }
 
 type metadataNetworkInterfacePrivateIPAddress struct {
@@ -14377,7 +14377,7 @@ type NewDHCPConfiguration struct {
 
 	Values []*string `locationName:"Value" locationNameList:"item" type:"list"`
 
-	metadataNewDHCPConfiguration `json:"-", xml:"-"`
+	metadataNewDHCPConfiguration `json:"-" xml:"-"`
 }
 
 type metadataNewDHCPConfiguration struct {
@@ -14396,7 +14396,7 @@ type Placement struct {
 	// with a tenancy of dedicated runs on single-tenant hardware.
 	Tenancy *string `locationName:"tenancy" type:"string"`
 
-	metadataPlacement `json:"-", xml:"-"`
+	metadataPlacement `json:"-" xml:"-"`
 }
 
 type metadataPlacement struct {
@@ -14414,7 +14414,7 @@ type PlacementGroup struct {
 	// The placement strategy.
 	Strategy *string `locationName:"strategy" type:"string"`
 
-	metadataPlacementGroup `json:"-", xml:"-"`
+	metadataPlacementGroup `json:"-" xml:"-"`
 }
 
 type metadataPlacementGroup struct {
@@ -14429,7 +14429,7 @@ type PortRange struct {
 	// The last port in the range.
 	To *int64 `locationName:"to" type:"integer"`
 
-	metadataPortRange `json:"-", xml:"-"`
+	metadataPortRange `json:"-" xml:"-"`
 }
 
 type metadataPortRange struct {
@@ -14461,7 +14461,7 @@ type PriceSchedule struct {
 	// second to the last month before the capacity reservation expires.
 	Term *int64 `locationName:"term" type:"long"`
 
-	metadataPriceSchedule `json:"-", xml:"-"`
+	metadataPriceSchedule `json:"-" xml:"-"`
 }
 
 type metadataPriceSchedule struct {
@@ -14481,7 +14481,7 @@ type PriceScheduleSpecification struct {
 	// second to the last month before the capacity reservation expires.
 	Term *int64 `locationName:"term" type:"long"`
 
-	metadataPriceScheduleSpecification `json:"-", xml:"-"`
+	metadataPriceScheduleSpecification `json:"-" xml:"-"`
 }
 
 type metadataPriceScheduleSpecification struct {
@@ -14496,7 +14496,7 @@ type PricingDetail struct {
 	// The price per instance.
 	Price *float64 `locationName:"price" type:"double"`
 
-	metadataPricingDetail `json:"-", xml:"-"`
+	metadataPricingDetail `json:"-" xml:"-"`
 }
 
 type metadataPricingDetail struct {
@@ -14512,7 +14512,7 @@ type PrivateIPAddressSpecification struct {
 	// The private IP addresses.
 	PrivateIPAddress *string `locationName:"privateIpAddress" type:"string" required:"true"`
 
-	metadataPrivateIPAddressSpecification `json:"-", xml:"-"`
+	metadataPrivateIPAddressSpecification `json:"-" xml:"-"`
 }
 
 type metadataPrivateIPAddressSpecification struct {
@@ -14527,7 +14527,7 @@ type ProductCode struct {
 	// The type of product code.
 	ProductCodeType *string `locationName:"type" type:"string"`
 
-	metadataProductCode `json:"-", xml:"-"`
+	metadataProductCode `json:"-" xml:"-"`
 }
 
 type metadataProductCode struct {
@@ -14539,7 +14539,7 @@ type PropagatingVGW struct {
 	// The ID of the virtual private gateway (VGW).
 	GatewayID *string `locationName:"gatewayId" type:"string"`
 
-	metadataPropagatingVGW `json:"-", xml:"-"`
+	metadataPropagatingVGW `json:"-" xml:"-"`
 }
 
 type metadataPropagatingVGW struct {
@@ -14560,7 +14560,7 @@ type PurchaseReservedInstancesOfferingInput struct {
 	// The ID of the Reserved Instance offering to purchase.
 	ReservedInstancesOfferingID *string `locationName:"ReservedInstancesOfferingId" type:"string" required:"true"`
 
-	metadataPurchaseReservedInstancesOfferingInput `json:"-", xml:"-"`
+	metadataPurchaseReservedInstancesOfferingInput `json:"-" xml:"-"`
 }
 
 type metadataPurchaseReservedInstancesOfferingInput struct {
@@ -14571,7 +14571,7 @@ type PurchaseReservedInstancesOfferingOutput struct {
 	// The IDs of the purchased Reserved Instances.
 	ReservedInstancesID *string `locationName:"reservedInstancesId" type:"string"`
 
-	metadataPurchaseReservedInstancesOfferingOutput `json:"-", xml:"-"`
+	metadataPurchaseReservedInstancesOfferingOutput `json:"-" xml:"-"`
 }
 
 type metadataPurchaseReservedInstancesOfferingOutput struct {
@@ -14584,7 +14584,7 @@ type RebootInstancesInput struct {
 	// One or more instance IDs.
 	InstanceIDs []*string `locationName:"InstanceId" locationNameList:"InstanceId" type:"list" required:"true"`
 
-	metadataRebootInstancesInput `json:"-", xml:"-"`
+	metadataRebootInstancesInput `json:"-" xml:"-"`
 }
 
 type metadataRebootInstancesInput struct {
@@ -14592,7 +14592,7 @@ type metadataRebootInstancesInput struct {
 }
 
 type RebootInstancesOutput struct {
-	metadataRebootInstancesOutput `json:"-", xml:"-"`
+	metadataRebootInstancesOutput `json:"-" xml:"-"`
 }
 
 type metadataRebootInstancesOutput struct {
@@ -14607,7 +14607,7 @@ type RecurringCharge struct {
 	// The frequency of the recurring charge.
 	Frequency *string `locationName:"frequency" type:"string"`
 
-	metadataRecurringCharge `json:"-", xml:"-"`
+	metadataRecurringCharge `json:"-" xml:"-"`
 }
 
 type metadataRecurringCharge struct {
@@ -14622,7 +14622,7 @@ type Region struct {
 	// The name of the region.
 	RegionName *string `locationName:"regionName" type:"string"`
 
-	metadataRegion `json:"-", xml:"-"`
+	metadataRegion `json:"-" xml:"-"`
 }
 
 type metadataRegion struct {
@@ -14677,7 +14677,7 @@ type RegisterImageInput struct {
 	// Default: paravirtual
 	VirtualizationType *string `locationName:"virtualizationType" type:"string"`
 
-	metadataRegisterImageInput `json:"-", xml:"-"`
+	metadataRegisterImageInput `json:"-" xml:"-"`
 }
 
 type metadataRegisterImageInput struct {
@@ -14688,7 +14688,7 @@ type RegisterImageOutput struct {
 	// The ID of the newly registered AMI.
 	ImageID *string `locationName:"imageId" type:"string"`
 
-	metadataRegisterImageOutput `json:"-", xml:"-"`
+	metadataRegisterImageOutput `json:"-" xml:"-"`
 }
 
 type metadataRegisterImageOutput struct {
@@ -14701,7 +14701,7 @@ type RejectVPCPeeringConnectionInput struct {
 	// The ID of the VPC peering connection.
 	VPCPeeringConnectionID *string `locationName:"vpcPeeringConnectionId" type:"string" required:"true"`
 
-	metadataRejectVPCPeeringConnectionInput `json:"-", xml:"-"`
+	metadataRejectVPCPeeringConnectionInput `json:"-" xml:"-"`
 }
 
 type metadataRejectVPCPeeringConnectionInput struct {
@@ -14712,7 +14712,7 @@ type RejectVPCPeeringConnectionOutput struct {
 	// Returns true if the request succeeds; otherwise, it returns an error.
 	Return *bool `locationName:"return" type:"boolean"`
 
-	metadataRejectVPCPeeringConnectionOutput `json:"-", xml:"-"`
+	metadataRejectVPCPeeringConnectionOutput `json:"-" xml:"-"`
 }
 
 type metadataRejectVPCPeeringConnectionOutput struct {
@@ -14728,7 +14728,7 @@ type ReleaseAddressInput struct {
 	// [EC2-Classic] The Elastic IP address. Required for EC2-Classic.
 	PublicIP *string `locationName:"PublicIp" type:"string"`
 
-	metadataReleaseAddressInput `json:"-", xml:"-"`
+	metadataReleaseAddressInput `json:"-" xml:"-"`
 }
 
 type metadataReleaseAddressInput struct {
@@ -14736,7 +14736,7 @@ type metadataReleaseAddressInput struct {
 }
 
 type ReleaseAddressOutput struct {
-	metadataReleaseAddressOutput `json:"-", xml:"-"`
+	metadataReleaseAddressOutput `json:"-" xml:"-"`
 }
 
 type metadataReleaseAddressOutput struct {
@@ -14753,7 +14753,7 @@ type ReplaceNetworkACLAssociationInput struct {
 	// The ID of the new network ACL to associate with the subnet.
 	NetworkACLID *string `locationName:"networkAclId" type:"string" required:"true"`
 
-	metadataReplaceNetworkACLAssociationInput `json:"-", xml:"-"`
+	metadataReplaceNetworkACLAssociationInput `json:"-" xml:"-"`
 }
 
 type metadataReplaceNetworkACLAssociationInput struct {
@@ -14764,7 +14764,7 @@ type ReplaceNetworkACLAssociationOutput struct {
 	// The ID of the new association.
 	NewAssociationID *string `locationName:"newAssociationId" type:"string"`
 
-	metadataReplaceNetworkACLAssociationOutput `json:"-", xml:"-"`
+	metadataReplaceNetworkACLAssociationOutput `json:"-" xml:"-"`
 }
 
 type metadataReplaceNetworkACLAssociationOutput struct {
@@ -14802,7 +14802,7 @@ type ReplaceNetworkACLEntryInput struct {
 	// The rule number of the entry to replace.
 	RuleNumber *int64 `locationName:"ruleNumber" type:"integer" required:"true"`
 
-	metadataReplaceNetworkACLEntryInput `json:"-", xml:"-"`
+	metadataReplaceNetworkACLEntryInput `json:"-" xml:"-"`
 }
 
 type metadataReplaceNetworkACLEntryInput struct {
@@ -14810,7 +14810,7 @@ type metadataReplaceNetworkACLEntryInput struct {
 }
 
 type ReplaceNetworkACLEntryOutput struct {
-	metadataReplaceNetworkACLEntryOutput `json:"-", xml:"-"`
+	metadataReplaceNetworkACLEntryOutput `json:"-" xml:"-"`
 }
 
 type metadataReplaceNetworkACLEntryOutput struct {
@@ -14839,7 +14839,7 @@ type ReplaceRouteInput struct {
 	// The ID of a VPC peering connection.
 	VPCPeeringConnectionID *string `locationName:"vpcPeeringConnectionId" type:"string"`
 
-	metadataReplaceRouteInput `json:"-", xml:"-"`
+	metadataReplaceRouteInput `json:"-" xml:"-"`
 }
 
 type metadataReplaceRouteInput struct {
@@ -14847,7 +14847,7 @@ type metadataReplaceRouteInput struct {
 }
 
 type ReplaceRouteOutput struct {
-	metadataReplaceRouteOutput `json:"-", xml:"-"`
+	metadataReplaceRouteOutput `json:"-" xml:"-"`
 }
 
 type metadataReplaceRouteOutput struct {
@@ -14863,7 +14863,7 @@ type ReplaceRouteTableAssociationInput struct {
 	// The ID of the new route table to associate with the subnet.
 	RouteTableID *string `locationName:"routeTableId" type:"string" required:"true"`
 
-	metadataReplaceRouteTableAssociationInput `json:"-", xml:"-"`
+	metadataReplaceRouteTableAssociationInput `json:"-" xml:"-"`
 }
 
 type metadataReplaceRouteTableAssociationInput struct {
@@ -14874,7 +14874,7 @@ type ReplaceRouteTableAssociationOutput struct {
 	// The ID of the new association.
 	NewAssociationID *string `locationName:"newAssociationId" type:"string"`
 
-	metadataReplaceRouteTableAssociationOutput `json:"-", xml:"-"`
+	metadataReplaceRouteTableAssociationOutput `json:"-" xml:"-"`
 }
 
 type metadataReplaceRouteTableAssociationOutput struct {
@@ -14923,7 +14923,7 @@ type ReportInstanceStatusInput struct {
 	// The status of all instances listed.
 	Status *string `locationName:"status" type:"string" required:"true"`
 
-	metadataReportInstanceStatusInput `json:"-", xml:"-"`
+	metadataReportInstanceStatusInput `json:"-" xml:"-"`
 }
 
 type metadataReportInstanceStatusInput struct {
@@ -14931,7 +14931,7 @@ type metadataReportInstanceStatusInput struct {
 }
 
 type ReportInstanceStatusOutput struct {
-	metadataReportInstanceStatusOutput `json:"-", xml:"-"`
+	metadataReportInstanceStatusOutput `json:"-" xml:"-"`
 }
 
 type metadataReportInstanceStatusOutput struct {
@@ -15002,7 +15002,7 @@ type RequestSpotInstancesInput struct {
 	// Default: The request is effective indefinitely.
 	ValidUntil *time.Time `locationName:"validUntil" type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataRequestSpotInstancesInput `json:"-", xml:"-"`
+	metadataRequestSpotInstancesInput `json:"-" xml:"-"`
 }
 
 type metadataRequestSpotInstancesInput struct {
@@ -15013,7 +15013,7 @@ type RequestSpotInstancesOutput struct {
 	// One or more Spot Instance requests.
 	SpotInstanceRequests []*SpotInstanceRequest `locationName:"spotInstanceRequestSet" locationNameList:"item" type:"list"`
 
-	metadataRequestSpotInstancesOutput `json:"-", xml:"-"`
+	metadataRequestSpotInstancesOutput `json:"-" xml:"-"`
 }
 
 type metadataRequestSpotInstancesOutput struct {
@@ -15074,7 +15074,7 @@ type RequestSpotLaunchSpecification struct {
 	// The Base64-encoded MIME user data to make available to the instances.
 	UserData *string `locationName:"userData" type:"string"`
 
-	metadataRequestSpotLaunchSpecification `json:"-", xml:"-"`
+	metadataRequestSpotLaunchSpecification `json:"-" xml:"-"`
 }
 
 type metadataRequestSpotLaunchSpecification struct {
@@ -15099,7 +15099,7 @@ type Reservation struct {
 	// The ID of the reservation.
 	ReservationID *string `locationName:"reservationId" type:"string"`
 
-	metadataReservation `json:"-", xml:"-"`
+	metadataReservation `json:"-" xml:"-"`
 }
 
 type metadataReservation struct {
@@ -15116,7 +15116,7 @@ type ReservedInstanceLimitPrice struct {
 	// only supported currency is USD.
 	CurrencyCode *string `locationName:"currencyCode" type:"string"`
 
-	metadataReservedInstanceLimitPrice `json:"-", xml:"-"`
+	metadataReservedInstanceLimitPrice `json:"-" xml:"-"`
 }
 
 type metadataReservedInstanceLimitPrice struct {
@@ -15174,7 +15174,7 @@ type ReservedInstances struct {
 	// The usage price of the Reserved Instance, per hour.
 	UsagePrice *float64 `locationName:"usagePrice" type:"float"`
 
-	metadataReservedInstances `json:"-", xml:"-"`
+	metadataReservedInstances `json:"-" xml:"-"`
 }
 
 type metadataReservedInstances struct {
@@ -15196,7 +15196,7 @@ type ReservedInstancesConfiguration struct {
 	// EC2-Classic or EC2-VPC.
 	Platform *string `locationName:"platform" type:"string"`
 
-	metadataReservedInstancesConfiguration `json:"-", xml:"-"`
+	metadataReservedInstancesConfiguration `json:"-" xml:"-"`
 }
 
 type metadataReservedInstancesConfiguration struct {
@@ -15208,7 +15208,7 @@ type ReservedInstancesID struct {
 	// The ID of the Reserved Instance.
 	ReservedInstancesID *string `locationName:"reservedInstancesId" type:"string"`
 
-	metadataReservedInstancesID `json:"-", xml:"-"`
+	metadataReservedInstancesID `json:"-" xml:"-"`
 }
 
 type metadataReservedInstancesID struct {
@@ -15249,7 +15249,7 @@ type ReservedInstancesListing struct {
 	// The last modified timestamp of the listing.
 	UpdateDate *time.Time `locationName:"updateDate" type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataReservedInstancesListing `json:"-", xml:"-"`
+	metadataReservedInstancesListing `json:"-" xml:"-"`
 }
 
 type metadataReservedInstancesListing struct {
@@ -15287,7 +15287,7 @@ type ReservedInstancesModification struct {
 	// The time when the modification request was last updated.
 	UpdateDate *time.Time `locationName:"updateDate" type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataReservedInstancesModification `json:"-", xml:"-"`
+	metadataReservedInstancesModification `json:"-" xml:"-"`
 }
 
 type metadataReservedInstancesModification struct {
@@ -15303,7 +15303,7 @@ type ReservedInstancesModificationResult struct {
 	// request.
 	TargetConfiguration *ReservedInstancesConfiguration `locationName:"targetConfiguration" type:"structure"`
 
-	metadataReservedInstancesModificationResult `json:"-", xml:"-"`
+	metadataReservedInstancesModificationResult `json:"-" xml:"-"`
 }
 
 type metadataReservedInstancesModificationResult struct {
@@ -15355,7 +15355,7 @@ type ReservedInstancesOffering struct {
 	// The usage price of the Reserved Instance, per hour.
 	UsagePrice *float64 `locationName:"usagePrice" type:"float"`
 
-	metadataReservedInstancesOffering `json:"-", xml:"-"`
+	metadataReservedInstancesOffering `json:"-" xml:"-"`
 }
 
 type metadataReservedInstancesOffering struct {
@@ -15372,7 +15372,7 @@ type ResetImageAttributeInput struct {
 	// The ID of the AMI.
 	ImageID *string `locationName:"ImageId" type:"string" required:"true"`
 
-	metadataResetImageAttributeInput `json:"-", xml:"-"`
+	metadataResetImageAttributeInput `json:"-" xml:"-"`
 }
 
 type metadataResetImageAttributeInput struct {
@@ -15380,7 +15380,7 @@ type metadataResetImageAttributeInput struct {
 }
 
 type ResetImageAttributeOutput struct {
-	metadataResetImageAttributeOutput `json:"-", xml:"-"`
+	metadataResetImageAttributeOutput `json:"-" xml:"-"`
 }
 
 type metadataResetImageAttributeOutput struct {
@@ -15396,7 +15396,7 @@ type ResetInstanceAttributeInput struct {
 	// The ID of the instance.
 	InstanceID *string `locationName:"instanceId" type:"string" required:"true"`
 
-	metadataResetInstanceAttributeInput `json:"-", xml:"-"`
+	metadataResetInstanceAttributeInput `json:"-" xml:"-"`
 }
 
 type metadataResetInstanceAttributeInput struct {
@@ -15404,7 +15404,7 @@ type metadataResetInstanceAttributeInput struct {
 }
 
 type ResetInstanceAttributeOutput struct {
-	metadataResetInstanceAttributeOutput `json:"-", xml:"-"`
+	metadataResetInstanceAttributeOutput `json:"-" xml:"-"`
 }
 
 type metadataResetInstanceAttributeOutput struct {
@@ -15420,7 +15420,7 @@ type ResetNetworkInterfaceAttributeInput struct {
 	// The source/destination checking attribute. Resets the value to true.
 	SourceDestCheck *string `locationName:"sourceDestCheck" type:"string"`
 
-	metadataResetNetworkInterfaceAttributeInput `json:"-", xml:"-"`
+	metadataResetNetworkInterfaceAttributeInput `json:"-" xml:"-"`
 }
 
 type metadataResetNetworkInterfaceAttributeInput struct {
@@ -15428,7 +15428,7 @@ type metadataResetNetworkInterfaceAttributeInput struct {
 }
 
 type ResetNetworkInterfaceAttributeOutput struct {
-	metadataResetNetworkInterfaceAttributeOutput `json:"-", xml:"-"`
+	metadataResetNetworkInterfaceAttributeOutput `json:"-" xml:"-"`
 }
 
 type metadataResetNetworkInterfaceAttributeOutput struct {
@@ -15445,7 +15445,7 @@ type ResetSnapshotAttributeInput struct {
 	// The ID of the snapshot.
 	SnapshotID *string `locationName:"SnapshotId" type:"string" required:"true"`
 
-	metadataResetSnapshotAttributeInput `json:"-", xml:"-"`
+	metadataResetSnapshotAttributeInput `json:"-" xml:"-"`
 }
 
 type metadataResetSnapshotAttributeInput struct {
@@ -15453,7 +15453,7 @@ type metadataResetSnapshotAttributeInput struct {
 }
 
 type ResetSnapshotAttributeOutput struct {
-	metadataResetSnapshotAttributeOutput `json:"-", xml:"-"`
+	metadataResetSnapshotAttributeOutput `json:"-" xml:"-"`
 }
 
 type metadataResetSnapshotAttributeOutput struct {
@@ -15494,7 +15494,7 @@ type RevokeSecurityGroupEgressInput struct {
 	// For the ICMP code number, use -1 to specify all ICMP codes for the ICMP type.
 	ToPort *int64 `locationName:"toPort" type:"integer"`
 
-	metadataRevokeSecurityGroupEgressInput `json:"-", xml:"-"`
+	metadataRevokeSecurityGroupEgressInput `json:"-" xml:"-"`
 }
 
 type metadataRevokeSecurityGroupEgressInput struct {
@@ -15502,7 +15502,7 @@ type metadataRevokeSecurityGroupEgressInput struct {
 }
 
 type RevokeSecurityGroupEgressOutput struct {
-	metadataRevokeSecurityGroupEgressOutput `json:"-", xml:"-"`
+	metadataRevokeSecurityGroupEgressOutput `json:"-" xml:"-"`
 }
 
 type metadataRevokeSecurityGroupEgressOutput struct {
@@ -15546,7 +15546,7 @@ type RevokeSecurityGroupIngressInput struct {
 	// For the ICMP code number, use -1 to specify all ICMP codes for the ICMP type.
 	ToPort *int64 `type:"integer"`
 
-	metadataRevokeSecurityGroupIngressInput `json:"-", xml:"-"`
+	metadataRevokeSecurityGroupIngressInput `json:"-" xml:"-"`
 }
 
 type metadataRevokeSecurityGroupIngressInput struct {
@@ -15554,7 +15554,7 @@ type metadataRevokeSecurityGroupIngressInput struct {
 }
 
 type RevokeSecurityGroupIngressOutput struct {
-	metadataRevokeSecurityGroupIngressOutput `json:"-", xml:"-"`
+	metadataRevokeSecurityGroupIngressOutput `json:"-" xml:"-"`
 }
 
 type metadataRevokeSecurityGroupIngressOutput struct {
@@ -15594,7 +15594,7 @@ type Route struct {
 	// The ID of the VPC peering connection.
 	VPCPeeringConnectionID *string `locationName:"vpcPeeringConnectionId" type:"string"`
 
-	metadataRoute `json:"-", xml:"-"`
+	metadataRoute `json:"-" xml:"-"`
 }
 
 type metadataRoute struct {
@@ -15621,7 +15621,7 @@ type RouteTable struct {
 	// The ID of the VPC.
 	VPCID *string `locationName:"vpcId" type:"string"`
 
-	metadataRouteTable `json:"-", xml:"-"`
+	metadataRouteTable `json:"-" xml:"-"`
 }
 
 type metadataRouteTable struct {
@@ -15642,7 +15642,7 @@ type RouteTableAssociation struct {
 	// The ID of the subnet.
 	SubnetID *string `locationName:"subnetId" type:"string"`
 
-	metadataRouteTableAssociation `json:"-", xml:"-"`
+	metadataRouteTableAssociation `json:"-" xml:"-"`
 }
 
 type metadataRouteTableAssociation struct {
@@ -15779,7 +15779,7 @@ type RunInstancesInput struct {
 	// The Base64-encoded MIME user data for the instances.
 	UserData *string `type:"string"`
 
-	metadataRunInstancesInput `json:"-", xml:"-"`
+	metadataRunInstancesInput `json:"-" xml:"-"`
 }
 
 type metadataRunInstancesInput struct {
@@ -15791,7 +15791,7 @@ type RunInstancesMonitoringEnabled struct {
 	// Indicates whether monitoring is enabled for the instance.
 	Enabled *bool `locationName:"enabled" type:"boolean" required:"true"`
 
-	metadataRunInstancesMonitoringEnabled `json:"-", xml:"-"`
+	metadataRunInstancesMonitoringEnabled `json:"-" xml:"-"`
 }
 
 type metadataRunInstancesMonitoringEnabled struct {
@@ -15821,7 +15821,7 @@ type S3Storage struct {
 	// The signature of the Base64 encoded JSON document.
 	UploadPolicySignature *string `locationName:"uploadPolicySignature" type:"string"`
 
-	metadataS3Storage `json:"-", xml:"-"`
+	metadataS3Storage `json:"-" xml:"-"`
 }
 
 type metadataS3Storage struct {
@@ -15854,7 +15854,7 @@ type SecurityGroup struct {
 	// [EC2-VPC] The ID of the VPC for the security group.
 	VPCID *string `locationName:"vpcId" type:"string"`
 
-	metadataSecurityGroup `json:"-", xml:"-"`
+	metadataSecurityGroup `json:"-" xml:"-"`
 }
 
 type metadataSecurityGroup struct {
@@ -15901,7 +15901,7 @@ type Snapshot struct {
 	// The size of the volume, in GiB.
 	VolumeSize *int64 `locationName:"volumeSize" type:"integer"`
 
-	metadataSnapshot `json:"-", xml:"-"`
+	metadataSnapshot `json:"-" xml:"-"`
 }
 
 type metadataSnapshot struct {
@@ -15940,7 +15940,7 @@ type SnapshotDetail struct {
 	// User's Amazon S3 bucket details used to access the image.
 	UserBucket *UserBucketDetails `locationName:"userBucket" type:"structure"`
 
-	metadataSnapshotDetail `json:"-", xml:"-"`
+	metadataSnapshotDetail `json:"-" xml:"-"`
 }
 
 type metadataSnapshotDetail struct {
@@ -15962,7 +15962,7 @@ type SnapshotDiskContainer struct {
 	// User's Amazon S3 bucket details used to access the image.
 	UserBucket *UserBucket `type:"structure"`
 
-	metadataSnapshotDiskContainer `json:"-", xml:"-"`
+	metadataSnapshotDiskContainer `json:"-" xml:"-"`
 }
 
 type metadataSnapshotDiskContainer struct {
@@ -15998,7 +15998,7 @@ type SnapshotTaskDetail struct {
 	// User's Amazon S3 bucket details used to access the image.
 	UserBucket *UserBucketDetails `locationName:"userBucket" type:"structure"`
 
-	metadataSnapshotTaskDetail `json:"-", xml:"-"`
+	metadataSnapshotTaskDetail `json:"-" xml:"-"`
 }
 
 type metadataSnapshotTaskDetail struct {
@@ -16022,7 +16022,7 @@ type SpotDatafeedSubscription struct {
 	// The state of the Spot Instance data feed subscription.
 	State *string `locationName:"state" type:"string"`
 
-	metadataSpotDatafeedSubscription `json:"-", xml:"-"`
+	metadataSpotDatafeedSubscription `json:"-" xml:"-"`
 }
 
 type metadataSpotDatafeedSubscription struct {
@@ -16094,7 +16094,7 @@ type SpotInstanceRequest struct {
 	// or this date is reached.
 	ValidUntil *time.Time `locationName:"validUntil" type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataSpotInstanceRequest `json:"-", xml:"-"`
+	metadataSpotInstanceRequest `json:"-" xml:"-"`
 }
 
 type metadataSpotInstanceRequest struct {
@@ -16109,7 +16109,7 @@ type SpotInstanceStateFault struct {
 	// The message for the Spot Instance state change.
 	Message *string `locationName:"message" type:"string"`
 
-	metadataSpotInstanceStateFault `json:"-", xml:"-"`
+	metadataSpotInstanceStateFault `json:"-" xml:"-"`
 }
 
 type metadataSpotInstanceStateFault struct {
@@ -16127,7 +16127,7 @@ type SpotInstanceStatus struct {
 	// The time of the most recent status update.
 	UpdateTime *time.Time `locationName:"updateTime" type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataSpotInstanceStatus `json:"-", xml:"-"`
+	metadataSpotInstanceStatus `json:"-" xml:"-"`
 }
 
 type metadataSpotInstanceStatus struct {
@@ -16142,7 +16142,7 @@ type SpotPlacement struct {
 	// The name of the placement group (for cluster instances).
 	GroupName *string `locationName:"groupName" type:"string"`
 
-	metadataSpotPlacement `json:"-", xml:"-"`
+	metadataSpotPlacement `json:"-" xml:"-"`
 }
 
 type metadataSpotPlacement struct {
@@ -16167,7 +16167,7 @@ type SpotPrice struct {
 	// The date and time the request was created.
 	Timestamp *time.Time `locationName:"timestamp" type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataSpotPrice `json:"-", xml:"-"`
+	metadataSpotPrice `json:"-" xml:"-"`
 }
 
 type metadataSpotPrice struct {
@@ -16183,7 +16183,7 @@ type StartInstancesInput struct {
 	// One or more instance IDs.
 	InstanceIDs []*string `locationName:"InstanceId" locationNameList:"InstanceId" type:"list" required:"true"`
 
-	metadataStartInstancesInput `json:"-", xml:"-"`
+	metadataStartInstancesInput `json:"-" xml:"-"`
 }
 
 type metadataStartInstancesInput struct {
@@ -16194,7 +16194,7 @@ type StartInstancesOutput struct {
 	// Information about one or more started instances.
 	StartingInstances []*InstanceStateChange `locationName:"instancesSet" locationNameList:"item" type:"list"`
 
-	metadataStartInstancesOutput `json:"-", xml:"-"`
+	metadataStartInstancesOutput `json:"-" xml:"-"`
 }
 
 type metadataStartInstancesOutput struct {
@@ -16231,7 +16231,7 @@ type StateReason struct {
 	// Client.InvalidSnapshot.NotFound: The specified snapshot was not found.
 	Message *string `locationName:"message" type:"string"`
 
-	metadataStateReason `json:"-", xml:"-"`
+	metadataStateReason `json:"-" xml:"-"`
 }
 
 type metadataStateReason struct {
@@ -16252,7 +16252,7 @@ type StopInstancesInput struct {
 	// One or more instance IDs.
 	InstanceIDs []*string `locationName:"InstanceId" locationNameList:"InstanceId" type:"list" required:"true"`
 
-	metadataStopInstancesInput `json:"-", xml:"-"`
+	metadataStopInstancesInput `json:"-" xml:"-"`
 }
 
 type metadataStopInstancesInput struct {
@@ -16263,7 +16263,7 @@ type StopInstancesOutput struct {
 	// Information about one or more stopped instances.
 	StoppingInstances []*InstanceStateChange `locationName:"instancesSet" locationNameList:"item" type:"list"`
 
-	metadataStopInstancesOutput `json:"-", xml:"-"`
+	metadataStopInstancesOutput `json:"-" xml:"-"`
 }
 
 type metadataStopInstancesOutput struct {
@@ -16275,7 +16275,7 @@ type Storage struct {
 	// An Amazon S3 storage location.
 	S3 *S3Storage `type:"structure"`
 
-	metadataStorage `json:"-", xml:"-"`
+	metadataStorage `json:"-" xml:"-"`
 }
 
 type metadataStorage struct {
@@ -16312,7 +16312,7 @@ type Subnet struct {
 	// The ID of the VPC the subnet is in.
 	VPCID *string `locationName:"vpcId" type:"string"`
 
-	metadataSubnet `json:"-", xml:"-"`
+	metadataSubnet `json:"-" xml:"-"`
 }
 
 type metadataSubnet struct {
@@ -16333,7 +16333,7 @@ type Tag struct {
 	// characters.
 	Value *string `locationName:"value" type:"string"`
 
-	metadataTag `json:"-", xml:"-"`
+	metadataTag `json:"-" xml:"-"`
 }
 
 type metadataTag struct {
@@ -16354,7 +16354,7 @@ type TagDescription struct {
 	// The tag value.
 	Value *string `locationName:"value" type:"string"`
 
-	metadataTagDescription `json:"-", xml:"-"`
+	metadataTagDescription `json:"-" xml:"-"`
 }
 
 type metadataTagDescription struct {
@@ -16367,7 +16367,7 @@ type TerminateInstancesInput struct {
 	// One or more instance IDs.
 	InstanceIDs []*string `locationName:"InstanceId" locationNameList:"InstanceId" type:"list" required:"true"`
 
-	metadataTerminateInstancesInput `json:"-", xml:"-"`
+	metadataTerminateInstancesInput `json:"-" xml:"-"`
 }
 
 type metadataTerminateInstancesInput struct {
@@ -16378,7 +16378,7 @@ type TerminateInstancesOutput struct {
 	// Information about one or more terminated instances.
 	TerminatingInstances []*InstanceStateChange `locationName:"instancesSet" locationNameList:"item" type:"list"`
 
-	metadataTerminateInstancesOutput `json:"-", xml:"-"`
+	metadataTerminateInstancesOutput `json:"-" xml:"-"`
 }
 
 type metadataTerminateInstancesOutput struct {
@@ -16393,7 +16393,7 @@ type UnassignPrivateIPAddressesInput struct {
 	// You can specify this option multiple times to unassign more than one IP address.
 	PrivateIPAddresses []*string `locationName:"privateIpAddress" locationNameList:"PrivateIpAddress" type:"list" required:"true"`
 
-	metadataUnassignPrivateIPAddressesInput `json:"-", xml:"-"`
+	metadataUnassignPrivateIPAddressesInput `json:"-" xml:"-"`
 }
 
 type metadataUnassignPrivateIPAddressesInput struct {
@@ -16401,7 +16401,7 @@ type metadataUnassignPrivateIPAddressesInput struct {
 }
 
 type UnassignPrivateIPAddressesOutput struct {
-	metadataUnassignPrivateIPAddressesOutput `json:"-", xml:"-"`
+	metadataUnassignPrivateIPAddressesOutput `json:"-" xml:"-"`
 }
 
 type metadataUnassignPrivateIPAddressesOutput struct {
@@ -16414,7 +16414,7 @@ type UnmonitorInstancesInput struct {
 	// One or more instance IDs.
 	InstanceIDs []*string `locationName:"InstanceId" locationNameList:"InstanceId" type:"list" required:"true"`
 
-	metadataUnmonitorInstancesInput `json:"-", xml:"-"`
+	metadataUnmonitorInstancesInput `json:"-" xml:"-"`
 }
 
 type metadataUnmonitorInstancesInput struct {
@@ -16425,7 +16425,7 @@ type UnmonitorInstancesOutput struct {
 	// Monitoring information for one or more instances.
 	InstanceMonitorings []*InstanceMonitoring `locationName:"instancesSet" locationNameList:"item" type:"list"`
 
-	metadataUnmonitorInstancesOutput `json:"-", xml:"-"`
+	metadataUnmonitorInstancesOutput `json:"-" xml:"-"`
 }
 
 type metadataUnmonitorInstancesOutput struct {
@@ -16440,7 +16440,7 @@ type UserBucket struct {
 	// The Amazon S3 Key for the disk image.
 	S3Key *string `type:"string"`
 
-	metadataUserBucket `json:"-", xml:"-"`
+	metadataUserBucket `json:"-" xml:"-"`
 }
 
 type metadataUserBucket struct {
@@ -16455,7 +16455,7 @@ type UserBucketDetails struct {
 	// The Amazon S3 key from which the disk image was created.
 	S3Key *string `locationName:"s3Key" type:"string"`
 
-	metadataUserBucketDetails `json:"-", xml:"-"`
+	metadataUserBucketDetails `json:"-" xml:"-"`
 }
 
 type metadataUserBucketDetails struct {
@@ -16465,7 +16465,7 @@ type metadataUserBucketDetails struct {
 type UserData struct {
 	Data *string `locationName:"data" type:"string"`
 
-	metadataUserData `json:"-", xml:"-"`
+	metadataUserData `json:"-" xml:"-"`
 }
 
 type metadataUserData struct {
@@ -16485,7 +16485,7 @@ type UserIDGroupPair struct {
 	// The ID of an AWS account. EC2-Classic only.
 	UserID *string `locationName:"userId" type:"string"`
 
-	metadataUserIDGroupPair `json:"-", xml:"-"`
+	metadataUserIDGroupPair `json:"-" xml:"-"`
 }
 
 type metadataUserIDGroupPair struct {
@@ -16510,7 +16510,7 @@ type VGWTelemetry struct {
 	// If an error occurs, a description of the error.
 	StatusMessage *string `locationName:"statusMessage" type:"string"`
 
-	metadataVGWTelemetry `json:"-", xml:"-"`
+	metadataVGWTelemetry `json:"-" xml:"-"`
 }
 
 type metadataVGWTelemetry struct {
@@ -16541,7 +16541,7 @@ type VPC struct {
 	// The ID of the VPC.
 	VPCID *string `locationName:"vpcId" type:"string"`
 
-	metadataVPC `json:"-", xml:"-"`
+	metadataVPC `json:"-" xml:"-"`
 }
 
 type metadataVPC struct {
@@ -16556,7 +16556,7 @@ type VPCAttachment struct {
 	// The ID of the VPC.
 	VPCID *string `locationName:"vpcId" type:"string"`
 
-	metadataVPCAttachment `json:"-", xml:"-"`
+	metadataVPCAttachment `json:"-" xml:"-"`
 }
 
 type metadataVPCAttachment struct {
@@ -16574,7 +16574,7 @@ type VPCClassicLink struct {
 	// The ID of the VPC.
 	VPCID *string `locationName:"vpcId" type:"string"`
 
-	metadataVPCClassicLink `json:"-", xml:"-"`
+	metadataVPCClassicLink `json:"-" xml:"-"`
 }
 
 type metadataVPCClassicLink struct {
@@ -16601,7 +16601,7 @@ type VPCPeeringConnection struct {
 	// The ID of the VPC peering connection.
 	VPCPeeringConnectionID *string `locationName:"vpcPeeringConnectionId" type:"string"`
 
-	metadataVPCPeeringConnection `json:"-", xml:"-"`
+	metadataVPCPeeringConnection `json:"-" xml:"-"`
 }
 
 type metadataVPCPeeringConnection struct {
@@ -16616,7 +16616,7 @@ type VPCPeeringConnectionStateReason struct {
 	// A message that provides more information about the status, if applicable.
 	Message *string `locationName:"message" type:"string"`
 
-	metadataVPCPeeringConnectionStateReason `json:"-", xml:"-"`
+	metadataVPCPeeringConnectionStateReason `json:"-" xml:"-"`
 }
 
 type metadataVPCPeeringConnectionStateReason struct {
@@ -16634,7 +16634,7 @@ type VPCPeeringConnectionVPCInfo struct {
 	// The ID of the VPC.
 	VPCID *string `locationName:"vpcId" type:"string"`
 
-	metadataVPCPeeringConnectionVPCInfo `json:"-", xml:"-"`
+	metadataVPCPeeringConnectionVPCInfo `json:"-" xml:"-"`
 }
 
 type metadataVPCPeeringConnectionVPCInfo struct {
@@ -16676,7 +16676,7 @@ type VPNConnection struct {
 	// The ID of the virtual private gateway at the AWS side of the VPN connection.
 	VPNGatewayID *string `locationName:"vpnGatewayId" type:"string"`
 
-	metadataVPNConnection `json:"-", xml:"-"`
+	metadataVPNConnection `json:"-" xml:"-"`
 }
 
 type metadataVPNConnection struct {
@@ -16689,7 +16689,7 @@ type VPNConnectionOptions struct {
 	// must be used for devices that don't support BGP.
 	StaticRoutesOnly *bool `locationName:"staticRoutesOnly" type:"boolean"`
 
-	metadataVPNConnectionOptions `json:"-", xml:"-"`
+	metadataVPNConnectionOptions `json:"-" xml:"-"`
 }
 
 type metadataVPNConnectionOptions struct {
@@ -16702,7 +16702,7 @@ type VPNConnectionOptionsSpecification struct {
 	// must be used for devices that don't support BGP.
 	StaticRoutesOnly *bool `locationName:"staticRoutesOnly" type:"boolean"`
 
-	metadataVPNConnectionOptionsSpecification `json:"-", xml:"-"`
+	metadataVPNConnectionOptionsSpecification `json:"-" xml:"-"`
 }
 
 type metadataVPNConnectionOptionsSpecification struct {
@@ -16729,7 +16729,7 @@ type VPNGateway struct {
 	// The ID of the virtual private gateway.
 	VPNGatewayID *string `locationName:"vpnGatewayId" type:"string"`
 
-	metadataVPNGateway `json:"-", xml:"-"`
+	metadataVPNGateway `json:"-" xml:"-"`
 }
 
 type metadataVPNGateway struct {
@@ -16747,7 +16747,7 @@ type VPNStaticRoute struct {
 	// The current state of the static route.
 	State *string `locationName:"state" type:"string"`
 
-	metadataVPNStaticRoute `json:"-", xml:"-"`
+	metadataVPNStaticRoute `json:"-" xml:"-"`
 }
 
 type metadataVPNStaticRoute struct {
@@ -16805,7 +16805,7 @@ type Volume struct {
 	// Provisioned IOPS (SSD) volumes, or standard for Magnetic volumes.
 	VolumeType *string `locationName:"volumeType" type:"string"`
 
-	metadataVolume `json:"-", xml:"-"`
+	metadataVolume `json:"-" xml:"-"`
 }
 
 type metadataVolume struct {
@@ -16832,7 +16832,7 @@ type VolumeAttachment struct {
 	// The ID of the volume.
 	VolumeID *string `locationName:"volumeId" type:"string"`
 
-	metadataVolumeAttachment `json:"-", xml:"-"`
+	metadataVolumeAttachment `json:"-" xml:"-"`
 }
 
 type metadataVolumeAttachment struct {
@@ -16844,7 +16844,7 @@ type VolumeDetail struct {
 	// The size of the volume, in GiB.
 	Size *int64 `locationName:"size" type:"long" required:"true"`
 
-	metadataVolumeDetail `json:"-", xml:"-"`
+	metadataVolumeDetail `json:"-" xml:"-"`
 }
 
 type metadataVolumeDetail struct {
@@ -16865,7 +16865,7 @@ type VolumeStatusAction struct {
 	// The event type associated with this operation.
 	EventType *string `locationName:"eventType" type:"string"`
 
-	metadataVolumeStatusAction `json:"-", xml:"-"`
+	metadataVolumeStatusAction `json:"-" xml:"-"`
 }
 
 type metadataVolumeStatusAction struct {
@@ -16880,7 +16880,7 @@ type VolumeStatusDetails struct {
 	// The intended status of the volume status.
 	Status *string `locationName:"status" type:"string"`
 
-	metadataVolumeStatusDetails `json:"-", xml:"-"`
+	metadataVolumeStatusDetails `json:"-" xml:"-"`
 }
 
 type metadataVolumeStatusDetails struct {
@@ -16904,7 +16904,7 @@ type VolumeStatusEvent struct {
 	// The earliest start time of the event.
 	NotBefore *time.Time `locationName:"notBefore" type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataVolumeStatusEvent `json:"-", xml:"-"`
+	metadataVolumeStatusEvent `json:"-" xml:"-"`
 }
 
 type metadataVolumeStatusEvent struct {
@@ -16919,7 +16919,7 @@ type VolumeStatusInfo struct {
 	// The status of the volume.
 	Status *string `locationName:"status" type:"string"`
 
-	metadataVolumeStatusInfo `json:"-", xml:"-"`
+	metadataVolumeStatusInfo `json:"-" xml:"-"`
 }
 
 type metadataVolumeStatusInfo struct {
@@ -16943,7 +16943,7 @@ type VolumeStatusItem struct {
 	// The volume status.
 	VolumeStatus *VolumeStatusInfo `locationName:"volumeStatus" type:"structure"`
 
-	metadataVolumeStatusItem `json:"-", xml:"-"`
+	metadataVolumeStatusItem `json:"-" xml:"-"`
 }
 
 type metadataVolumeStatusItem struct {

--- a/service/ecs/api.go
+++ b/service/ecs/api.go
@@ -957,7 +957,7 @@ type Cluster struct {
 	// the associated instances can accept tasks.
 	Status *string `locationName:"status" type:"string"`
 
-	metadataCluster `json:"-", xml:"-"`
+	metadataCluster `json:"-" xml:"-"`
 }
 
 type metadataCluster struct {
@@ -986,7 +986,7 @@ type Container struct {
 	// The Amazon Resource Name (ARN) of the task.
 	TaskARN *string `locationName:"taskArn" type:"string"`
 
-	metadataContainer `json:"-", xml:"-"`
+	metadataContainer `json:"-" xml:"-"`
 }
 
 type metadataContainer struct {
@@ -1051,7 +1051,7 @@ type ContainerDefinition struct {
 	// Data volumes to mount from another container.
 	VolumesFrom []*VolumeFrom `locationName:"volumesFrom" type:"list"`
 
-	metadataContainerDefinition `json:"-", xml:"-"`
+	metadataContainerDefinition `json:"-" xml:"-"`
 }
 
 type metadataContainerDefinition struct {
@@ -1094,7 +1094,7 @@ type ContainerInstance struct {
 	// ACTIVE indicates that the container instance can accept tasks.
 	Status *string `locationName:"status" type:"string"`
 
-	metadataContainerInstance `json:"-", xml:"-"`
+	metadataContainerInstance `json:"-" xml:"-"`
 }
 
 type metadataContainerInstance struct {
@@ -1111,7 +1111,7 @@ type ContainerOverride struct {
 	// The name of the container that receives the override.
 	Name *string `locationName:"name" type:"string"`
 
-	metadataContainerOverride `json:"-", xml:"-"`
+	metadataContainerOverride `json:"-" xml:"-"`
 }
 
 type metadataContainerOverride struct {
@@ -1124,7 +1124,7 @@ type CreateClusterInput struct {
 	// lowercase), numbers, hyphens, and underscores are allowed.
 	ClusterName *string `locationName:"clusterName" type:"string"`
 
-	metadataCreateClusterInput `json:"-", xml:"-"`
+	metadataCreateClusterInput `json:"-" xml:"-"`
 }
 
 type metadataCreateClusterInput struct {
@@ -1135,7 +1135,7 @@ type CreateClusterOutput struct {
 	// The full description of your new cluster.
 	Cluster *Cluster `locationName:"cluster" type:"structure"`
 
-	metadataCreateClusterOutput `json:"-", xml:"-"`
+	metadataCreateClusterOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateClusterOutput struct {
@@ -1175,7 +1175,7 @@ type CreateServiceInput struct {
 	// of the task definition that you want to run in your service.
 	TaskDefinition *string `locationName:"taskDefinition" type:"string"`
 
-	metadataCreateServiceInput `json:"-", xml:"-"`
+	metadataCreateServiceInput `json:"-" xml:"-"`
 }
 
 type metadataCreateServiceInput struct {
@@ -1186,7 +1186,7 @@ type CreateServiceOutput struct {
 	// The full description of your service following the create call.
 	Service *Service `locationName:"service" type:"structure"`
 
-	metadataCreateServiceOutput `json:"-", xml:"-"`
+	metadataCreateServiceOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateServiceOutput struct {
@@ -1198,7 +1198,7 @@ type DeleteClusterInput struct {
 	// want to delete.
 	Cluster *string `locationName:"cluster" type:"string" required:"true"`
 
-	metadataDeleteClusterInput `json:"-", xml:"-"`
+	metadataDeleteClusterInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteClusterInput struct {
@@ -1209,7 +1209,7 @@ type DeleteClusterOutput struct {
 	// The full description of the deleted cluster.
 	Cluster *Cluster `locationName:"cluster" type:"structure"`
 
-	metadataDeleteClusterOutput `json:"-", xml:"-"`
+	metadataDeleteClusterOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteClusterOutput struct {
@@ -1223,7 +1223,7 @@ type DeleteServiceInput struct {
 	// The name of the service you want to delete.
 	Service *string `locationName:"service" type:"string" required:"true"`
 
-	metadataDeleteServiceInput `json:"-", xml:"-"`
+	metadataDeleteServiceInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteServiceInput struct {
@@ -1233,7 +1233,7 @@ type metadataDeleteServiceInput struct {
 type DeleteServiceOutput struct {
 	Service *Service `locationName:"service" type:"structure"`
 
-	metadataDeleteServiceOutput `json:"-", xml:"-"`
+	metadataDeleteServiceOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteServiceOutput struct {
@@ -1269,7 +1269,7 @@ type Deployment struct {
 	// The Unix time in seconds and milliseconds when the service was last updated.
 	UpdatedAt *time.Time `locationName:"updatedAt" type:"timestamp" timestampFormat:"unix"`
 
-	metadataDeployment `json:"-", xml:"-"`
+	metadataDeployment `json:"-" xml:"-"`
 }
 
 type metadataDeployment struct {
@@ -1295,7 +1295,7 @@ type DeregisterContainerInstanceInput struct {
 	// instance.
 	Force *bool `locationName:"force" type:"boolean"`
 
-	metadataDeregisterContainerInstanceInput `json:"-", xml:"-"`
+	metadataDeregisterContainerInstanceInput `json:"-" xml:"-"`
 }
 
 type metadataDeregisterContainerInstanceInput struct {
@@ -1307,7 +1307,7 @@ type DeregisterContainerInstanceOutput struct {
 	// registered with a cluster.
 	ContainerInstance *ContainerInstance `locationName:"containerInstance" type:"structure"`
 
-	metadataDeregisterContainerInstanceOutput `json:"-", xml:"-"`
+	metadataDeregisterContainerInstanceOutput `json:"-" xml:"-"`
 }
 
 type metadataDeregisterContainerInstanceOutput struct {
@@ -1319,7 +1319,7 @@ type DeregisterTaskDefinitionInput struct {
 	// of the task definition that you want to deregister.
 	TaskDefinition *string `locationName:"taskDefinition" type:"string" required:"true"`
 
-	metadataDeregisterTaskDefinitionInput `json:"-", xml:"-"`
+	metadataDeregisterTaskDefinitionInput `json:"-" xml:"-"`
 }
 
 type metadataDeregisterTaskDefinitionInput struct {
@@ -1330,7 +1330,7 @@ type DeregisterTaskDefinitionOutput struct {
 	// The full description of the deregistered task.
 	TaskDefinition *TaskDefinition `locationName:"taskDefinition" type:"structure"`
 
-	metadataDeregisterTaskDefinitionOutput `json:"-", xml:"-"`
+	metadataDeregisterTaskDefinitionOutput `json:"-" xml:"-"`
 }
 
 type metadataDeregisterTaskDefinitionOutput struct {
@@ -1342,7 +1342,7 @@ type DescribeClustersInput struct {
 	// (ARN) entries. If you do not specify a cluster, the default cluster is assumed.
 	Clusters []*string `locationName:"clusters" type:"list"`
 
-	metadataDescribeClustersInput `json:"-", xml:"-"`
+	metadataDescribeClustersInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeClustersInput struct {
@@ -1355,7 +1355,7 @@ type DescribeClustersOutput struct {
 
 	Failures []*Failure `locationName:"failures" type:"list"`
 
-	metadataDescribeClustersOutput `json:"-", xml:"-"`
+	metadataDescribeClustersOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeClustersOutput struct {
@@ -1372,7 +1372,7 @@ type DescribeContainerInstancesInput struct {
 	// Name (ARN) entries.
 	ContainerInstances []*string `locationName:"containerInstances" type:"list" required:"true"`
 
-	metadataDescribeContainerInstancesInput `json:"-", xml:"-"`
+	metadataDescribeContainerInstancesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeContainerInstancesInput struct {
@@ -1385,7 +1385,7 @@ type DescribeContainerInstancesOutput struct {
 
 	Failures []*Failure `locationName:"failures" type:"list"`
 
-	metadataDescribeContainerInstancesOutput `json:"-", xml:"-"`
+	metadataDescribeContainerInstancesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeContainerInstancesOutput struct {
@@ -1399,7 +1399,7 @@ type DescribeServicesInput struct {
 	// A list of services you want to describe.
 	Services []*string `locationName:"services" type:"list" required:"true"`
 
-	metadataDescribeServicesInput `json:"-", xml:"-"`
+	metadataDescribeServicesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeServicesInput struct {
@@ -1413,7 +1413,7 @@ type DescribeServicesOutput struct {
 	// The list of services described.
 	Services []*Service `locationName:"services" type:"list"`
 
-	metadataDescribeServicesOutput `json:"-", xml:"-"`
+	metadataDescribeServicesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeServicesOutput struct {
@@ -1426,7 +1426,7 @@ type DescribeTaskDefinitionInput struct {
 	// of the task definition that you want to describe.
 	TaskDefinition *string `locationName:"taskDefinition" type:"string" required:"true"`
 
-	metadataDescribeTaskDefinitionInput `json:"-", xml:"-"`
+	metadataDescribeTaskDefinitionInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeTaskDefinitionInput struct {
@@ -1437,7 +1437,7 @@ type DescribeTaskDefinitionOutput struct {
 	// The full task definition description.
 	TaskDefinition *TaskDefinition `locationName:"taskDefinition" type:"structure"`
 
-	metadataDescribeTaskDefinitionOutput `json:"-", xml:"-"`
+	metadataDescribeTaskDefinitionOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeTaskDefinitionOutput struct {
@@ -1453,7 +1453,7 @@ type DescribeTasksInput struct {
 	// A space-separated list of task UUIDs or full Amazon Resource Name (ARN) entries.
 	Tasks []*string `locationName:"tasks" type:"list" required:"true"`
 
-	metadataDescribeTasksInput `json:"-", xml:"-"`
+	metadataDescribeTasksInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeTasksInput struct {
@@ -1466,7 +1466,7 @@ type DescribeTasksOutput struct {
 	// The list of tasks.
 	Tasks []*Task `locationName:"tasks" type:"list"`
 
-	metadataDescribeTasksOutput `json:"-", xml:"-"`
+	metadataDescribeTasksOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeTasksOutput struct {
@@ -1484,7 +1484,7 @@ type DiscoverPollEndpointInput struct {
 	// example, arn:aws:ecs:region:aws_account_id:container-instance/container_instance_UUID.
 	ContainerInstance *string `locationName:"containerInstance" type:"string"`
 
-	metadataDiscoverPollEndpointInput `json:"-", xml:"-"`
+	metadataDiscoverPollEndpointInput `json:"-" xml:"-"`
 }
 
 type metadataDiscoverPollEndpointInput struct {
@@ -1495,7 +1495,7 @@ type DiscoverPollEndpointOutput struct {
 	// The endpoint for the Amazon ECS agent to poll.
 	Endpoint *string `locationName:"endpoint" type:"string"`
 
-	metadataDiscoverPollEndpointOutput `json:"-", xml:"-"`
+	metadataDiscoverPollEndpointOutput `json:"-" xml:"-"`
 }
 
 type metadataDiscoverPollEndpointOutput struct {
@@ -1509,7 +1509,7 @@ type Failure struct {
 	// The reason for the failure.
 	Reason *string `locationName:"reason" type:"string"`
 
-	metadataFailure `json:"-", xml:"-"`
+	metadataFailure `json:"-" xml:"-"`
 }
 
 type metadataFailure struct {
@@ -1522,7 +1522,7 @@ type HostVolumeProperties struct {
 	// for you.
 	SourcePath *string `locationName:"sourcePath" type:"string"`
 
-	metadataHostVolumeProperties `json:"-", xml:"-"`
+	metadataHostVolumeProperties `json:"-" xml:"-"`
 }
 
 type metadataHostVolumeProperties struct {
@@ -1536,7 +1536,7 @@ type KeyValuePair struct {
 	// The value of the key value pair.
 	Value *string `locationName:"value" type:"string"`
 
-	metadataKeyValuePair `json:"-", xml:"-"`
+	metadataKeyValuePair `json:"-" xml:"-"`
 }
 
 type metadataKeyValuePair struct {
@@ -1559,7 +1559,7 @@ type ListClustersInput struct {
 	// nextToken value. This value is null when there are no more results to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListClustersInput `json:"-", xml:"-"`
+	metadataListClustersInput `json:"-" xml:"-"`
 }
 
 type metadataListClustersInput struct {
@@ -1577,7 +1577,7 @@ type ListClustersOutput struct {
 	// more results to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListClustersOutput `json:"-", xml:"-"`
+	metadataListClustersOutput `json:"-" xml:"-"`
 }
 
 type metadataListClustersOutput struct {
@@ -1607,7 +1607,7 @@ type ListContainerInstancesInput struct {
 	// to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListContainerInstancesInput `json:"-", xml:"-"`
+	metadataListContainerInstancesInput `json:"-" xml:"-"`
 }
 
 type metadataListContainerInstancesInput struct {
@@ -1625,7 +1625,7 @@ type ListContainerInstancesOutput struct {
 	// when there are no more results to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListContainerInstancesOutput `json:"-", xml:"-"`
+	metadataListContainerInstancesOutput `json:"-" xml:"-"`
 }
 
 type metadataListContainerInstancesOutput struct {
@@ -1653,7 +1653,7 @@ type ListServicesInput struct {
 	// nextToken value. This value is null when there are no more results to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListServicesInput `json:"-", xml:"-"`
+	metadataListServicesInput `json:"-" xml:"-"`
 }
 
 type metadataListServicesInput struct {
@@ -1671,7 +1671,7 @@ type ListServicesOutput struct {
 	// with the specified cluster.
 	ServiceARNs []*string `locationName:"serviceArns" type:"list"`
 
-	metadataListServicesOutput `json:"-", xml:"-"`
+	metadataListServicesOutput `json:"-" xml:"-"`
 }
 
 type metadataListServicesOutput struct {
@@ -1701,7 +1701,7 @@ type ListTaskDefinitionFamiliesInput struct {
 	// to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListTaskDefinitionFamiliesInput `json:"-", xml:"-"`
+	metadataListTaskDefinitionFamiliesInput `json:"-" xml:"-"`
 }
 
 type metadataListTaskDefinitionFamiliesInput struct {
@@ -1719,7 +1719,7 @@ type ListTaskDefinitionFamiliesOutput struct {
 	// null when there are no more results to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListTaskDefinitionFamiliesOutput `json:"-", xml:"-"`
+	metadataListTaskDefinitionFamiliesOutput `json:"-" xml:"-"`
 }
 
 type metadataListTaskDefinitionFamiliesOutput struct {
@@ -1748,7 +1748,7 @@ type ListTaskDefinitionsInput struct {
 	// to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListTaskDefinitionsInput `json:"-", xml:"-"`
+	metadataListTaskDefinitionsInput `json:"-" xml:"-"`
 }
 
 type metadataListTaskDefinitionsInput struct {
@@ -1766,7 +1766,7 @@ type ListTaskDefinitionsOutput struct {
 	// request.
 	TaskDefinitionARNs []*string `locationName:"taskDefinitionArns" type:"list"`
 
-	metadataListTaskDefinitionsOutput `json:"-", xml:"-"`
+	metadataListTaskDefinitionsOutput `json:"-" xml:"-"`
 }
 
 type metadataListTaskDefinitionsOutput struct {
@@ -1814,7 +1814,7 @@ type ListTasksInput struct {
 	// that value.
 	StartedBy *string `locationName:"startedBy" type:"string"`
 
-	metadataListTasksInput `json:"-", xml:"-"`
+	metadataListTasksInput `json:"-" xml:"-"`
 }
 
 type metadataListTasksInput struct {
@@ -1831,7 +1831,7 @@ type ListTasksOutput struct {
 	// The list of task Amazon Resource Name (ARN) entries for the ListTasks request.
 	TaskARNs []*string `locationName:"taskArns" type:"list"`
 
-	metadataListTasksOutput `json:"-", xml:"-"`
+	metadataListTasksOutput `json:"-" xml:"-"`
 }
 
 type metadataListTasksOutput struct {
@@ -1848,7 +1848,7 @@ type LoadBalancer struct {
 	// The name of the load balancer.
 	LoadBalancerName *string `locationName:"loadBalancerName" type:"string"`
 
-	metadataLoadBalancer `json:"-", xml:"-"`
+	metadataLoadBalancer `json:"-" xml:"-"`
 }
 
 type metadataLoadBalancer struct {
@@ -1867,7 +1867,7 @@ type MountPoint struct {
 	// The name of the volume to mount.
 	SourceVolume *string `locationName:"sourceVolume" type:"string"`
 
-	metadataMountPoint `json:"-", xml:"-"`
+	metadataMountPoint `json:"-" xml:"-"`
 }
 
 type metadataMountPoint struct {
@@ -1884,7 +1884,7 @@ type NetworkBinding struct {
 	// The port number on the host that is used with the network binding.
 	HostPort *int64 `locationName:"hostPort" type:"integer"`
 
-	metadataNetworkBinding `json:"-", xml:"-"`
+	metadataNetworkBinding `json:"-" xml:"-"`
 }
 
 type metadataNetworkBinding struct {
@@ -1917,7 +1917,7 @@ type PortMapping struct {
 	// reserved ports (automatically assigned ports do not count toward this limit).
 	HostPort *int64 `locationName:"hostPort" type:"integer"`
 
-	metadataPortMapping `json:"-", xml:"-"`
+	metadataPortMapping `json:"-" xml:"-"`
 }
 
 type metadataPortMapping struct {
@@ -1938,7 +1938,7 @@ type RegisterContainerInstanceInput struct {
 
 	VersionInfo *VersionInfo `locationName:"versionInfo" type:"structure"`
 
-	metadataRegisterContainerInstanceInput `json:"-", xml:"-"`
+	metadataRegisterContainerInstanceInput `json:"-" xml:"-"`
 }
 
 type metadataRegisterContainerInstanceInput struct {
@@ -1950,7 +1950,7 @@ type RegisterContainerInstanceOutput struct {
 	// registered with a cluster.
 	ContainerInstance *ContainerInstance `locationName:"containerInstance" type:"structure"`
 
-	metadataRegisterContainerInstanceOutput `json:"-", xml:"-"`
+	metadataRegisterContainerInstanceOutput `json:"-" xml:"-"`
 }
 
 type metadataRegisterContainerInstanceOutput struct {
@@ -1972,7 +1972,7 @@ type RegisterTaskDefinitionInput struct {
 	// may use.
 	Volumes []*Volume `locationName:"volumes" type:"list"`
 
-	metadataRegisterTaskDefinitionInput `json:"-", xml:"-"`
+	metadataRegisterTaskDefinitionInput `json:"-" xml:"-"`
 }
 
 type metadataRegisterTaskDefinitionInput struct {
@@ -1982,7 +1982,7 @@ type metadataRegisterTaskDefinitionInput struct {
 type RegisterTaskDefinitionOutput struct {
 	TaskDefinition *TaskDefinition `locationName:"taskDefinition" type:"structure"`
 
-	metadataRegisterTaskDefinitionOutput `json:"-", xml:"-"`
+	metadataRegisterTaskDefinitionOutput `json:"-" xml:"-"`
 }
 
 type metadataRegisterTaskDefinitionOutput struct {
@@ -2012,7 +2012,7 @@ type Resource struct {
 	// The type of the resource, such as INTEGER, DOUBLE, LONG, or STRINGSET.
 	Type *string `locationName:"type" type:"string"`
 
-	metadataResource `json:"-", xml:"-"`
+	metadataResource `json:"-" xml:"-"`
 }
 
 type metadataResource struct {
@@ -2051,7 +2051,7 @@ type RunTaskInput struct {
 	// of the task definition that you want to run.
 	TaskDefinition *string `locationName:"taskDefinition" type:"string" required:"true"`
 
-	metadataRunTaskInput `json:"-", xml:"-"`
+	metadataRunTaskInput `json:"-" xml:"-"`
 }
 
 type metadataRunTaskInput struct {
@@ -2066,7 +2066,7 @@ type RunTaskOutput struct {
 	// placed on your cluster will be described here.
 	Tasks []*Task `locationName:"tasks" type:"list"`
 
-	metadataRunTaskOutput `json:"-", xml:"-"`
+	metadataRunTaskOutput `json:"-" xml:"-"`
 }
 
 type metadataRunTaskOutput struct {
@@ -2122,7 +2122,7 @@ type Service struct {
 	// UpdateService.
 	TaskDefinition *string `locationName:"taskDefinition" type:"string"`
 
-	metadataService `json:"-", xml:"-"`
+	metadataService `json:"-" xml:"-"`
 }
 
 type metadataService struct {
@@ -2139,7 +2139,7 @@ type ServiceEvent struct {
 	// The event message.
 	Message *string `locationName:"message" type:"string"`
 
-	metadataServiceEvent `json:"-", xml:"-"`
+	metadataServiceEvent `json:"-" xml:"-"`
 }
 
 type metadataServiceEvent struct {
@@ -2178,7 +2178,7 @@ type StartTaskInput struct {
 	// of the task definition that you want to start.
 	TaskDefinition *string `locationName:"taskDefinition" type:"string" required:"true"`
 
-	metadataStartTaskInput `json:"-", xml:"-"`
+	metadataStartTaskInput `json:"-" xml:"-"`
 }
 
 type metadataStartTaskInput struct {
@@ -2193,7 +2193,7 @@ type StartTaskOutput struct {
 	// placed on your container instances will be described here.
 	Tasks []*Task `locationName:"tasks" type:"list"`
 
-	metadataStartTaskOutput `json:"-", xml:"-"`
+	metadataStartTaskOutput `json:"-" xml:"-"`
 }
 
 type metadataStartTaskOutput struct {
@@ -2210,7 +2210,7 @@ type StopTaskInput struct {
 	// like to stop.
 	Task *string `locationName:"task" type:"string" required:"true"`
 
-	metadataStopTaskInput `json:"-", xml:"-"`
+	metadataStopTaskInput `json:"-" xml:"-"`
 }
 
 type metadataStopTaskInput struct {
@@ -2220,7 +2220,7 @@ type metadataStopTaskInput struct {
 type StopTaskOutput struct {
 	Task *Task `locationName:"task" type:"structure"`
 
-	metadataStopTaskOutput `json:"-", xml:"-"`
+	metadataStopTaskOutput `json:"-" xml:"-"`
 }
 
 type metadataStopTaskOutput struct {
@@ -2251,7 +2251,7 @@ type SubmitContainerStateChangeInput struct {
 	// container.
 	Task *string `locationName:"task" type:"string"`
 
-	metadataSubmitContainerStateChangeInput `json:"-", xml:"-"`
+	metadataSubmitContainerStateChangeInput `json:"-" xml:"-"`
 }
 
 type metadataSubmitContainerStateChangeInput struct {
@@ -2262,7 +2262,7 @@ type SubmitContainerStateChangeOutput struct {
 	// Acknowledgement of the state change.
 	Acknowledgment *string `locationName:"acknowledgment" type:"string"`
 
-	metadataSubmitContainerStateChangeOutput `json:"-", xml:"-"`
+	metadataSubmitContainerStateChangeOutput `json:"-" xml:"-"`
 }
 
 type metadataSubmitContainerStateChangeOutput struct {
@@ -2284,7 +2284,7 @@ type SubmitTaskStateChangeInput struct {
 	// change request.
 	Task *string `locationName:"task" type:"string"`
 
-	metadataSubmitTaskStateChangeInput `json:"-", xml:"-"`
+	metadataSubmitTaskStateChangeInput `json:"-" xml:"-"`
 }
 
 type metadataSubmitTaskStateChangeInput struct {
@@ -2295,7 +2295,7 @@ type SubmitTaskStateChangeOutput struct {
 	// Acknowledgement of the state change.
 	Acknowledgment *string `locationName:"acknowledgment" type:"string"`
 
-	metadataSubmitTaskStateChangeOutput `json:"-", xml:"-"`
+	metadataSubmitTaskStateChangeOutput `json:"-" xml:"-"`
 }
 
 type metadataSubmitTaskStateChangeOutput struct {
@@ -2333,7 +2333,7 @@ type Task struct {
 	// the task.
 	TaskDefinitionARN *string `locationName:"taskDefinitionArn" type:"string"`
 
-	metadataTask `json:"-", xml:"-"`
+	metadataTask `json:"-" xml:"-"`
 }
 
 type metadataTask struct {
@@ -2366,7 +2366,7 @@ type TaskDefinition struct {
 	// in the Amazon EC2 Container Service Developer Guide.
 	Volumes []*Volume `locationName:"volumes" type:"list"`
 
-	metadataTaskDefinition `json:"-", xml:"-"`
+	metadataTaskDefinition `json:"-" xml:"-"`
 }
 
 type metadataTaskDefinition struct {
@@ -2379,7 +2379,7 @@ type TaskOverride struct {
 	// One or more container overrides sent to a task.
 	ContainerOverrides []*ContainerOverride `locationName:"containerOverrides" type:"list"`
 
-	metadataTaskOverride `json:"-", xml:"-"`
+	metadataTaskOverride `json:"-" xml:"-"`
 }
 
 type metadataTaskOverride struct {
@@ -2406,7 +2406,7 @@ type UpdateServiceInput struct {
 	// version is running.
 	TaskDefinition *string `locationName:"taskDefinition" type:"string"`
 
-	metadataUpdateServiceInput `json:"-", xml:"-"`
+	metadataUpdateServiceInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateServiceInput struct {
@@ -2417,7 +2417,7 @@ type UpdateServiceOutput struct {
 	// The full description of your service following the update call.
 	Service *Service `locationName:"service" type:"structure"`
 
-	metadataUpdateServiceOutput `json:"-", xml:"-"`
+	metadataUpdateServiceOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateServiceOutput struct {
@@ -2435,7 +2435,7 @@ type VersionInfo struct {
 	// The Docker version running on the container instance.
 	DockerVersion *string `locationName:"dockerVersion" type:"string"`
 
-	metadataVersionInfo `json:"-", xml:"-"`
+	metadataVersionInfo `json:"-" xml:"-"`
 }
 
 type metadataVersionInfo struct {
@@ -2452,7 +2452,7 @@ type Volume struct {
 	// of container definition mountPoints.
 	Name *string `locationName:"name" type:"string"`
 
-	metadataVolume `json:"-", xml:"-"`
+	metadataVolume `json:"-" xml:"-"`
 }
 
 type metadataVolume struct {
@@ -2468,7 +2468,7 @@ type VolumeFrom struct {
 	// The name of the container to mount volumes from.
 	SourceContainer *string `locationName:"sourceContainer" type:"string"`
 
-	metadataVolumeFrom `json:"-", xml:"-"`
+	metadataVolumeFrom `json:"-" xml:"-"`
 }
 
 type metadataVolumeFrom struct {

--- a/service/elasticache/api.go
+++ b/service/elasticache/api.go
@@ -1376,7 +1376,7 @@ type AddTagsToResourceInput struct {
 	// pair. A tag key must be accompanied by a tag value.
 	Tags []*Tag `locationNameList:"Tag" type:"list" required:"true"`
 
-	metadataAddTagsToResourceInput `json:"-", xml:"-"`
+	metadataAddTagsToResourceInput `json:"-" xml:"-"`
 }
 
 type metadataAddTagsToResourceInput struct {
@@ -1397,7 +1397,7 @@ type AuthorizeCacheSecurityGroupIngressInput struct {
 	// AWS account number for this parameter.
 	EC2SecurityGroupOwnerID *string `locationName:"EC2SecurityGroupOwnerId" type:"string" required:"true"`
 
-	metadataAuthorizeCacheSecurityGroupIngressInput `json:"-", xml:"-"`
+	metadataAuthorizeCacheSecurityGroupIngressInput `json:"-" xml:"-"`
 }
 
 type metadataAuthorizeCacheSecurityGroupIngressInput struct {
@@ -1410,7 +1410,7 @@ type AuthorizeCacheSecurityGroupIngressOutput struct {
 	//   AuthorizeCacheSecurityGroupIngress   CreateCacheSecurityGroup   RevokeCacheSecurityGroupIngress
 	CacheSecurityGroup *CacheSecurityGroup `type:"structure"`
 
-	metadataAuthorizeCacheSecurityGroupIngressOutput `json:"-", xml:"-"`
+	metadataAuthorizeCacheSecurityGroupIngressOutput `json:"-" xml:"-"`
 }
 
 type metadataAuthorizeCacheSecurityGroupIngressOutput struct {
@@ -1422,7 +1422,7 @@ type AvailabilityZone struct {
 	// The name of the Availability Zone.
 	Name *string `type:"string"`
 
-	metadataAvailabilityZone `json:"-", xml:"-"`
+	metadataAvailabilityZone `json:"-" xml:"-"`
 }
 
 type metadataAvailabilityZone struct {
@@ -1543,7 +1543,7 @@ type CacheCluster struct {
 	// Example: 05:00-09:00
 	SnapshotWindow *string `type:"string"`
 
-	metadataCacheCluster `json:"-", xml:"-"`
+	metadataCacheCluster `json:"-" xml:"-"`
 }
 
 type metadataCacheCluster struct {
@@ -1567,7 +1567,7 @@ type CacheEngineVersion struct {
 	// The version number of the cache engine.
 	EngineVersion *string `type:"string"`
 
-	metadataCacheEngineVersion `json:"-", xml:"-"`
+	metadataCacheEngineVersion `json:"-" xml:"-"`
 }
 
 type metadataCacheEngineVersion struct {
@@ -1621,7 +1621,7 @@ type CacheNode struct {
 	// cluster.
 	SourceCacheNodeID *string `locationName:"SourceCacheNodeId" type:"string"`
 
-	metadataCacheNode `json:"-", xml:"-"`
+	metadataCacheNode `json:"-" xml:"-"`
 }
 
 type metadataCacheNode struct {
@@ -1658,7 +1658,7 @@ type CacheNodeTypeSpecificParameter struct {
 	// The source of the parameter value.
 	Source *string `type:"string"`
 
-	metadataCacheNodeTypeSpecificParameter `json:"-", xml:"-"`
+	metadataCacheNodeTypeSpecificParameter `json:"-" xml:"-"`
 }
 
 type metadataCacheNodeTypeSpecificParameter struct {
@@ -1673,7 +1673,7 @@ type CacheNodeTypeSpecificValue struct {
 	// The value for the cache node type.
 	Value *string `type:"string"`
 
-	metadataCacheNodeTypeSpecificValue `json:"-", xml:"-"`
+	metadataCacheNodeTypeSpecificValue `json:"-" xml:"-"`
 }
 
 type metadataCacheNodeTypeSpecificValue struct {
@@ -1692,7 +1692,7 @@ type CacheParameterGroup struct {
 	// The description for this cache parameter group.
 	Description *string `type:"string"`
 
-	metadataCacheParameterGroup `json:"-", xml:"-"`
+	metadataCacheParameterGroup `json:"-" xml:"-"`
 }
 
 type metadataCacheParameterGroup struct {
@@ -1706,7 +1706,7 @@ type CacheParameterGroupNameMessage struct {
 	// The name of the cache parameter group.
 	CacheParameterGroupName *string `type:"string"`
 
-	metadataCacheParameterGroupNameMessage `json:"-", xml:"-"`
+	metadataCacheParameterGroupNameMessage `json:"-" xml:"-"`
 }
 
 type metadataCacheParameterGroupNameMessage struct {
@@ -1725,7 +1725,7 @@ type CacheParameterGroupStatus struct {
 	// The status of parameter updates.
 	ParameterApplyStatus *string `type:"string"`
 
-	metadataCacheParameterGroupStatus `json:"-", xml:"-"`
+	metadataCacheParameterGroupStatus `json:"-" xml:"-"`
 }
 
 type metadataCacheParameterGroupStatus struct {
@@ -1749,7 +1749,7 @@ type CacheSecurityGroup struct {
 	// The AWS account ID of the cache security group owner.
 	OwnerID *string `locationName:"OwnerId" type:"string"`
 
-	metadataCacheSecurityGroup `json:"-", xml:"-"`
+	metadataCacheSecurityGroup `json:"-" xml:"-"`
 }
 
 type metadataCacheSecurityGroup struct {
@@ -1766,7 +1766,7 @@ type CacheSecurityGroupMembership struct {
 	// to a cache cluster are modified.
 	Status *string `type:"string"`
 
-	metadataCacheSecurityGroupMembership `json:"-", xml:"-"`
+	metadataCacheSecurityGroupMembership `json:"-" xml:"-"`
 }
 
 type metadataCacheSecurityGroupMembership struct {
@@ -1790,7 +1790,7 @@ type CacheSubnetGroup struct {
 	// group.
 	VPCID *string `locationName:"VpcId" type:"string"`
 
-	metadataCacheSubnetGroup `json:"-", xml:"-"`
+	metadataCacheSubnetGroup `json:"-" xml:"-"`
 }
 
 type metadataCacheSubnetGroup struct {
@@ -1805,7 +1805,7 @@ type CopySnapshotInput struct {
 	// A name for the copied snapshot.
 	TargetSnapshotName *string `type:"string" required:"true"`
 
-	metadataCopySnapshotInput `json:"-", xml:"-"`
+	metadataCopySnapshotInput `json:"-" xml:"-"`
 }
 
 type metadataCopySnapshotInput struct {
@@ -1817,7 +1817,7 @@ type CopySnapshotOutput struct {
 	// was taken.
 	Snapshot *Snapshot `type:"structure"`
 
-	metadataCopySnapshotOutput `json:"-", xml:"-"`
+	metadataCopySnapshotOutput `json:"-" xml:"-"`
 }
 
 type metadataCopySnapshotOutput struct {
@@ -2016,7 +2016,7 @@ type CreateCacheClusterInput struct {
 	// pair. A tag key must be accompanied by a tag value.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataCreateCacheClusterInput `json:"-", xml:"-"`
+	metadataCreateCacheClusterInput `json:"-" xml:"-"`
 }
 
 type metadataCreateCacheClusterInput struct {
@@ -2027,7 +2027,7 @@ type CreateCacheClusterOutput struct {
 	// Contains all of the attributes of a specific cache cluster.
 	CacheCluster *CacheCluster `type:"structure"`
 
-	metadataCreateCacheClusterOutput `json:"-", xml:"-"`
+	metadataCreateCacheClusterOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateCacheClusterOutput struct {
@@ -2048,7 +2048,7 @@ type CreateCacheParameterGroupInput struct {
 	// A user-specified description for the cache parameter group.
 	Description *string `type:"string" required:"true"`
 
-	metadataCreateCacheParameterGroupInput `json:"-", xml:"-"`
+	metadataCreateCacheParameterGroupInput `json:"-" xml:"-"`
 }
 
 type metadataCreateCacheParameterGroupInput struct {
@@ -2059,7 +2059,7 @@ type CreateCacheParameterGroupOutput struct {
 	// Represents the output of a CreateCacheParameterGroup action.
 	CacheParameterGroup *CacheParameterGroup `type:"structure"`
 
-	metadataCreateCacheParameterGroupOutput `json:"-", xml:"-"`
+	metadataCreateCacheParameterGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateCacheParameterGroupOutput struct {
@@ -2080,7 +2080,7 @@ type CreateCacheSecurityGroupInput struct {
 	// A description for the cache security group.
 	Description *string `type:"string" required:"true"`
 
-	metadataCreateCacheSecurityGroupInput `json:"-", xml:"-"`
+	metadataCreateCacheSecurityGroupInput `json:"-" xml:"-"`
 }
 
 type metadataCreateCacheSecurityGroupInput struct {
@@ -2093,7 +2093,7 @@ type CreateCacheSecurityGroupOutput struct {
 	//   AuthorizeCacheSecurityGroupIngress   CreateCacheSecurityGroup   RevokeCacheSecurityGroupIngress
 	CacheSecurityGroup *CacheSecurityGroup `type:"structure"`
 
-	metadataCreateCacheSecurityGroupOutput `json:"-", xml:"-"`
+	metadataCreateCacheSecurityGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateCacheSecurityGroupOutput struct {
@@ -2115,7 +2115,7 @@ type CreateCacheSubnetGroupInput struct {
 	// A list of VPC subnet IDs for the cache subnet group.
 	SubnetIDs []*string `locationName:"SubnetIds" locationNameList:"SubnetIdentifier" type:"list" required:"true"`
 
-	metadataCreateCacheSubnetGroupInput `json:"-", xml:"-"`
+	metadataCreateCacheSubnetGroupInput `json:"-" xml:"-"`
 }
 
 type metadataCreateCacheSubnetGroupInput struct {
@@ -2128,7 +2128,7 @@ type CreateCacheSubnetGroupOutput struct {
 	//   CreateCacheSubnetGroup   ModifyCacheSubnetGroup
 	CacheSubnetGroup *CacheSubnetGroup `type:"structure"`
 
-	metadataCreateCacheSubnetGroupOutput `json:"-", xml:"-"`
+	metadataCreateCacheSubnetGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateCacheSubnetGroupOutput struct {
@@ -2306,7 +2306,7 @@ type CreateReplicationGroupInput struct {
 	// pair. A tag key must be accompanied by a tag value.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataCreateReplicationGroupInput `json:"-", xml:"-"`
+	metadataCreateReplicationGroupInput `json:"-" xml:"-"`
 }
 
 type metadataCreateReplicationGroupInput struct {
@@ -2317,7 +2317,7 @@ type CreateReplicationGroupOutput struct {
 	// Contains all of the attributes of a specific replication group.
 	ReplicationGroup *ReplicationGroup `type:"structure"`
 
-	metadataCreateReplicationGroupOutput `json:"-", xml:"-"`
+	metadataCreateReplicationGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateReplicationGroupOutput struct {
@@ -2333,7 +2333,7 @@ type CreateSnapshotInput struct {
 	// A name for the snapshot being created.
 	SnapshotName *string `type:"string" required:"true"`
 
-	metadataCreateSnapshotInput `json:"-", xml:"-"`
+	metadataCreateSnapshotInput `json:"-" xml:"-"`
 }
 
 type metadataCreateSnapshotInput struct {
@@ -2345,7 +2345,7 @@ type CreateSnapshotOutput struct {
 	// was taken.
 	Snapshot *Snapshot `type:"structure"`
 
-	metadataCreateSnapshotOutput `json:"-", xml:"-"`
+	metadataCreateSnapshotOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateSnapshotOutput struct {
@@ -2363,7 +2363,7 @@ type DeleteCacheClusterInput struct {
 	// then deletes the cache cluster immediately afterward.
 	FinalSnapshotIdentifier *string `type:"string"`
 
-	metadataDeleteCacheClusterInput `json:"-", xml:"-"`
+	metadataDeleteCacheClusterInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteCacheClusterInput struct {
@@ -2374,7 +2374,7 @@ type DeleteCacheClusterOutput struct {
 	// Contains all of the attributes of a specific cache cluster.
 	CacheCluster *CacheCluster `type:"structure"`
 
-	metadataDeleteCacheClusterOutput `json:"-", xml:"-"`
+	metadataDeleteCacheClusterOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteCacheClusterOutput struct {
@@ -2389,7 +2389,7 @@ type DeleteCacheParameterGroupInput struct {
 	// clusters.
 	CacheParameterGroupName *string `type:"string" required:"true"`
 
-	metadataDeleteCacheParameterGroupInput `json:"-", xml:"-"`
+	metadataDeleteCacheParameterGroupInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteCacheParameterGroupInput struct {
@@ -2397,7 +2397,7 @@ type metadataDeleteCacheParameterGroupInput struct {
 }
 
 type DeleteCacheParameterGroupOutput struct {
-	metadataDeleteCacheParameterGroupOutput `json:"-", xml:"-"`
+	metadataDeleteCacheParameterGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteCacheParameterGroupOutput struct {
@@ -2411,7 +2411,7 @@ type DeleteCacheSecurityGroupInput struct {
 	// You cannot delete the default security group.
 	CacheSecurityGroupName *string `type:"string" required:"true"`
 
-	metadataDeleteCacheSecurityGroupInput `json:"-", xml:"-"`
+	metadataDeleteCacheSecurityGroupInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteCacheSecurityGroupInput struct {
@@ -2419,7 +2419,7 @@ type metadataDeleteCacheSecurityGroupInput struct {
 }
 
 type DeleteCacheSecurityGroupOutput struct {
-	metadataDeleteCacheSecurityGroupOutput `json:"-", xml:"-"`
+	metadataDeleteCacheSecurityGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteCacheSecurityGroupOutput struct {
@@ -2433,7 +2433,7 @@ type DeleteCacheSubnetGroupInput struct {
 	// Constraints: Must contain no more than 255 alphanumeric characters or hyphens.
 	CacheSubnetGroupName *string `type:"string" required:"true"`
 
-	metadataDeleteCacheSubnetGroupInput `json:"-", xml:"-"`
+	metadataDeleteCacheSubnetGroupInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteCacheSubnetGroupInput struct {
@@ -2441,7 +2441,7 @@ type metadataDeleteCacheSubnetGroupInput struct {
 }
 
 type DeleteCacheSubnetGroupOutput struct {
-	metadataDeleteCacheSubnetGroupOutput `json:"-", xml:"-"`
+	metadataDeleteCacheSubnetGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteCacheSubnetGroupOutput struct {
@@ -2464,7 +2464,7 @@ type DeleteReplicationGroupInput struct {
 	// node will be retained.
 	RetainPrimaryCluster *bool `type:"boolean"`
 
-	metadataDeleteReplicationGroupInput `json:"-", xml:"-"`
+	metadataDeleteReplicationGroupInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteReplicationGroupInput struct {
@@ -2475,7 +2475,7 @@ type DeleteReplicationGroupOutput struct {
 	// Contains all of the attributes of a specific replication group.
 	ReplicationGroup *ReplicationGroup `type:"structure"`
 
-	metadataDeleteReplicationGroupOutput `json:"-", xml:"-"`
+	metadataDeleteReplicationGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteReplicationGroupOutput struct {
@@ -2487,7 +2487,7 @@ type DeleteSnapshotInput struct {
 	// The name of the snapshot to be deleted.
 	SnapshotName *string `type:"string" required:"true"`
 
-	metadataDeleteSnapshotInput `json:"-", xml:"-"`
+	metadataDeleteSnapshotInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteSnapshotInput struct {
@@ -2499,7 +2499,7 @@ type DeleteSnapshotOutput struct {
 	// was taken.
 	Snapshot *Snapshot `type:"structure"`
 
-	metadataDeleteSnapshotOutput `json:"-", xml:"-"`
+	metadataDeleteSnapshotOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteSnapshotOutput struct {
@@ -2531,7 +2531,7 @@ type DescribeCacheClustersInput struct {
 	// to retrieve information about the individual cache nodes.
 	ShowCacheNodeInfo *bool `type:"boolean"`
 
-	metadataDescribeCacheClustersInput `json:"-", xml:"-"`
+	metadataDescribeCacheClustersInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeCacheClustersInput struct {
@@ -2547,7 +2547,7 @@ type DescribeCacheClustersOutput struct {
 	// Provides an identifier to allow retrieval of paginated results.
 	Marker *string `type:"string"`
 
-	metadataDescribeCacheClustersOutput `json:"-", xml:"-"`
+	metadataDescribeCacheClustersOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeCacheClustersOutput struct {
@@ -2590,7 +2590,7 @@ type DescribeCacheEngineVersionsInput struct {
 	// Constraints: minimum 20; maximum 100.
 	MaxRecords *int64 `type:"integer"`
 
-	metadataDescribeCacheEngineVersionsInput `json:"-", xml:"-"`
+	metadataDescribeCacheEngineVersionsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeCacheEngineVersionsInput struct {
@@ -2606,7 +2606,7 @@ type DescribeCacheEngineVersionsOutput struct {
 	// Provides an identifier to allow retrieval of paginated results.
 	Marker *string `type:"string"`
 
-	metadataDescribeCacheEngineVersionsOutput `json:"-", xml:"-"`
+	metadataDescribeCacheEngineVersionsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeCacheEngineVersionsOutput struct {
@@ -2632,7 +2632,7 @@ type DescribeCacheParameterGroupsInput struct {
 	// Constraints: minimum 20; maximum 100.
 	MaxRecords *int64 `type:"integer"`
 
-	metadataDescribeCacheParameterGroupsInput `json:"-", xml:"-"`
+	metadataDescribeCacheParameterGroupsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeCacheParameterGroupsInput struct {
@@ -2648,7 +2648,7 @@ type DescribeCacheParameterGroupsOutput struct {
 	// Provides an identifier to allow retrieval of paginated results.
 	Marker *string `type:"string"`
 
-	metadataDescribeCacheParameterGroupsOutput `json:"-", xml:"-"`
+	metadataDescribeCacheParameterGroupsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeCacheParameterGroupsOutput struct {
@@ -2679,7 +2679,7 @@ type DescribeCacheParametersInput struct {
 	// Valid values: user | system | engine-default
 	Source *string `type:"string"`
 
-	metadataDescribeCacheParametersInput `json:"-", xml:"-"`
+	metadataDescribeCacheParametersInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeCacheParametersInput struct {
@@ -2698,7 +2698,7 @@ type DescribeCacheParametersOutput struct {
 	// A list of Parameter instances.
 	Parameters []*Parameter `locationNameList:"Parameter" type:"list"`
 
-	metadataDescribeCacheParametersOutput `json:"-", xml:"-"`
+	metadataDescribeCacheParametersOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeCacheParametersOutput struct {
@@ -2724,7 +2724,7 @@ type DescribeCacheSecurityGroupsInput struct {
 	// Constraints: minimum 20; maximum 100.
 	MaxRecords *int64 `type:"integer"`
 
-	metadataDescribeCacheSecurityGroupsInput `json:"-", xml:"-"`
+	metadataDescribeCacheSecurityGroupsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeCacheSecurityGroupsInput struct {
@@ -2740,7 +2740,7 @@ type DescribeCacheSecurityGroupsOutput struct {
 	// Provides an identifier to allow retrieval of paginated results.
 	Marker *string `type:"string"`
 
-	metadataDescribeCacheSecurityGroupsOutput `json:"-", xml:"-"`
+	metadataDescribeCacheSecurityGroupsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeCacheSecurityGroupsOutput struct {
@@ -2766,7 +2766,7 @@ type DescribeCacheSubnetGroupsInput struct {
 	// Constraints: minimum 20; maximum 100.
 	MaxRecords *int64 `type:"integer"`
 
-	metadataDescribeCacheSubnetGroupsInput `json:"-", xml:"-"`
+	metadataDescribeCacheSubnetGroupsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeCacheSubnetGroupsInput struct {
@@ -2782,7 +2782,7 @@ type DescribeCacheSubnetGroupsOutput struct {
 	// Provides an identifier to allow retrieval of paginated results.
 	Marker *string `type:"string"`
 
-	metadataDescribeCacheSubnetGroupsOutput `json:"-", xml:"-"`
+	metadataDescribeCacheSubnetGroupsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeCacheSubnetGroupsOutput struct {
@@ -2809,7 +2809,7 @@ type DescribeEngineDefaultParametersInput struct {
 	// Constraints: minimum 20; maximum 100.
 	MaxRecords *int64 `type:"integer"`
 
-	metadataDescribeEngineDefaultParametersInput `json:"-", xml:"-"`
+	metadataDescribeEngineDefaultParametersInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeEngineDefaultParametersInput struct {
@@ -2820,7 +2820,7 @@ type DescribeEngineDefaultParametersOutput struct {
 	// Represents the output of a DescribeEngineDefaultParameters action.
 	EngineDefaults *EngineDefaults `type:"structure"`
 
-	metadataDescribeEngineDefaultParametersOutput `json:"-", xml:"-"`
+	metadataDescribeEngineDefaultParametersOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeEngineDefaultParametersOutput struct {
@@ -2865,7 +2865,7 @@ type DescribeEventsInput struct {
 	// 8601 format.
 	StartTime *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataDescribeEventsInput `json:"-", xml:"-"`
+	metadataDescribeEventsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeEventsInput struct {
@@ -2881,7 +2881,7 @@ type DescribeEventsOutput struct {
 	// Provides an identifier to allow retrieval of paginated results.
 	Marker *string `type:"string"`
 
-	metadataDescribeEventsOutput `json:"-", xml:"-"`
+	metadataDescribeEventsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeEventsOutput struct {
@@ -2911,7 +2911,7 @@ type DescribeReplicationGroupsInput struct {
 	// groups is returned.
 	ReplicationGroupID *string `locationName:"ReplicationGroupId" type:"string"`
 
-	metadataDescribeReplicationGroupsInput `json:"-", xml:"-"`
+	metadataDescribeReplicationGroupsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeReplicationGroupsInput struct {
@@ -2927,7 +2927,7 @@ type DescribeReplicationGroupsOutput struct {
 	// about one replication group.
 	ReplicationGroups []*ReplicationGroup `locationNameList:"ReplicationGroup" type:"list"`
 
-	metadataDescribeReplicationGroupsOutput `json:"-", xml:"-"`
+	metadataDescribeReplicationGroupsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeReplicationGroupsOutput struct {
@@ -2996,7 +2996,7 @@ type DescribeReservedCacheNodesInput struct {
 	// reservations matching the specified offering identifier.
 	ReservedCacheNodesOfferingID *string `locationName:"ReservedCacheNodesOfferingId" type:"string"`
 
-	metadataDescribeReservedCacheNodesInput `json:"-", xml:"-"`
+	metadataDescribeReservedCacheNodesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeReservedCacheNodesInput struct {
@@ -3063,7 +3063,7 @@ type DescribeReservedCacheNodesOfferingsInput struct {
 	// Example: 438012d3-4052-4cc7-b2e3-8d3372e0e706
 	ReservedCacheNodesOfferingID *string `locationName:"ReservedCacheNodesOfferingId" type:"string"`
 
-	metadataDescribeReservedCacheNodesOfferingsInput `json:"-", xml:"-"`
+	metadataDescribeReservedCacheNodesOfferingsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeReservedCacheNodesOfferingsInput struct {
@@ -3079,7 +3079,7 @@ type DescribeReservedCacheNodesOfferingsOutput struct {
 	// detailed information about one offering.
 	ReservedCacheNodesOfferings []*ReservedCacheNodesOffering `locationNameList:"ReservedCacheNodesOffering" type:"list"`
 
-	metadataDescribeReservedCacheNodesOfferingsOutput `json:"-", xml:"-"`
+	metadataDescribeReservedCacheNodesOfferingsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeReservedCacheNodesOfferingsOutput struct {
@@ -3095,7 +3095,7 @@ type DescribeReservedCacheNodesOutput struct {
 	// information about one node.
 	ReservedCacheNodes []*ReservedCacheNode `locationNameList:"ReservedCacheNode" type:"list"`
 
-	metadataDescribeReservedCacheNodesOutput `json:"-", xml:"-"`
+	metadataDescribeReservedCacheNodesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeReservedCacheNodesOutput struct {
@@ -3132,7 +3132,7 @@ type DescribeSnapshotsInput struct {
 	// snapshots.
 	SnapshotSource *string `type:"string"`
 
-	metadataDescribeSnapshotsInput `json:"-", xml:"-"`
+	metadataDescribeSnapshotsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeSnapshotsInput struct {
@@ -3150,7 +3150,7 @@ type DescribeSnapshotsOutput struct {
 	// about one snapshot.
 	Snapshots []*Snapshot `locationNameList:"Snapshot" type:"list"`
 
-	metadataDescribeSnapshotsOutput `json:"-", xml:"-"`
+	metadataDescribeSnapshotsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeSnapshotsOutput struct {
@@ -3168,7 +3168,7 @@ type EC2SecurityGroup struct {
 	// The status of the Amazon EC2 security group.
 	Status *string `type:"string"`
 
-	metadataEC2SecurityGroup `json:"-", xml:"-"`
+	metadataEC2SecurityGroup `json:"-" xml:"-"`
 }
 
 type metadataEC2SecurityGroup struct {
@@ -3184,7 +3184,7 @@ type Endpoint struct {
 	// The port number that the cache engine is listening on.
 	Port *int64 `type:"integer"`
 
-	metadataEndpoint `json:"-", xml:"-"`
+	metadataEndpoint `json:"-" xml:"-"`
 }
 
 type metadataEndpoint struct {
@@ -3207,7 +3207,7 @@ type EngineDefaults struct {
 	// Contains a list of engine default parameters.
 	Parameters []*Parameter `locationNameList:"Parameter" type:"list"`
 
-	metadataEngineDefaults `json:"-", xml:"-"`
+	metadataEngineDefaults `json:"-" xml:"-"`
 }
 
 type metadataEngineDefaults struct {
@@ -3233,7 +3233,7 @@ type Event struct {
 	// a security group, etc.
 	SourceType *string `type:"string"`
 
-	metadataEvent `json:"-", xml:"-"`
+	metadataEvent `json:"-" xml:"-"`
 }
 
 type metadataEvent struct {
@@ -3246,7 +3246,7 @@ type ListTagsForResourceInput struct {
 	// arn:aws:elasticache:us-west-2:0123456789:cluster:myCluster.
 	ResourceName *string `type:"string" required:"true"`
 
-	metadataListTagsForResourceInput `json:"-", xml:"-"`
+	metadataListTagsForResourceInput `json:"-" xml:"-"`
 }
 
 type metadataListTagsForResourceInput struct {
@@ -3433,7 +3433,7 @@ type ModifyCacheClusterInput struct {
 	// a daily snapshot of your cache cluster.
 	SnapshotWindow *string `type:"string"`
 
-	metadataModifyCacheClusterInput `json:"-", xml:"-"`
+	metadataModifyCacheClusterInput `json:"-" xml:"-"`
 }
 
 type metadataModifyCacheClusterInput struct {
@@ -3444,7 +3444,7 @@ type ModifyCacheClusterOutput struct {
 	// Contains all of the attributes of a specific cache cluster.
 	CacheCluster *CacheCluster `type:"structure"`
 
-	metadataModifyCacheClusterOutput `json:"-", xml:"-"`
+	metadataModifyCacheClusterOutput `json:"-" xml:"-"`
 }
 
 type metadataModifyCacheClusterOutput struct {
@@ -3461,7 +3461,7 @@ type ModifyCacheParameterGroupInput struct {
 	// A maximum of 20 parameters may be modified per request.
 	ParameterNameValues []*ParameterNameValue `locationNameList:"ParameterNameValue" type:"list" required:"true"`
 
-	metadataModifyCacheParameterGroupInput `json:"-", xml:"-"`
+	metadataModifyCacheParameterGroupInput `json:"-" xml:"-"`
 }
 
 type metadataModifyCacheParameterGroupInput struct {
@@ -3484,7 +3484,7 @@ type ModifyCacheSubnetGroupInput struct {
 	// The EC2 subnet IDs for the cache subnet group.
 	SubnetIDs []*string `locationName:"SubnetIds" locationNameList:"SubnetIdentifier" type:"list"`
 
-	metadataModifyCacheSubnetGroupInput `json:"-", xml:"-"`
+	metadataModifyCacheSubnetGroupInput `json:"-" xml:"-"`
 }
 
 type metadataModifyCacheSubnetGroupInput struct {
@@ -3497,7 +3497,7 @@ type ModifyCacheSubnetGroupOutput struct {
 	//   CreateCacheSubnetGroup   ModifyCacheSubnetGroup
 	CacheSubnetGroup *CacheSubnetGroup `type:"structure"`
 
-	metadataModifyCacheSubnetGroupOutput `json:"-", xml:"-"`
+	metadataModifyCacheSubnetGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataModifyCacheSubnetGroupOutput struct {
@@ -3613,7 +3613,7 @@ type ModifyReplicationGroupInput struct {
 	// replication group.
 	SnapshottingClusterID *string `locationName:"SnapshottingClusterId" type:"string"`
 
-	metadataModifyReplicationGroupInput `json:"-", xml:"-"`
+	metadataModifyReplicationGroupInput `json:"-" xml:"-"`
 }
 
 type metadataModifyReplicationGroupInput struct {
@@ -3624,7 +3624,7 @@ type ModifyReplicationGroupOutput struct {
 	// Contains all of the attributes of a specific replication group.
 	ReplicationGroup *ReplicationGroup `type:"structure"`
 
-	metadataModifyReplicationGroupOutput `json:"-", xml:"-"`
+	metadataModifyReplicationGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataModifyReplicationGroupOutput struct {
@@ -3647,7 +3647,7 @@ type NodeGroup struct {
 	// The current state of this replication group - creating, available, etc.
 	Status *string `type:"string"`
 
-	metadataNodeGroup `json:"-", xml:"-"`
+	metadataNodeGroup `json:"-" xml:"-"`
 }
 
 type metadataNodeGroup struct {
@@ -3673,7 +3673,7 @@ type NodeGroupMember struct {
 	// node.
 	ReadEndpoint *Endpoint `type:"structure"`
 
-	metadataNodeGroupMember `json:"-", xml:"-"`
+	metadataNodeGroupMember `json:"-" xml:"-"`
 }
 
 type metadataNodeGroupMember struct {
@@ -3695,7 +3695,7 @@ type NodeSnapshot struct {
 	// obtained for the snapshot.
 	SnapshotCreateTime *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataNodeSnapshot `json:"-", xml:"-"`
+	metadataNodeSnapshot `json:"-" xml:"-"`
 }
 
 type metadataNodeSnapshot struct {
@@ -3712,7 +3712,7 @@ type NotificationConfiguration struct {
 	// The current state of the topic.
 	TopicStatus *string `type:"string"`
 
-	metadataNotificationConfiguration `json:"-", xml:"-"`
+	metadataNotificationConfiguration `json:"-" xml:"-"`
 }
 
 type metadataNotificationConfiguration struct {
@@ -3748,7 +3748,7 @@ type Parameter struct {
 	// The source of the parameter.
 	Source *string `type:"string"`
 
-	metadataParameter `json:"-", xml:"-"`
+	metadataParameter `json:"-" xml:"-"`
 }
 
 type metadataParameter struct {
@@ -3763,7 +3763,7 @@ type ParameterNameValue struct {
 	// The value of the parameter.
 	ParameterValue *string `type:"string"`
 
-	metadataParameterNameValue `json:"-", xml:"-"`
+	metadataParameterNameValue `json:"-" xml:"-"`
 }
 
 type metadataParameterNameValue struct {
@@ -3786,7 +3786,7 @@ type PendingModifiedValues struct {
 	// this value must be between 1 and 20.
 	NumCacheNodes *int64 `type:"integer"`
 
-	metadataPendingModifiedValues `json:"-", xml:"-"`
+	metadataPendingModifiedValues `json:"-" xml:"-"`
 }
 
 type metadataPendingModifiedValues struct {
@@ -3810,7 +3810,7 @@ type PurchaseReservedCacheNodesOfferingInput struct {
 	// Example: 438012d3-4052-4cc7-b2e3-8d3372e0e706
 	ReservedCacheNodesOfferingID *string `locationName:"ReservedCacheNodesOfferingId" type:"string" required:"true"`
 
-	metadataPurchaseReservedCacheNodesOfferingInput `json:"-", xml:"-"`
+	metadataPurchaseReservedCacheNodesOfferingInput `json:"-" xml:"-"`
 }
 
 type metadataPurchaseReservedCacheNodesOfferingInput struct {
@@ -3821,7 +3821,7 @@ type PurchaseReservedCacheNodesOfferingOutput struct {
 	// Represents the output of a PurchaseReservedCacheNodesOffering action.
 	ReservedCacheNode *ReservedCacheNode `type:"structure"`
 
-	metadataPurchaseReservedCacheNodesOfferingOutput `json:"-", xml:"-"`
+	metadataPurchaseReservedCacheNodesOfferingOutput `json:"-" xml:"-"`
 }
 
 type metadataPurchaseReservedCacheNodesOfferingOutput struct {
@@ -3838,7 +3838,7 @@ type RebootCacheClusterInput struct {
 	// node IDs.
 	CacheNodeIDsToReboot []*string `locationName:"CacheNodeIdsToReboot" locationNameList:"CacheNodeId" type:"list" required:"true"`
 
-	metadataRebootCacheClusterInput `json:"-", xml:"-"`
+	metadataRebootCacheClusterInput `json:"-" xml:"-"`
 }
 
 type metadataRebootCacheClusterInput struct {
@@ -3849,7 +3849,7 @@ type RebootCacheClusterOutput struct {
 	// Contains all of the attributes of a specific cache cluster.
 	CacheCluster *CacheCluster `type:"structure"`
 
-	metadataRebootCacheClusterOutput `json:"-", xml:"-"`
+	metadataRebootCacheClusterOutput `json:"-" xml:"-"`
 }
 
 type metadataRebootCacheClusterOutput struct {
@@ -3865,7 +3865,7 @@ type RecurringCharge struct {
 	// The frequency of the recurring charge.
 	RecurringChargeFrequency *string `type:"string"`
 
-	metadataRecurringCharge `json:"-", xml:"-"`
+	metadataRecurringCharge `json:"-" xml:"-"`
 }
 
 type metadataRecurringCharge struct {
@@ -3883,7 +3883,7 @@ type RemoveTagsFromResourceInput struct {
 	// the key name Region from the resource named by the ResourceName parameter.
 	TagKeys []*string `type:"list" required:"true"`
 
-	metadataRemoveTagsFromResourceInput `json:"-", xml:"-"`
+	metadataRemoveTagsFromResourceInput `json:"-" xml:"-"`
 }
 
 type metadataRemoveTagsFromResourceInput struct {
@@ -3923,7 +3923,7 @@ type ReplicationGroup struct {
 	// The current state of this replication group - creating, available, etc.
 	Status *string `type:"string"`
 
-	metadataReplicationGroup `json:"-", xml:"-"`
+	metadataReplicationGroup `json:"-" xml:"-"`
 }
 
 type metadataReplicationGroup struct {
@@ -3944,7 +3944,7 @@ type ReplicationGroupPendingModifiedValues struct {
 	// was specified), or during the next maintenance window.
 	PrimaryClusterID *string `locationName:"PrimaryClusterId" type:"string"`
 
-	metadataReplicationGroupPendingModifiedValues `json:"-", xml:"-"`
+	metadataReplicationGroupPendingModifiedValues `json:"-" xml:"-"`
 }
 
 type metadataReplicationGroupPendingModifiedValues struct {
@@ -4007,7 +4007,7 @@ type ReservedCacheNode struct {
 	// The hourly price charged for this reserved cache node.
 	UsagePrice *float64 `type:"double"`
 
-	metadataReservedCacheNode `json:"-", xml:"-"`
+	metadataReservedCacheNode `json:"-" xml:"-"`
 }
 
 type metadataReservedCacheNode struct {
@@ -4058,7 +4058,7 @@ type ReservedCacheNodesOffering struct {
 	// The hourly price charged for this offering.
 	UsagePrice *float64 `type:"double"`
 
-	metadataReservedCacheNodesOffering `json:"-", xml:"-"`
+	metadataReservedCacheNodesOffering `json:"-" xml:"-"`
 }
 
 type metadataReservedCacheNodesOffering struct {
@@ -4080,7 +4080,7 @@ type ResetCacheParameterGroupInput struct {
 	// Valid values: true | false
 	ResetAllParameters *bool `type:"boolean"`
 
-	metadataResetCacheParameterGroupInput `json:"-", xml:"-"`
+	metadataResetCacheParameterGroupInput `json:"-" xml:"-"`
 }
 
 type metadataResetCacheParameterGroupInput struct {
@@ -4100,7 +4100,7 @@ type RevokeCacheSecurityGroupIngressInput struct {
 	// AWS account number for this parameter.
 	EC2SecurityGroupOwnerID *string `locationName:"EC2SecurityGroupOwnerId" type:"string" required:"true"`
 
-	metadataRevokeCacheSecurityGroupIngressInput `json:"-", xml:"-"`
+	metadataRevokeCacheSecurityGroupIngressInput `json:"-" xml:"-"`
 }
 
 type metadataRevokeCacheSecurityGroupIngressInput struct {
@@ -4113,7 +4113,7 @@ type RevokeCacheSecurityGroupIngressOutput struct {
 	//   AuthorizeCacheSecurityGroupIngress   CreateCacheSecurityGroup   RevokeCacheSecurityGroupIngress
 	CacheSecurityGroup *CacheSecurityGroup `type:"structure"`
 
-	metadataRevokeCacheSecurityGroupIngressOutput `json:"-", xml:"-"`
+	metadataRevokeCacheSecurityGroupIngressOutput `json:"-" xml:"-"`
 }
 
 type metadataRevokeCacheSecurityGroupIngressOutput struct {
@@ -4130,7 +4130,7 @@ type SecurityGroupMembership struct {
 	// to a cache cluster are modified.
 	Status *string `type:"string"`
 
-	metadataSecurityGroupMembership `json:"-", xml:"-"`
+	metadataSecurityGroupMembership `json:"-" xml:"-"`
 }
 
 type metadataSecurityGroupMembership struct {
@@ -4244,7 +4244,7 @@ type Snapshot struct {
 	// group for the source cache cluster.
 	VPCID *string `locationName:"VpcId" type:"string"`
 
-	metadataSnapshot `json:"-", xml:"-"`
+	metadataSnapshot `json:"-" xml:"-"`
 }
 
 type metadataSnapshot struct {
@@ -4261,7 +4261,7 @@ type Subnet struct {
 	// The unique identifier for the subnet.
 	SubnetIdentifier *string `type:"string"`
 
-	metadataSubnet `json:"-", xml:"-"`
+	metadataSubnet `json:"-" xml:"-"`
 }
 
 type metadataSubnet struct {
@@ -4278,7 +4278,7 @@ type Tag struct {
 	// The tag's value. May not be null.
 	Value *string `type:"string"`
 
-	metadataTag `json:"-", xml:"-"`
+	metadataTag `json:"-" xml:"-"`
 }
 
 type metadataTag struct {
@@ -4291,7 +4291,7 @@ type TagListMessage struct {
 	// A list of cost allocation tags as key-value pairs.
 	TagList []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataTagListMessage `json:"-", xml:"-"`
+	metadataTagListMessage `json:"-" xml:"-"`
 }
 
 type metadataTagListMessage struct {

--- a/service/elasticbeanstalk/api.go
+++ b/service/elasticbeanstalk/api.go
@@ -1058,7 +1058,7 @@ type ApplicationDescription struct {
 	// The names of the versions for this application.
 	Versions []*string `type:"list"`
 
-	metadataApplicationDescription `json:"-", xml:"-"`
+	metadataApplicationDescription `json:"-" xml:"-"`
 }
 
 type metadataApplicationDescription struct {
@@ -1070,7 +1070,7 @@ type ApplicationDescriptionMessage struct {
 	// The ApplicationDescription of the application.
 	Application *ApplicationDescription `type:"structure"`
 
-	metadataApplicationDescriptionMessage `json:"-", xml:"-"`
+	metadataApplicationDescriptionMessage `json:"-" xml:"-"`
 }
 
 type metadataApplicationDescriptionMessage struct {
@@ -1097,7 +1097,7 @@ type ApplicationVersionDescription struct {
 	// A label uniquely identifying the version for the associated application.
 	VersionLabel *string `type:"string"`
 
-	metadataApplicationVersionDescription `json:"-", xml:"-"`
+	metadataApplicationVersionDescription `json:"-" xml:"-"`
 }
 
 type metadataApplicationVersionDescription struct {
@@ -1109,7 +1109,7 @@ type ApplicationVersionDescriptionMessage struct {
 	// The ApplicationVersionDescription of the application version.
 	ApplicationVersion *ApplicationVersionDescription `type:"structure"`
 
-	metadataApplicationVersionDescriptionMessage `json:"-", xml:"-"`
+	metadataApplicationVersionDescriptionMessage `json:"-" xml:"-"`
 }
 
 type metadataApplicationVersionDescriptionMessage struct {
@@ -1121,7 +1121,7 @@ type AutoScalingGroup struct {
 	// The name of the AutoScalingGroup .
 	Name *string `type:"string"`
 
-	metadataAutoScalingGroup `json:"-", xml:"-"`
+	metadataAutoScalingGroup `json:"-" xml:"-"`
 }
 
 type metadataAutoScalingGroup struct {
@@ -1133,7 +1133,7 @@ type CheckDNSAvailabilityInput struct {
 	// The prefix used when this CNAME is reserved.
 	CNAMEPrefix *string `type:"string" required:"true"`
 
-	metadataCheckDNSAvailabilityInput `json:"-", xml:"-"`
+	metadataCheckDNSAvailabilityInput `json:"-" xml:"-"`
 }
 
 type metadataCheckDNSAvailabilityInput struct {
@@ -1155,7 +1155,7 @@ type CheckDNSAvailabilityOutput struct {
 	// the provided prefix.
 	FullyQualifiedCNAME *string `type:"string"`
 
-	metadataCheckDNSAvailabilityOutput `json:"-", xml:"-"`
+	metadataCheckDNSAvailabilityOutput `json:"-" xml:"-"`
 }
 
 type metadataCheckDNSAvailabilityOutput struct {
@@ -1252,7 +1252,7 @@ type ConfigurationOptionDescription struct {
 	// false .
 	ValueType *string `type:"string"`
 
-	metadataConfigurationOptionDescription `json:"-", xml:"-"`
+	metadataConfigurationOptionDescription `json:"-" xml:"-"`
 }
 
 type metadataConfigurationOptionDescription struct {
@@ -1273,7 +1273,7 @@ type ConfigurationOptionSetting struct {
 	// The current value for the configuration option.
 	Value *string `type:"string"`
 
-	metadataConfigurationOptionSetting `json:"-", xml:"-"`
+	metadataConfigurationOptionSetting `json:"-" xml:"-"`
 }
 
 type metadataConfigurationOptionSetting struct {
@@ -1328,7 +1328,7 @@ type ConfigurationSettingsDescription struct {
 	// set.
 	TemplateName *string `type:"string"`
 
-	metadataConfigurationSettingsDescription `json:"-", xml:"-"`
+	metadataConfigurationSettingsDescription `json:"-" xml:"-"`
 }
 
 type metadataConfigurationSettingsDescription struct {
@@ -1346,7 +1346,7 @@ type CreateApplicationInput struct {
 	// Describes the application.
 	Description *string `type:"string"`
 
-	metadataCreateApplicationInput `json:"-", xml:"-"`
+	metadataCreateApplicationInput `json:"-" xml:"-"`
 }
 
 type metadataCreateApplicationInput struct {
@@ -1398,7 +1398,7 @@ type CreateApplicationVersionInput struct {
 	// returns an InvalidParameterValue error.
 	VersionLabel *string `type:"string" required:"true"`
 
-	metadataCreateApplicationVersionInput `json:"-", xml:"-"`
+	metadataCreateApplicationVersionInput `json:"-" xml:"-"`
 }
 
 type metadataCreateApplicationVersionInput struct {
@@ -1462,7 +1462,7 @@ type CreateConfigurationTemplateInput struct {
 	// Elastic Beanstalk returns an InvalidParameterValue error.
 	TemplateName *string `type:"string" required:"true"`
 
-	metadataCreateConfigurationTemplateInput `json:"-", xml:"-"`
+	metadataCreateConfigurationTemplateInput `json:"-" xml:"-"`
 }
 
 type metadataCreateConfigurationTemplateInput struct {
@@ -1540,7 +1540,7 @@ type CreateEnvironmentInput struct {
 	// sample application in the container.
 	VersionLabel *string `type:"string"`
 
-	metadataCreateEnvironmentInput `json:"-", xml:"-"`
+	metadataCreateEnvironmentInput `json:"-" xml:"-"`
 }
 
 type metadataCreateEnvironmentInput struct {
@@ -1548,7 +1548,7 @@ type metadataCreateEnvironmentInput struct {
 }
 
 type CreateStorageLocationInput struct {
-	metadataCreateStorageLocationInput `json:"-", xml:"-"`
+	metadataCreateStorageLocationInput `json:"-" xml:"-"`
 }
 
 type metadataCreateStorageLocationInput struct {
@@ -1560,7 +1560,7 @@ type CreateStorageLocationOutput struct {
 	// The name of the Amazon S3 bucket created.
 	S3Bucket *string `type:"string"`
 
-	metadataCreateStorageLocationOutput `json:"-", xml:"-"`
+	metadataCreateStorageLocationOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateStorageLocationOutput struct {
@@ -1576,7 +1576,7 @@ type DeleteApplicationInput struct {
 	// the application.
 	TerminateEnvByForce *bool `type:"boolean"`
 
-	metadataDeleteApplicationInput `json:"-", xml:"-"`
+	metadataDeleteApplicationInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteApplicationInput struct {
@@ -1584,7 +1584,7 @@ type metadataDeleteApplicationInput struct {
 }
 
 type DeleteApplicationOutput struct {
-	metadataDeleteApplicationOutput `json:"-", xml:"-"`
+	metadataDeleteApplicationOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteApplicationOutput struct {
@@ -1606,7 +1606,7 @@ type DeleteApplicationVersionInput struct {
 	// The label of the version to delete.
 	VersionLabel *string `type:"string" required:"true"`
 
-	metadataDeleteApplicationVersionInput `json:"-", xml:"-"`
+	metadataDeleteApplicationVersionInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteApplicationVersionInput struct {
@@ -1614,7 +1614,7 @@ type metadataDeleteApplicationVersionInput struct {
 }
 
 type DeleteApplicationVersionOutput struct {
-	metadataDeleteApplicationVersionOutput `json:"-", xml:"-"`
+	metadataDeleteApplicationVersionOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteApplicationVersionOutput struct {
@@ -1629,7 +1629,7 @@ type DeleteConfigurationTemplateInput struct {
 	// The name of the configuration template to delete.
 	TemplateName *string `type:"string" required:"true"`
 
-	metadataDeleteConfigurationTemplateInput `json:"-", xml:"-"`
+	metadataDeleteConfigurationTemplateInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteConfigurationTemplateInput struct {
@@ -1637,7 +1637,7 @@ type metadataDeleteConfigurationTemplateInput struct {
 }
 
 type DeleteConfigurationTemplateOutput struct {
-	metadataDeleteConfigurationTemplateOutput `json:"-", xml:"-"`
+	metadataDeleteConfigurationTemplateOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteConfigurationTemplateOutput struct {
@@ -1652,7 +1652,7 @@ type DeleteEnvironmentConfigurationInput struct {
 	// The name of the environment to delete the draft configuration from.
 	EnvironmentName *string `type:"string" required:"true"`
 
-	metadataDeleteEnvironmentConfigurationInput `json:"-", xml:"-"`
+	metadataDeleteEnvironmentConfigurationInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteEnvironmentConfigurationInput struct {
@@ -1660,7 +1660,7 @@ type metadataDeleteEnvironmentConfigurationInput struct {
 }
 
 type DeleteEnvironmentConfigurationOutput struct {
-	metadataDeleteEnvironmentConfigurationOutput `json:"-", xml:"-"`
+	metadataDeleteEnvironmentConfigurationOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteEnvironmentConfigurationOutput struct {
@@ -1677,7 +1677,7 @@ type DescribeApplicationVersionsInput struct {
 	// have the specified version labels.
 	VersionLabels []*string `type:"list"`
 
-	metadataDescribeApplicationVersionsInput `json:"-", xml:"-"`
+	metadataDescribeApplicationVersionsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeApplicationVersionsInput struct {
@@ -1689,7 +1689,7 @@ type DescribeApplicationVersionsOutput struct {
 	// A list of ApplicationVersionDescription .
 	ApplicationVersions []*ApplicationVersionDescription `type:"list"`
 
-	metadataDescribeApplicationVersionsOutput `json:"-", xml:"-"`
+	metadataDescribeApplicationVersionsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeApplicationVersionsOutput struct {
@@ -1702,7 +1702,7 @@ type DescribeApplicationsInput struct {
 	// only include those with the specified names.
 	ApplicationNames []*string `type:"list"`
 
-	metadataDescribeApplicationsInput `json:"-", xml:"-"`
+	metadataDescribeApplicationsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeApplicationsInput struct {
@@ -1714,7 +1714,7 @@ type DescribeApplicationsOutput struct {
 	// This parameter contains a list of ApplicationDescription.
 	Applications []*ApplicationDescription `type:"list"`
 
-	metadataDescribeApplicationsOutput `json:"-", xml:"-"`
+	metadataDescribeApplicationsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeApplicationsOutput struct {
@@ -1741,7 +1741,7 @@ type DescribeConfigurationOptionsInput struct {
 	// to describe.
 	TemplateName *string `type:"string"`
 
-	metadataDescribeConfigurationOptionsInput `json:"-", xml:"-"`
+	metadataDescribeConfigurationOptionsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeConfigurationOptionsInput struct {
@@ -1756,7 +1756,7 @@ type DescribeConfigurationOptionsOutput struct {
 	// The name of the solution stack these configuration options belong to.
 	SolutionStackName *string `type:"string"`
 
-	metadataDescribeConfigurationOptionsOutput `json:"-", xml:"-"`
+	metadataDescribeConfigurationOptionsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeConfigurationOptionsOutput struct {
@@ -1785,7 +1785,7 @@ type DescribeConfigurationSettingsInput struct {
 	// error.
 	TemplateName *string `type:"string"`
 
-	metadataDescribeConfigurationSettingsInput `json:"-", xml:"-"`
+	metadataDescribeConfigurationSettingsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeConfigurationSettingsInput struct {
@@ -1797,7 +1797,7 @@ type DescribeConfigurationSettingsOutput struct {
 	// A list of ConfigurationSettingsDescription.
 	ConfigurationSettings []*ConfigurationSettingsDescription `type:"list"`
 
-	metadataDescribeConfigurationSettingsOutput `json:"-", xml:"-"`
+	metadataDescribeConfigurationSettingsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeConfigurationSettingsOutput struct {
@@ -1820,7 +1820,7 @@ type DescribeEnvironmentResourcesInput struct {
 	// error.
 	EnvironmentName *string `type:"string"`
 
-	metadataDescribeEnvironmentResourcesInput `json:"-", xml:"-"`
+	metadataDescribeEnvironmentResourcesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeEnvironmentResourcesInput struct {
@@ -1832,7 +1832,7 @@ type DescribeEnvironmentResourcesOutput struct {
 	// A list of EnvironmentResourceDescription.
 	EnvironmentResources *EnvironmentResourceDescription `type:"structure"`
 
-	metadataDescribeEnvironmentResourcesOutput `json:"-", xml:"-"`
+	metadataDescribeEnvironmentResourcesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeEnvironmentResourcesOutput struct {
@@ -1869,7 +1869,7 @@ type DescribeEnvironmentsInput struct {
 	// include only those that are associated with this application version.
 	VersionLabel *string `type:"string"`
 
-	metadataDescribeEnvironmentsInput `json:"-", xml:"-"`
+	metadataDescribeEnvironmentsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeEnvironmentsInput struct {
@@ -1881,7 +1881,7 @@ type DescribeEnvironmentsOutput struct {
 	// Returns an EnvironmentDescription list.
 	Environments []*EnvironmentDescription `type:"list"`
 
-	metadataDescribeEnvironmentsOutput `json:"-", xml:"-"`
+	metadataDescribeEnvironmentsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeEnvironmentsOutput struct {
@@ -1933,7 +1933,7 @@ type DescribeEventsInput struct {
 	// those associated with this application version.
 	VersionLabel *string `type:"string"`
 
-	metadataDescribeEventsInput `json:"-", xml:"-"`
+	metadataDescribeEventsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeEventsInput struct {
@@ -1949,7 +1949,7 @@ type DescribeEventsOutput struct {
 	// token in the next DescribeEvents call to get the next batch of events.
 	NextToken *string `type:"string"`
 
-	metadataDescribeEventsOutput `json:"-", xml:"-"`
+	metadataDescribeEventsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeEventsOutput struct {
@@ -2026,7 +2026,7 @@ type EnvironmentDescription struct {
 	// The application version deployed in this environment.
 	VersionLabel *string `type:"string"`
 
-	metadataEnvironmentDescription `json:"-", xml:"-"`
+	metadataEnvironmentDescription `json:"-" xml:"-"`
 }
 
 type metadataEnvironmentDescription struct {
@@ -2047,7 +2047,7 @@ type EnvironmentInfoDescription struct {
 	// The time stamp when this information was retrieved.
 	SampleTimestamp *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataEnvironmentInfoDescription `json:"-", xml:"-"`
+	metadataEnvironmentInfoDescription `json:"-" xml:"-"`
 }
 
 type metadataEnvironmentInfoDescription struct {
@@ -2077,7 +2077,7 @@ type EnvironmentResourceDescription struct {
 	// The AutoScaling triggers in use by this environment.
 	Triggers []*Trigger `type:"list"`
 
-	metadataEnvironmentResourceDescription `json:"-", xml:"-"`
+	metadataEnvironmentResourceDescription `json:"-" xml:"-"`
 }
 
 type metadataEnvironmentResourceDescription struct {
@@ -2090,7 +2090,7 @@ type EnvironmentResourcesDescription struct {
 	// Describes the LoadBalancer.
 	LoadBalancer *LoadBalancerDescription `type:"structure"`
 
-	metadataEnvironmentResourcesDescription `json:"-", xml:"-"`
+	metadataEnvironmentResourcesDescription `json:"-" xml:"-"`
 }
 
 type metadataEnvironmentResourcesDescription struct {
@@ -2108,7 +2108,7 @@ type EnvironmentTier struct {
 	// The version of this environment tier.
 	Version *string `type:"string"`
 
-	metadataEnvironmentTier `json:"-", xml:"-"`
+	metadataEnvironmentTier `json:"-" xml:"-"`
 }
 
 type metadataEnvironmentTier struct {
@@ -2141,7 +2141,7 @@ type EventDescription struct {
 	// The release label for the application version associated with this event.
 	VersionLabel *string `type:"string"`
 
-	metadataEventDescription `json:"-", xml:"-"`
+	metadataEventDescription `json:"-" xml:"-"`
 }
 
 type metadataEventDescription struct {
@@ -2153,7 +2153,7 @@ type Instance struct {
 	// The ID of the Amazon EC2 instance.
 	ID *string `locationName:"Id" type:"string"`
 
-	metadataInstance `json:"-", xml:"-"`
+	metadataInstance `json:"-" xml:"-"`
 }
 
 type metadataInstance struct {
@@ -2165,7 +2165,7 @@ type LaunchConfiguration struct {
 	// The name of the launch configuration.
 	Name *string `type:"string"`
 
-	metadataLaunchConfiguration `json:"-", xml:"-"`
+	metadataLaunchConfiguration `json:"-" xml:"-"`
 }
 
 type metadataLaunchConfiguration struct {
@@ -2173,7 +2173,7 @@ type metadataLaunchConfiguration struct {
 }
 
 type ListAvailableSolutionStacksInput struct {
-	metadataListAvailableSolutionStacksInput `json:"-", xml:"-"`
+	metadataListAvailableSolutionStacksInput `json:"-" xml:"-"`
 }
 
 type metadataListAvailableSolutionStacksInput struct {
@@ -2188,7 +2188,7 @@ type ListAvailableSolutionStacksOutput struct {
 	// A list of available solution stacks.
 	SolutionStacks []*string `type:"list"`
 
-	metadataListAvailableSolutionStacksOutput `json:"-", xml:"-"`
+	metadataListAvailableSolutionStacksOutput `json:"-" xml:"-"`
 }
 
 type metadataListAvailableSolutionStacksOutput struct {
@@ -2203,7 +2203,7 @@ type Listener struct {
 	// The protocol that is used by the Listener.
 	Protocol *string `type:"string"`
 
-	metadataListener `json:"-", xml:"-"`
+	metadataListener `json:"-" xml:"-"`
 }
 
 type metadataListener struct {
@@ -2215,7 +2215,7 @@ type LoadBalancer struct {
 	// The name of the LoadBalancer.
 	Name *string `type:"string"`
 
-	metadataLoadBalancer `json:"-", xml:"-"`
+	metadataLoadBalancer `json:"-" xml:"-"`
 }
 
 type metadataLoadBalancer struct {
@@ -2233,7 +2233,7 @@ type LoadBalancerDescription struct {
 	// The name of the LoadBalancer.
 	LoadBalancerName *string `type:"string"`
 
-	metadataLoadBalancerDescription `json:"-", xml:"-"`
+	metadataLoadBalancerDescription `json:"-" xml:"-"`
 }
 
 type metadataLoadBalancerDescription struct {
@@ -2250,7 +2250,7 @@ type OptionRestrictionRegex struct {
 	// this restriction must match.
 	Pattern *string `type:"string"`
 
-	metadataOptionRestrictionRegex `json:"-", xml:"-"`
+	metadataOptionRestrictionRegex `json:"-" xml:"-"`
 }
 
 type metadataOptionRestrictionRegex struct {
@@ -2265,7 +2265,7 @@ type OptionSpecification struct {
 	// The name of the configuration option.
 	OptionName *string `type:"string"`
 
-	metadataOptionSpecification `json:"-", xml:"-"`
+	metadataOptionSpecification `json:"-" xml:"-"`
 }
 
 type metadataOptionSpecification struct {
@@ -2280,7 +2280,7 @@ type Queue struct {
 	// The URL of the queue.
 	URL *string `type:"string"`
 
-	metadataQueue `json:"-", xml:"-"`
+	metadataQueue `json:"-" xml:"-"`
 }
 
 type metadataQueue struct {
@@ -2302,7 +2302,7 @@ type RebuildEnvironmentInput struct {
 	// error.
 	EnvironmentName *string `type:"string"`
 
-	metadataRebuildEnvironmentInput `json:"-", xml:"-"`
+	metadataRebuildEnvironmentInput `json:"-" xml:"-"`
 }
 
 type metadataRebuildEnvironmentInput struct {
@@ -2310,7 +2310,7 @@ type metadataRebuildEnvironmentInput struct {
 }
 
 type RebuildEnvironmentOutput struct {
-	metadataRebuildEnvironmentOutput `json:"-", xml:"-"`
+	metadataRebuildEnvironmentOutput `json:"-" xml:"-"`
 }
 
 type metadataRebuildEnvironmentOutput struct {
@@ -2342,7 +2342,7 @@ type RequestEnvironmentInfoInput struct {
 	// The type of information to request.
 	InfoType *string `type:"string" required:"true"`
 
-	metadataRequestEnvironmentInfoInput `json:"-", xml:"-"`
+	metadataRequestEnvironmentInfoInput `json:"-" xml:"-"`
 }
 
 type metadataRequestEnvironmentInfoInput struct {
@@ -2350,7 +2350,7 @@ type metadataRequestEnvironmentInfoInput struct {
 }
 
 type RequestEnvironmentInfoOutput struct {
-	metadataRequestEnvironmentInfoOutput `json:"-", xml:"-"`
+	metadataRequestEnvironmentInfoOutput `json:"-" xml:"-"`
 }
 
 type metadataRequestEnvironmentInfoOutput struct {
@@ -2372,7 +2372,7 @@ type RestartAppServerInput struct {
 	// error.
 	EnvironmentName *string `type:"string"`
 
-	metadataRestartAppServerInput `json:"-", xml:"-"`
+	metadataRestartAppServerInput `json:"-" xml:"-"`
 }
 
 type metadataRestartAppServerInput struct {
@@ -2380,7 +2380,7 @@ type metadataRestartAppServerInput struct {
 }
 
 type RestartAppServerOutput struct {
-	metadataRestartAppServerOutput `json:"-", xml:"-"`
+	metadataRestartAppServerOutput `json:"-" xml:"-"`
 }
 
 type metadataRestartAppServerOutput struct {
@@ -2410,7 +2410,7 @@ type RetrieveEnvironmentInfoInput struct {
 	// The type of information to retrieve.
 	InfoType *string `type:"string" required:"true"`
 
-	metadataRetrieveEnvironmentInfoInput `json:"-", xml:"-"`
+	metadataRetrieveEnvironmentInfoInput `json:"-" xml:"-"`
 }
 
 type metadataRetrieveEnvironmentInfoInput struct {
@@ -2422,7 +2422,7 @@ type RetrieveEnvironmentInfoOutput struct {
 	// The EnvironmentInfoDescription of the environment.
 	EnvironmentInfo []*EnvironmentInfoDescription `type:"list"`
 
-	metadataRetrieveEnvironmentInfoOutput `json:"-", xml:"-"`
+	metadataRetrieveEnvironmentInfoOutput `json:"-" xml:"-"`
 }
 
 type metadataRetrieveEnvironmentInfoOutput struct {
@@ -2437,7 +2437,7 @@ type S3Location struct {
 	// The Amazon S3 key where the data is located.
 	S3Key *string `type:"string"`
 
-	metadataS3Location `json:"-", xml:"-"`
+	metadataS3Location `json:"-" xml:"-"`
 }
 
 type metadataS3Location struct {
@@ -2452,7 +2452,7 @@ type SolutionStackDescription struct {
 	// The name of the solution stack.
 	SolutionStackName *string `type:"string"`
 
-	metadataSolutionStackDescription `json:"-", xml:"-"`
+	metadataSolutionStackDescription `json:"-" xml:"-"`
 }
 
 type metadataSolutionStackDescription struct {
@@ -2467,7 +2467,7 @@ type SourceConfiguration struct {
 	// The name of the configuration template.
 	TemplateName *string `type:"string"`
 
-	metadataSourceConfiguration `json:"-", xml:"-"`
+	metadataSourceConfiguration `json:"-" xml:"-"`
 }
 
 type metadataSourceConfiguration struct {
@@ -2503,7 +2503,7 @@ type SwapEnvironmentCNAMEsInput struct {
 	// must specify the DestinationEnvironmentName.
 	SourceEnvironmentName *string `type:"string"`
 
-	metadataSwapEnvironmentCNAMEsInput `json:"-", xml:"-"`
+	metadataSwapEnvironmentCNAMEsInput `json:"-" xml:"-"`
 }
 
 type metadataSwapEnvironmentCNAMEsInput struct {
@@ -2511,7 +2511,7 @@ type metadataSwapEnvironmentCNAMEsInput struct {
 }
 
 type SwapEnvironmentCNAMEsOutput struct {
-	metadataSwapEnvironmentCNAMEsOutput `json:"-", xml:"-"`
+	metadataSwapEnvironmentCNAMEsOutput `json:"-" xml:"-"`
 }
 
 type metadataSwapEnvironmentCNAMEsOutput struct {
@@ -2526,7 +2526,7 @@ type Tag struct {
 	// The value of the tag.
 	Value *string `type:"string"`
 
-	metadataTag `json:"-", xml:"-"`
+	metadataTag `json:"-" xml:"-"`
 }
 
 type metadataTag struct {
@@ -2569,7 +2569,7 @@ type TerminateEnvironmentInput struct {
 	//  Valid Values: true | false
 	TerminateResources *bool `type:"boolean"`
 
-	metadataTerminateEnvironmentInput `json:"-", xml:"-"`
+	metadataTerminateEnvironmentInput `json:"-" xml:"-"`
 }
 
 type metadataTerminateEnvironmentInput struct {
@@ -2581,7 +2581,7 @@ type Trigger struct {
 	// The name of the trigger.
 	Name *string `type:"string"`
 
-	metadataTrigger `json:"-", xml:"-"`
+	metadataTrigger `json:"-" xml:"-"`
 }
 
 type metadataTrigger struct {
@@ -2599,7 +2599,7 @@ type UpdateApplicationInput struct {
 	// Default: If not specified, AWS Elastic Beanstalk does not update the description.
 	Description *string `type:"string"`
 
-	metadataUpdateApplicationInput `json:"-", xml:"-"`
+	metadataUpdateApplicationInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateApplicationInput struct {
@@ -2622,7 +2622,7 @@ type UpdateApplicationVersionInput struct {
 	// an InvalidParameterValue error.
 	VersionLabel *string `type:"string" required:"true"`
 
-	metadataUpdateApplicationVersionInput `json:"-", xml:"-"`
+	metadataUpdateApplicationVersionInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateApplicationVersionInput struct {
@@ -2656,7 +2656,7 @@ type UpdateConfigurationTemplateInput struct {
 	// returns an InvalidParameterValue error.
 	TemplateName *string `type:"string" required:"true"`
 
-	metadataUpdateConfigurationTemplateInput `json:"-", xml:"-"`
+	metadataUpdateConfigurationTemplateInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateConfigurationTemplateInput struct {
@@ -2713,7 +2713,7 @@ type UpdateEnvironmentInput struct {
 	// an InvalidParameterValue error.
 	VersionLabel *string `type:"string"`
 
-	metadataUpdateEnvironmentInput `json:"-", xml:"-"`
+	metadataUpdateEnvironmentInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateEnvironmentInput struct {
@@ -2739,7 +2739,7 @@ type ValidateConfigurationSettingsInput struct {
 	//  Condition: You cannot specify both this and an environment name.
 	TemplateName *string `type:"string"`
 
-	metadataValidateConfigurationSettingsInput `json:"-", xml:"-"`
+	metadataValidateConfigurationSettingsInput `json:"-" xml:"-"`
 }
 
 type metadataValidateConfigurationSettingsInput struct {
@@ -2751,7 +2751,7 @@ type ValidateConfigurationSettingsOutput struct {
 	// A list of ValidationMessage.
 	Messages []*ValidationMessage `type:"list"`
 
-	metadataValidateConfigurationSettingsOutput `json:"-", xml:"-"`
+	metadataValidateConfigurationSettingsOutput `json:"-" xml:"-"`
 }
 
 type metadataValidateConfigurationSettingsOutput struct {
@@ -2779,7 +2779,7 @@ type ValidationMessage struct {
 	// into account.
 	Severity *string `type:"string"`
 
-	metadataValidationMessage `json:"-", xml:"-"`
+	metadataValidationMessage `json:"-" xml:"-"`
 }
 
 type metadataValidationMessage struct {

--- a/service/elastictranscoder/api.go
+++ b/service/elastictranscoder/api.go
@@ -697,7 +697,7 @@ type Artwork struct {
 	// this option, Elastic Transcoder does not scale the art up.
 	SizingPolicy *string `type:"string"`
 
-	metadataArtwork `json:"-", xml:"-"`
+	metadataArtwork `json:"-" xml:"-"`
 }
 
 type metadataArtwork struct {
@@ -725,7 +725,7 @@ type AudioCodecOptions struct {
 	// as required.
 	Profile *string `type:"string"`
 
-	metadataAudioCodecOptions `json:"-", xml:"-"`
+	metadataAudioCodecOptions `json:"-" xml:"-"`
 }
 
 type metadataAudioCodecOptions struct {
@@ -768,7 +768,7 @@ type AudioParameters struct {
 	// rate.
 	SampleRate *string `type:"string"`
 
-	metadataAudioParameters `json:"-", xml:"-"`
+	metadataAudioParameters `json:"-" xml:"-"`
 }
 
 type metadataAudioParameters struct {
@@ -783,7 +783,7 @@ type CancelJobInput struct {
 	// Submitted, use the ListJobsByStatus API action.
 	ID *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
-	metadataCancelJobInput `json:"-", xml:"-"`
+	metadataCancelJobInput `json:"-" xml:"-"`
 }
 
 type metadataCancelJobInput struct {
@@ -793,7 +793,7 @@ type metadataCancelJobInput struct {
 // The response body contains a JSON object. If the job is successfully canceled,
 // the value of Success is true.
 type CancelJobOutput struct {
-	metadataCancelJobOutput `json:"-", xml:"-"`
+	metadataCancelJobOutput `json:"-" xml:"-"`
 }
 
 type metadataCancelJobOutput struct {
@@ -847,7 +847,7 @@ type CaptionFormat struct {
 	// (en), the name of the first caption file will be Sydney-en-sunrise00000.srt.
 	Pattern *string `type:"string"`
 
-	metadataCaptionFormat `json:"-", xml:"-"`
+	metadataCaptionFormat `json:"-" xml:"-"`
 }
 
 type metadataCaptionFormat struct {
@@ -888,7 +888,7 @@ type CaptionSource struct {
 	// Specify the TimeOffset in the form [+-]SS.sss or [+-]HH:mm:SS.ss.
 	TimeOffset *string `type:"string"`
 
-	metadataCaptionSource `json:"-", xml:"-"`
+	metadataCaptionSource `json:"-" xml:"-"`
 }
 
 type metadataCaptionSource struct {
@@ -925,7 +925,7 @@ type Captions struct {
 	//  MergePolicy cannot be null.
 	MergePolicy *string `type:"string"`
 
-	metadataCaptions `json:"-", xml:"-"`
+	metadataCaptions `json:"-" xml:"-"`
 }
 
 type metadataCaptions struct {
@@ -938,7 +938,7 @@ type Clip struct {
 	// Settings that determine when a clip begins and how long it lasts.
 	TimeSpan *TimeSpan `type:"structure"`
 
-	metadataClip `json:"-", xml:"-"`
+	metadataClip `json:"-" xml:"-"`
 }
 
 type metadataClip struct {
@@ -983,7 +983,7 @@ type CreateJobInput struct {
 	// will be returned in the same order in which you specify them.
 	UserMetadata *map[string]*string `type:"map"`
 
-	metadataCreateJobInput `json:"-", xml:"-"`
+	metadataCreateJobInput `json:"-" xml:"-"`
 }
 
 type metadataCreateJobInput struct {
@@ -1130,7 +1130,7 @@ type CreateJobOutput struct {
 	// the current output.
 	Watermarks []*JobWatermark `type:"list"`
 
-	metadataCreateJobOutput `json:"-", xml:"-"`
+	metadataCreateJobOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateJobOutput struct {
@@ -1198,7 +1198,7 @@ type CreateJobPlaylist struct {
 	// all outputs.
 	OutputKeys []*string `type:"list"`
 
-	metadataCreateJobPlaylist `json:"-", xml:"-"`
+	metadataCreateJobPlaylist `json:"-" xml:"-"`
 }
 
 type metadataCreateJobPlaylist struct {
@@ -1211,7 +1211,7 @@ type CreateJobResponse struct {
 	// is created.
 	Job *Job `type:"structure"`
 
-	metadataCreateJobResponse `json:"-", xml:"-"`
+	metadataCreateJobResponse `json:"-" xml:"-"`
 }
 
 type metadataCreateJobResponse struct {
@@ -1371,7 +1371,7 @@ type CreatePipelineInput struct {
 	// Transcoder to assign to the thumbnails that it stores in your Amazon S3 bucket.
 	ThumbnailConfig *PipelineOutputConfig `type:"structure"`
 
-	metadataCreatePipelineInput `json:"-", xml:"-"`
+	metadataCreatePipelineInput `json:"-" xml:"-"`
 }
 
 type metadataCreatePipelineInput struct {
@@ -1393,7 +1393,7 @@ type CreatePipelineOutput struct {
 	// cross-regional charges.
 	Warnings []*Warning `type:"list"`
 
-	metadataCreatePipelineOutput `json:"-", xml:"-"`
+	metadataCreatePipelineOutput `json:"-" xml:"-"`
 }
 
 type metadataCreatePipelineOutput struct {
@@ -1423,7 +1423,7 @@ type CreatePresetInput struct {
 	// A section of the request body that specifies the video parameters.
 	Video *VideoParameters `type:"structure"`
 
-	metadataCreatePresetInput `json:"-", xml:"-"`
+	metadataCreatePresetInput `json:"-" xml:"-"`
 }
 
 type metadataCreatePresetInput struct {
@@ -1442,7 +1442,7 @@ type CreatePresetOutput struct {
 	// preset because the settings might produce acceptable output.
 	Warning *string `type:"string"`
 
-	metadataCreatePresetOutput `json:"-", xml:"-"`
+	metadataCreatePresetOutput `json:"-" xml:"-"`
 }
 
 type metadataCreatePresetOutput struct {
@@ -1454,7 +1454,7 @@ type DeletePipelineInput struct {
 	// The identifier of the pipeline that you want to delete.
 	ID *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
-	metadataDeletePipelineInput `json:"-", xml:"-"`
+	metadataDeletePipelineInput `json:"-" xml:"-"`
 }
 
 type metadataDeletePipelineInput struct {
@@ -1463,7 +1463,7 @@ type metadataDeletePipelineInput struct {
 
 // The DeletePipelineResponse structure.
 type DeletePipelineOutput struct {
-	metadataDeletePipelineOutput `json:"-", xml:"-"`
+	metadataDeletePipelineOutput `json:"-" xml:"-"`
 }
 
 type metadataDeletePipelineOutput struct {
@@ -1475,7 +1475,7 @@ type DeletePresetInput struct {
 	// The identifier of the preset for which you want to get detailed information.
 	ID *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
-	metadataDeletePresetInput `json:"-", xml:"-"`
+	metadataDeletePresetInput `json:"-" xml:"-"`
 }
 
 type metadataDeletePresetInput struct {
@@ -1484,7 +1484,7 @@ type metadataDeletePresetInput struct {
 
 // The DeletePresetResponse structure.
 type DeletePresetOutput struct {
-	metadataDeletePresetOutput `json:"-", xml:"-"`
+	metadataDeletePresetOutput `json:"-" xml:"-"`
 }
 
 type metadataDeletePresetOutput struct {
@@ -1556,7 +1556,7 @@ type Encryption struct {
 	// data.
 	Mode *string `type:"string"`
 
-	metadataEncryption `json:"-", xml:"-"`
+	metadataEncryption `json:"-" xml:"-"`
 }
 
 type metadataEncryption struct {
@@ -1611,7 +1611,7 @@ type HLSContentProtection struct {
 	// tag in the output playlist.
 	Method *string `type:"string"`
 
-	metadataHLSContentProtection `json:"-", xml:"-"`
+	metadataHLSContentProtection `json:"-" xml:"-"`
 }
 
 type metadataHLSContentProtection struct {
@@ -1689,7 +1689,7 @@ type Job struct {
 	// The following symbols: _.:/=+-%@
 	UserMetadata *map[string]*string `type:"map"`
 
-	metadataJob `json:"-", xml:"-"`
+	metadataJob `json:"-" xml:"-"`
 }
 
 type metadataJob struct {
@@ -1714,7 +1714,7 @@ type JobAlbumArt struct {
 	// file.
 	MergePolicy *string `type:"string"`
 
-	metadataJobAlbumArt `json:"-", xml:"-"`
+	metadataJobAlbumArt `json:"-" xml:"-"`
 }
 
 type metadataJobAlbumArt struct {
@@ -1782,7 +1782,7 @@ type JobInput struct {
 	// detect the resolution of the input file.
 	Resolution *string `type:"string"`
 
-	metadataJobInput `json:"-", xml:"-"`
+	metadataJobInput `json:"-" xml:"-"`
 }
 
 type metadataJobInput struct {
@@ -1982,7 +1982,7 @@ type JobOutput struct {
 	// Specifies the width of the output file in pixels.
 	Width *int64 `type:"integer"`
 
-	metadataJobOutput `json:"-", xml:"-"`
+	metadataJobOutput `json:"-" xml:"-"`
 }
 
 type metadataJobOutput struct {
@@ -2012,7 +2012,7 @@ type JobWatermark struct {
 	// Id tells Elastic Transcoder which settings to use.
 	PresetWatermarkID *string `locationName:"PresetWatermarkId" type:"string"`
 
-	metadataJobWatermark `json:"-", xml:"-"`
+	metadataJobWatermark `json:"-" xml:"-"`
 }
 
 type metadataJobWatermark struct {
@@ -2032,7 +2032,7 @@ type ListJobsByPipelineInput struct {
 	// The ID of the pipeline for which you want to get job information.
 	PipelineID *string `location:"uri" locationName:"PipelineId" type:"string" required:"true"`
 
-	metadataListJobsByPipelineInput `json:"-", xml:"-"`
+	metadataListJobsByPipelineInput `json:"-" xml:"-"`
 }
 
 type metadataListJobsByPipelineInput struct {
@@ -2049,7 +2049,7 @@ type ListJobsByPipelineOutput struct {
 	// reached the last page of results, the value of NextPageToken is null.
 	NextPageToken *string `type:"string"`
 
-	metadataListJobsByPipelineOutput `json:"-", xml:"-"`
+	metadataListJobsByPipelineOutput `json:"-" xml:"-"`
 }
 
 type metadataListJobsByPipelineOutput struct {
@@ -2071,7 +2071,7 @@ type ListJobsByStatusInput struct {
 	// Progressing, Complete, Canceled, or Error.
 	Status *string `location:"uri" locationName:"Status" type:"string" required:"true"`
 
-	metadataListJobsByStatusInput `json:"-", xml:"-"`
+	metadataListJobsByStatusInput `json:"-" xml:"-"`
 }
 
 type metadataListJobsByStatusInput struct {
@@ -2088,7 +2088,7 @@ type ListJobsByStatusOutput struct {
 	// reached the last page of results, the value of NextPageToken is null.
 	NextPageToken *string `type:"string"`
 
-	metadataListJobsByStatusOutput `json:"-", xml:"-"`
+	metadataListJobsByStatusOutput `json:"-" xml:"-"`
 }
 
 type metadataListJobsByStatusOutput struct {
@@ -2106,7 +2106,7 @@ type ListPipelinesInput struct {
 	// in subsequent GET requests to get each successive page of results.
 	PageToken *string `location:"querystring" locationName:"PageToken" type:"string"`
 
-	metadataListPipelinesInput `json:"-", xml:"-"`
+	metadataListPipelinesInput `json:"-" xml:"-"`
 }
 
 type metadataListPipelinesInput struct {
@@ -2123,7 +2123,7 @@ type ListPipelinesOutput struct {
 	// An array of Pipeline objects.
 	Pipelines []*Pipeline `type:"list"`
 
-	metadataListPipelinesOutput `json:"-", xml:"-"`
+	metadataListPipelinesOutput `json:"-" xml:"-"`
 }
 
 type metadataListPipelinesOutput struct {
@@ -2141,7 +2141,7 @@ type ListPresetsInput struct {
 	// in subsequent GET requests to get each successive page of results.
 	PageToken *string `location:"querystring" locationName:"PageToken" type:"string"`
 
-	metadataListPresetsInput `json:"-", xml:"-"`
+	metadataListPresetsInput `json:"-" xml:"-"`
 }
 
 type metadataListPresetsInput struct {
@@ -2158,7 +2158,7 @@ type ListPresetsOutput struct {
 	// An array of Preset objects.
 	Presets []*Preset `type:"list"`
 
-	metadataListPresetsOutput `json:"-", xml:"-"`
+	metadataListPresetsOutput `json:"-" xml:"-"`
 }
 
 type metadataListPresetsOutput struct {
@@ -2187,7 +2187,7 @@ type Notifications struct {
 	// a warning condition.
 	Warning *string `type:"string"`
 
-	metadataNotifications `json:"-", xml:"-"`
+	metadataNotifications `json:"-" xml:"-"`
 }
 
 type metadataNotifications struct {
@@ -2221,7 +2221,7 @@ type Permission struct {
 	// or LogDelivery.
 	GranteeType *string `type:"string"`
 
-	metadataPermission `json:"-", xml:"-"`
+	metadataPermission `json:"-" xml:"-"`
 }
 
 type metadataPermission struct {
@@ -2341,7 +2341,7 @@ type Pipeline struct {
 	// to the thumbnails that it stores in your Amazon S3 bucket.
 	ThumbnailConfig *PipelineOutputConfig `type:"structure"`
 
-	metadataPipeline `json:"-", xml:"-"`
+	metadataPipeline `json:"-" xml:"-"`
 }
 
 type metadataPipeline struct {
@@ -2384,7 +2384,7 @@ type PipelineOutputConfig struct {
 	// in your Amazon S3 bucket.
 	StorageClass *string `type:"string"`
 
-	metadataPipelineOutputConfig `json:"-", xml:"-"`
+	metadataPipelineOutputConfig `json:"-" xml:"-"`
 }
 
 type metadataPipelineOutputConfig struct {
@@ -2462,7 +2462,7 @@ type Playlist struct {
 	// Information that further explains the status.
 	StatusDetail *string `type:"string"`
 
-	metadataPlaylist `json:"-", xml:"-"`
+	metadataPlaylist `json:"-" xml:"-"`
 }
 
 type metadataPlaylist struct {
@@ -2509,7 +2509,7 @@ type Preset struct {
 	// preset values.
 	Video *VideoParameters `type:"structure"`
 
-	metadataPreset `json:"-", xml:"-"`
+	metadataPreset `json:"-" xml:"-"`
 }
 
 type metadataPreset struct {
@@ -2642,7 +2642,7 @@ type PresetWatermark struct {
 	// offset calculation.
 	VerticalOffset *string `type:"string"`
 
-	metadataPresetWatermark `json:"-", xml:"-"`
+	metadataPresetWatermark `json:"-" xml:"-"`
 }
 
 type metadataPresetWatermark struct {
@@ -2654,7 +2654,7 @@ type ReadJobInput struct {
 	// The identifier of the job for which you want to get detailed information.
 	ID *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
-	metadataReadJobInput `json:"-", xml:"-"`
+	metadataReadJobInput `json:"-" xml:"-"`
 }
 
 type metadataReadJobInput struct {
@@ -2666,7 +2666,7 @@ type ReadJobOutput struct {
 	// A section of the response body that provides information about the job.
 	Job *Job `type:"structure"`
 
-	metadataReadJobOutput `json:"-", xml:"-"`
+	metadataReadJobOutput `json:"-" xml:"-"`
 }
 
 type metadataReadJobOutput struct {
@@ -2678,7 +2678,7 @@ type ReadPipelineInput struct {
 	// The identifier of the pipeline to read.
 	ID *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
-	metadataReadPipelineInput `json:"-", xml:"-"`
+	metadataReadPipelineInput `json:"-" xml:"-"`
 }
 
 type metadataReadPipelineInput struct {
@@ -2698,7 +2698,7 @@ type ReadPipelineOutput struct {
 	// cross-regional charges.
 	Warnings []*Warning `type:"list"`
 
-	metadataReadPipelineOutput `json:"-", xml:"-"`
+	metadataReadPipelineOutput `json:"-" xml:"-"`
 }
 
 type metadataReadPipelineOutput struct {
@@ -2710,7 +2710,7 @@ type ReadPresetInput struct {
 	// The identifier of the preset for which you want to get detailed information.
 	ID *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
-	metadataReadPresetInput `json:"-", xml:"-"`
+	metadataReadPresetInput `json:"-" xml:"-"`
 }
 
 type metadataReadPresetInput struct {
@@ -2722,7 +2722,7 @@ type ReadPresetOutput struct {
 	// A section of the response body that provides information about the preset.
 	Preset *Preset `type:"structure"`
 
-	metadataReadPresetOutput `json:"-", xml:"-"`
+	metadataReadPresetOutput `json:"-" xml:"-"`
 }
 
 type metadataReadPresetOutput struct {
@@ -2747,7 +2747,7 @@ type TestRoleInput struct {
 	// that you want the action to send a test notification to.
 	Topics []*string `type:"list" required:"true"`
 
-	metadataTestRoleInput `json:"-", xml:"-"`
+	metadataTestRoleInput `json:"-" xml:"-"`
 }
 
 type metadataTestRoleInput struct {
@@ -2764,7 +2764,7 @@ type TestRoleOutput struct {
 	// is false.
 	Success *string `type:"string"`
 
-	metadataTestRoleOutput `json:"-", xml:"-"`
+	metadataTestRoleOutput `json:"-" xml:"-"`
 }
 
 type metadataTestRoleOutput struct {
@@ -2846,7 +2846,7 @@ type Thumbnails struct {
 	// Transcoder does not scale thumbnails up.
 	SizingPolicy *string `type:"string"`
 
-	metadataThumbnails `json:"-", xml:"-"`
+	metadataThumbnails `json:"-" xml:"-"`
 }
 
 type metadataThumbnails struct {
@@ -2870,7 +2870,7 @@ type TimeSpan struct {
 	// value, Elastic Transcoder starts at the beginning of the input file.
 	StartTime *string `type:"string"`
 
-	metadataTimeSpan `json:"-", xml:"-"`
+	metadataTimeSpan `json:"-" xml:"-"`
 }
 
 type metadataTimeSpan struct {
@@ -3001,7 +3001,7 @@ type UpdatePipelineInput struct {
 	// Transcoder to assign to the thumbnails that it stores in your Amazon S3 bucket.
 	ThumbnailConfig *PipelineOutputConfig `type:"structure"`
 
-	metadataUpdatePipelineInput `json:"-", xml:"-"`
+	metadataUpdatePipelineInput `json:"-" xml:"-"`
 }
 
 type metadataUpdatePipelineInput struct {
@@ -3032,7 +3032,7 @@ type UpdatePipelineNotificationsInput struct {
 	// returned when you created the topic.
 	Notifications *Notifications `type:"structure" required:"true"`
 
-	metadataUpdatePipelineNotificationsInput `json:"-", xml:"-"`
+	metadataUpdatePipelineNotificationsInput `json:"-" xml:"-"`
 }
 
 type metadataUpdatePipelineNotificationsInput struct {
@@ -3044,7 +3044,7 @@ type UpdatePipelineNotificationsOutput struct {
 	// A section of the response body that provides information about the pipeline.
 	Pipeline *Pipeline `type:"structure"`
 
-	metadataUpdatePipelineNotificationsOutput `json:"-", xml:"-"`
+	metadataUpdatePipelineNotificationsOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdatePipelineNotificationsOutput struct {
@@ -3065,7 +3065,7 @@ type UpdatePipelineOutput struct {
 	// cross-regional charges.
 	Warnings []*Warning `type:"list"`
 
-	metadataUpdatePipelineOutput `json:"-", xml:"-"`
+	metadataUpdatePipelineOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdatePipelineOutput struct {
@@ -3083,7 +3083,7 @@ type UpdatePipelineStatusInput struct {
 	// currently processing jobs.
 	Status *string `type:"string" required:"true"`
 
-	metadataUpdatePipelineStatusInput `json:"-", xml:"-"`
+	metadataUpdatePipelineStatusInput `json:"-" xml:"-"`
 }
 
 type metadataUpdatePipelineStatusInput struct {
@@ -3096,7 +3096,7 @@ type UpdatePipelineStatusOutput struct {
 	// A section of the response body that provides information about the pipeline.
 	Pipeline *Pipeline `type:"structure"`
 
-	metadataUpdatePipelineStatusOutput `json:"-", xml:"-"`
+	metadataUpdatePipelineStatusOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdatePipelineStatusOutput struct {
@@ -3400,7 +3400,7 @@ type VideoParameters struct {
 	// that have different dimensions.
 	Watermarks []*PresetWatermark `type:"list"`
 
-	metadataVideoParameters `json:"-", xml:"-"`
+	metadataVideoParameters `json:"-" xml:"-"`
 }
 
 type metadataVideoParameters struct {
@@ -3423,7 +3423,7 @@ type Warning struct {
 	// Note: AWS KMS keys must be in the same region as the pipeline.
 	Message *string `type:"string"`
 
-	metadataWarning `json:"-", xml:"-"`
+	metadataWarning `json:"-" xml:"-"`
 }
 
 type metadataWarning struct {

--- a/service/elb/api.go
+++ b/service/elb/api.go
@@ -1148,7 +1148,7 @@ type AccessLog struct {
 	// the root level of the bucket.
 	S3BucketPrefix *string `type:"string"`
 
-	metadataAccessLog `json:"-", xml:"-"`
+	metadataAccessLog `json:"-" xml:"-"`
 }
 
 type metadataAccessLog struct {
@@ -1162,7 +1162,7 @@ type AddTagsInput struct {
 	// The tags.
 	Tags []*Tag `type:"list" required:"true"`
 
-	metadataAddTagsInput `json:"-", xml:"-"`
+	metadataAddTagsInput `json:"-" xml:"-"`
 }
 
 type metadataAddTagsInput struct {
@@ -1170,7 +1170,7 @@ type metadataAddTagsInput struct {
 }
 
 type AddTagsOutput struct {
-	metadataAddTagsOutput `json:"-", xml:"-"`
+	metadataAddTagsOutput `json:"-" xml:"-"`
 }
 
 type metadataAddTagsOutput struct {
@@ -1185,7 +1185,7 @@ type AdditionalAttribute struct {
 	// This parameter is reserved.
 	Value *string `type:"string"`
 
-	metadataAdditionalAttribute `json:"-", xml:"-"`
+	metadataAdditionalAttribute `json:"-" xml:"-"`
 }
 
 type metadataAdditionalAttribute struct {
@@ -1201,7 +1201,7 @@ type AppCookieStickinessPolicy struct {
 	// a set of policies for this load balancer.
 	PolicyName *string `type:"string"`
 
-	metadataAppCookieStickinessPolicy `json:"-", xml:"-"`
+	metadataAppCookieStickinessPolicy `json:"-" xml:"-"`
 }
 
 type metadataAppCookieStickinessPolicy struct {
@@ -1216,7 +1216,7 @@ type ApplySecurityGroupsToLoadBalancerInput struct {
 	// that you cannot specify the name of the security group.
 	SecurityGroups []*string `type:"list" required:"true"`
 
-	metadataApplySecurityGroupsToLoadBalancerInput `json:"-", xml:"-"`
+	metadataApplySecurityGroupsToLoadBalancerInput `json:"-" xml:"-"`
 }
 
 type metadataApplySecurityGroupsToLoadBalancerInput struct {
@@ -1227,7 +1227,7 @@ type ApplySecurityGroupsToLoadBalancerOutput struct {
 	// The IDs of the security groups associated with the load balancer.
 	SecurityGroups []*string `type:"list"`
 
-	metadataApplySecurityGroupsToLoadBalancerOutput `json:"-", xml:"-"`
+	metadataApplySecurityGroupsToLoadBalancerOutput `json:"-" xml:"-"`
 }
 
 type metadataApplySecurityGroupsToLoadBalancerOutput struct {
@@ -1242,7 +1242,7 @@ type AttachLoadBalancerToSubnetsInput struct {
 	// subnet per Availability Zone.
 	Subnets []*string `type:"list" required:"true"`
 
-	metadataAttachLoadBalancerToSubnetsInput `json:"-", xml:"-"`
+	metadataAttachLoadBalancerToSubnetsInput `json:"-" xml:"-"`
 }
 
 type metadataAttachLoadBalancerToSubnetsInput struct {
@@ -1253,7 +1253,7 @@ type AttachLoadBalancerToSubnetsOutput struct {
 	// The IDs of the subnets attached to the load balancer.
 	Subnets []*string `type:"list"`
 
-	metadataAttachLoadBalancerToSubnetsOutput `json:"-", xml:"-"`
+	metadataAttachLoadBalancerToSubnetsOutput `json:"-" xml:"-"`
 }
 
 type metadataAttachLoadBalancerToSubnetsOutput struct {
@@ -1268,7 +1268,7 @@ type BackendServerDescription struct {
 	// The names of the policies enabled for the back-end server.
 	PolicyNames []*string `type:"list"`
 
-	metadataBackendServerDescription `json:"-", xml:"-"`
+	metadataBackendServerDescription `json:"-" xml:"-"`
 }
 
 type metadataBackendServerDescription struct {
@@ -1282,7 +1282,7 @@ type ConfigureHealthCheckInput struct {
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string" required:"true"`
 
-	metadataConfigureHealthCheckInput `json:"-", xml:"-"`
+	metadataConfigureHealthCheckInput `json:"-" xml:"-"`
 }
 
 type metadataConfigureHealthCheckInput struct {
@@ -1293,7 +1293,7 @@ type ConfigureHealthCheckOutput struct {
 	// The updated health check.
 	HealthCheck *HealthCheck `type:"structure"`
 
-	metadataConfigureHealthCheckOutput `json:"-", xml:"-"`
+	metadataConfigureHealthCheckOutput `json:"-" xml:"-"`
 }
 
 type metadataConfigureHealthCheckOutput struct {
@@ -1309,7 +1309,7 @@ type ConnectionDraining struct {
 	// deregistering the instances.
 	Timeout *int64 `type:"integer"`
 
-	metadataConnectionDraining `json:"-", xml:"-"`
+	metadataConnectionDraining `json:"-" xml:"-"`
 }
 
 type metadataConnectionDraining struct {
@@ -1322,7 +1322,7 @@ type ConnectionSettings struct {
 	// has been sent over the connection) before it is closed by the load balancer.
 	IdleTimeout *int64 `type:"integer" required:"true"`
 
-	metadataConnectionSettings `json:"-", xml:"-"`
+	metadataConnectionSettings `json:"-" xml:"-"`
 }
 
 type metadataConnectionSettings struct {
@@ -1340,7 +1340,7 @@ type CreateAppCookieStickinessPolicyInput struct {
 	// set of policies for this load balancer.
 	PolicyName *string `type:"string" required:"true"`
 
-	metadataCreateAppCookieStickinessPolicyInput `json:"-", xml:"-"`
+	metadataCreateAppCookieStickinessPolicyInput `json:"-" xml:"-"`
 }
 
 type metadataCreateAppCookieStickinessPolicyInput struct {
@@ -1348,7 +1348,7 @@ type metadataCreateAppCookieStickinessPolicyInput struct {
 }
 
 type CreateAppCookieStickinessPolicyOutput struct {
-	metadataCreateAppCookieStickinessPolicyOutput `json:"-", xml:"-"`
+	metadataCreateAppCookieStickinessPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateAppCookieStickinessPolicyOutput struct {
@@ -1368,7 +1368,7 @@ type CreateLBCookieStickinessPolicyInput struct {
 	// set of policies for this load balancer.
 	PolicyName *string `type:"string" required:"true"`
 
-	metadataCreateLBCookieStickinessPolicyInput `json:"-", xml:"-"`
+	metadataCreateLBCookieStickinessPolicyInput `json:"-" xml:"-"`
 }
 
 type metadataCreateLBCookieStickinessPolicyInput struct {
@@ -1376,7 +1376,7 @@ type metadataCreateLBCookieStickinessPolicyInput struct {
 }
 
 type CreateLBCookieStickinessPolicyOutput struct {
-	metadataCreateLBCookieStickinessPolicyOutput `json:"-", xml:"-"`
+	metadataCreateLBCookieStickinessPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateLBCookieStickinessPolicyOutput struct {
@@ -1432,7 +1432,7 @@ type CreateLoadBalancerInput struct {
 	// in the Elastic Load Balancing Developer Guide.
 	Tags []*Tag `type:"list"`
 
-	metadataCreateLoadBalancerInput `json:"-", xml:"-"`
+	metadataCreateLoadBalancerInput `json:"-" xml:"-"`
 }
 
 type metadataCreateLoadBalancerInput struct {
@@ -1446,7 +1446,7 @@ type CreateLoadBalancerListenersInput struct {
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string" required:"true"`
 
-	metadataCreateLoadBalancerListenersInput `json:"-", xml:"-"`
+	metadataCreateLoadBalancerListenersInput `json:"-" xml:"-"`
 }
 
 type metadataCreateLoadBalancerListenersInput struct {
@@ -1454,7 +1454,7 @@ type metadataCreateLoadBalancerListenersInput struct {
 }
 
 type CreateLoadBalancerListenersOutput struct {
-	metadataCreateLoadBalancerListenersOutput `json:"-", xml:"-"`
+	metadataCreateLoadBalancerListenersOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateLoadBalancerListenersOutput struct {
@@ -1465,7 +1465,7 @@ type CreateLoadBalancerOutput struct {
 	// The DNS name of the load balancer.
 	DNSName *string `type:"string"`
 
-	metadataCreateLoadBalancerOutput `json:"-", xml:"-"`
+	metadataCreateLoadBalancerOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateLoadBalancerOutput struct {
@@ -1486,7 +1486,7 @@ type CreateLoadBalancerPolicyInput struct {
 	// The name of the base policy type. To get the list of policy types, use DescribeLoadBalancerPolicyTypes.
 	PolicyTypeName *string `type:"string" required:"true"`
 
-	metadataCreateLoadBalancerPolicyInput `json:"-", xml:"-"`
+	metadataCreateLoadBalancerPolicyInput `json:"-" xml:"-"`
 }
 
 type metadataCreateLoadBalancerPolicyInput struct {
@@ -1494,7 +1494,7 @@ type metadataCreateLoadBalancerPolicyInput struct {
 }
 
 type CreateLoadBalancerPolicyOutput struct {
-	metadataCreateLoadBalancerPolicyOutput `json:"-", xml:"-"`
+	metadataCreateLoadBalancerPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateLoadBalancerPolicyOutput struct {
@@ -1506,7 +1506,7 @@ type CrossZoneLoadBalancing struct {
 	// Specifies whether cross-zone load balancing is enabled for the load balancer.
 	Enabled *bool `type:"boolean" required:"true"`
 
-	metadataCrossZoneLoadBalancing `json:"-", xml:"-"`
+	metadataCrossZoneLoadBalancing `json:"-" xml:"-"`
 }
 
 type metadataCrossZoneLoadBalancing struct {
@@ -1517,7 +1517,7 @@ type DeleteLoadBalancerInput struct {
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string" required:"true"`
 
-	metadataDeleteLoadBalancerInput `json:"-", xml:"-"`
+	metadataDeleteLoadBalancerInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteLoadBalancerInput struct {
@@ -1531,7 +1531,7 @@ type DeleteLoadBalancerListenersInput struct {
 	// The client port numbers of the listeners.
 	LoadBalancerPorts []*int64 `type:"list" required:"true"`
 
-	metadataDeleteLoadBalancerListenersInput `json:"-", xml:"-"`
+	metadataDeleteLoadBalancerListenersInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteLoadBalancerListenersInput struct {
@@ -1539,7 +1539,7 @@ type metadataDeleteLoadBalancerListenersInput struct {
 }
 
 type DeleteLoadBalancerListenersOutput struct {
-	metadataDeleteLoadBalancerListenersOutput `json:"-", xml:"-"`
+	metadataDeleteLoadBalancerListenersOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteLoadBalancerListenersOutput struct {
@@ -1547,7 +1547,7 @@ type metadataDeleteLoadBalancerListenersOutput struct {
 }
 
 type DeleteLoadBalancerOutput struct {
-	metadataDeleteLoadBalancerOutput `json:"-", xml:"-"`
+	metadataDeleteLoadBalancerOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteLoadBalancerOutput struct {
@@ -1562,7 +1562,7 @@ type DeleteLoadBalancerPolicyInput struct {
 	// The name of the policy.
 	PolicyName *string `type:"string" required:"true"`
 
-	metadataDeleteLoadBalancerPolicyInput `json:"-", xml:"-"`
+	metadataDeleteLoadBalancerPolicyInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteLoadBalancerPolicyInput struct {
@@ -1570,7 +1570,7 @@ type metadataDeleteLoadBalancerPolicyInput struct {
 }
 
 type DeleteLoadBalancerPolicyOutput struct {
-	metadataDeleteLoadBalancerPolicyOutput `json:"-", xml:"-"`
+	metadataDeleteLoadBalancerPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteLoadBalancerPolicyOutput struct {
@@ -1584,7 +1584,7 @@ type DeregisterInstancesFromLoadBalancerInput struct {
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string" required:"true"`
 
-	metadataDeregisterInstancesFromLoadBalancerInput `json:"-", xml:"-"`
+	metadataDeregisterInstancesFromLoadBalancerInput `json:"-" xml:"-"`
 }
 
 type metadataDeregisterInstancesFromLoadBalancerInput struct {
@@ -1595,7 +1595,7 @@ type DeregisterInstancesFromLoadBalancerOutput struct {
 	// The remaining instances registered with the load balancer.
 	Instances []*Instance `type:"list"`
 
-	metadataDeregisterInstancesFromLoadBalancerOutput `json:"-", xml:"-"`
+	metadataDeregisterInstancesFromLoadBalancerOutput `json:"-" xml:"-"`
 }
 
 type metadataDeregisterInstancesFromLoadBalancerOutput struct {
@@ -1609,7 +1609,7 @@ type DescribeInstanceHealthInput struct {
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string" required:"true"`
 
-	metadataDescribeInstanceHealthInput `json:"-", xml:"-"`
+	metadataDescribeInstanceHealthInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeInstanceHealthInput struct {
@@ -1620,7 +1620,7 @@ type DescribeInstanceHealthOutput struct {
 	// Information about the health of the instances.
 	InstanceStates []*InstanceState `type:"list"`
 
-	metadataDescribeInstanceHealthOutput `json:"-", xml:"-"`
+	metadataDescribeInstanceHealthOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeInstanceHealthOutput struct {
@@ -1631,7 +1631,7 @@ type DescribeLoadBalancerAttributesInput struct {
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string" required:"true"`
 
-	metadataDescribeLoadBalancerAttributesInput `json:"-", xml:"-"`
+	metadataDescribeLoadBalancerAttributesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeLoadBalancerAttributesInput struct {
@@ -1642,7 +1642,7 @@ type DescribeLoadBalancerAttributesOutput struct {
 	// Information about the load balancer attributes.
 	LoadBalancerAttributes *LoadBalancerAttributes `type:"structure"`
 
-	metadataDescribeLoadBalancerAttributesOutput `json:"-", xml:"-"`
+	metadataDescribeLoadBalancerAttributesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeLoadBalancerAttributesOutput struct {
@@ -1656,7 +1656,7 @@ type DescribeLoadBalancerPoliciesInput struct {
 	// The names of the policies.
 	PolicyNames []*string `type:"list"`
 
-	metadataDescribeLoadBalancerPoliciesInput `json:"-", xml:"-"`
+	metadataDescribeLoadBalancerPoliciesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeLoadBalancerPoliciesInput struct {
@@ -1667,7 +1667,7 @@ type DescribeLoadBalancerPoliciesOutput struct {
 	// Information about the policies.
 	PolicyDescriptions []*PolicyDescription `type:"list"`
 
-	metadataDescribeLoadBalancerPoliciesOutput `json:"-", xml:"-"`
+	metadataDescribeLoadBalancerPoliciesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeLoadBalancerPoliciesOutput struct {
@@ -1679,7 +1679,7 @@ type DescribeLoadBalancerPolicyTypesInput struct {
 	// types defined by Elastic Load Balancing.
 	PolicyTypeNames []*string `type:"list"`
 
-	metadataDescribeLoadBalancerPolicyTypesInput `json:"-", xml:"-"`
+	metadataDescribeLoadBalancerPolicyTypesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeLoadBalancerPolicyTypesInput struct {
@@ -1690,7 +1690,7 @@ type DescribeLoadBalancerPolicyTypesOutput struct {
 	// Information about the policy types.
 	PolicyTypeDescriptions []*PolicyTypeDescription `type:"list"`
 
-	metadataDescribeLoadBalancerPolicyTypesOutput `json:"-", xml:"-"`
+	metadataDescribeLoadBalancerPolicyTypesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeLoadBalancerPolicyTypesOutput struct {
@@ -1709,7 +1709,7 @@ type DescribeLoadBalancersInput struct {
 	// 400). The default is 400.
 	PageSize *int64 `type:"integer"`
 
-	metadataDescribeLoadBalancersInput `json:"-", xml:"-"`
+	metadataDescribeLoadBalancersInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeLoadBalancersInput struct {
@@ -1724,7 +1724,7 @@ type DescribeLoadBalancersOutput struct {
 	// additional results, the string is empty.
 	NextMarker *string `type:"string"`
 
-	metadataDescribeLoadBalancersOutput `json:"-", xml:"-"`
+	metadataDescribeLoadBalancersOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeLoadBalancersOutput struct {
@@ -1735,7 +1735,7 @@ type DescribeTagsInput struct {
 	// The names of the load balancers.
 	LoadBalancerNames []*string `type:"list" required:"true"`
 
-	metadataDescribeTagsInput `json:"-", xml:"-"`
+	metadataDescribeTagsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeTagsInput struct {
@@ -1746,7 +1746,7 @@ type DescribeTagsOutput struct {
 	// Information about the tags.
 	TagDescriptions []*TagDescription `type:"list"`
 
-	metadataDescribeTagsOutput `json:"-", xml:"-"`
+	metadataDescribeTagsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeTagsOutput struct {
@@ -1760,7 +1760,7 @@ type DetachLoadBalancerFromSubnetsInput struct {
 	// The IDs of the subnets.
 	Subnets []*string `type:"list" required:"true"`
 
-	metadataDetachLoadBalancerFromSubnetsInput `json:"-", xml:"-"`
+	metadataDetachLoadBalancerFromSubnetsInput `json:"-" xml:"-"`
 }
 
 type metadataDetachLoadBalancerFromSubnetsInput struct {
@@ -1771,7 +1771,7 @@ type DetachLoadBalancerFromSubnetsOutput struct {
 	// The IDs of the remaining subnets for the load balancer.
 	Subnets []*string `type:"list"`
 
-	metadataDetachLoadBalancerFromSubnetsOutput `json:"-", xml:"-"`
+	metadataDetachLoadBalancerFromSubnetsOutput `json:"-" xml:"-"`
 }
 
 type metadataDetachLoadBalancerFromSubnetsOutput struct {
@@ -1785,7 +1785,7 @@ type DisableAvailabilityZonesForLoadBalancerInput struct {
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string" required:"true"`
 
-	metadataDisableAvailabilityZonesForLoadBalancerInput `json:"-", xml:"-"`
+	metadataDisableAvailabilityZonesForLoadBalancerInput `json:"-" xml:"-"`
 }
 
 type metadataDisableAvailabilityZonesForLoadBalancerInput struct {
@@ -1796,7 +1796,7 @@ type DisableAvailabilityZonesForLoadBalancerOutput struct {
 	// The remaining Availability Zones for the load balancer.
 	AvailabilityZones []*string `type:"list"`
 
-	metadataDisableAvailabilityZonesForLoadBalancerOutput `json:"-", xml:"-"`
+	metadataDisableAvailabilityZonesForLoadBalancerOutput `json:"-" xml:"-"`
 }
 
 type metadataDisableAvailabilityZonesForLoadBalancerOutput struct {
@@ -1810,7 +1810,7 @@ type EnableAvailabilityZonesForLoadBalancerInput struct {
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string" required:"true"`
 
-	metadataEnableAvailabilityZonesForLoadBalancerInput `json:"-", xml:"-"`
+	metadataEnableAvailabilityZonesForLoadBalancerInput `json:"-" xml:"-"`
 }
 
 type metadataEnableAvailabilityZonesForLoadBalancerInput struct {
@@ -1821,7 +1821,7 @@ type EnableAvailabilityZonesForLoadBalancerOutput struct {
 	// The updated list of Availability Zones for the load balancer.
 	AvailabilityZones []*string `type:"list"`
 
-	metadataEnableAvailabilityZonesForLoadBalancerOutput `json:"-", xml:"-"`
+	metadataEnableAvailabilityZonesForLoadBalancerOutput `json:"-" xml:"-"`
 }
 
 type metadataEnableAvailabilityZonesForLoadBalancerOutput struct {
@@ -1868,7 +1868,7 @@ type HealthCheck struct {
 	// instance to the Unhealthy state.
 	UnhealthyThreshold *int64 `type:"integer" required:"true"`
 
-	metadataHealthCheck `json:"-", xml:"-"`
+	metadataHealthCheck `json:"-" xml:"-"`
 }
 
 type metadataHealthCheck struct {
@@ -1880,7 +1880,7 @@ type Instance struct {
 	// The ID of the instance.
 	InstanceID *string `locationName:"InstanceId" type:"string"`
 
-	metadataInstance `json:"-", xml:"-"`
+	metadataInstance `json:"-" xml:"-"`
 }
 
 type metadataInstance struct {
@@ -1934,7 +1934,7 @@ type InstanceState struct {
 	// Valid values: InService | OutOfService | Unknown
 	State *string `type:"string"`
 
-	metadataInstanceState `json:"-", xml:"-"`
+	metadataInstanceState `json:"-" xml:"-"`
 }
 
 type metadataInstanceState struct {
@@ -1952,7 +1952,7 @@ type LBCookieStickinessPolicy struct {
 	// set of policies for this load balancer.
 	PolicyName *string `type:"string"`
 
-	metadataLBCookieStickinessPolicy `json:"-", xml:"-"`
+	metadataLBCookieStickinessPolicy `json:"-" xml:"-"`
 }
 
 type metadataLBCookieStickinessPolicy struct {
@@ -1993,7 +1993,7 @@ type Listener struct {
 	// The Amazon Resource Name (ARN) of the server certificate.
 	SSLCertificateID *string `locationName:"SSLCertificateId" type:"string"`
 
-	metadataListener `json:"-", xml:"-"`
+	metadataListener `json:"-" xml:"-"`
 }
 
 type metadataListener struct {
@@ -2012,7 +2012,7 @@ type ListenerDescription struct {
 	// The policies. If there are no policies enabled, the list is empty.
 	PolicyNames []*string `type:"list"`
 
-	metadataListenerDescription `json:"-", xml:"-"`
+	metadataListenerDescription `json:"-" xml:"-"`
 }
 
 type metadataListenerDescription struct {
@@ -2055,7 +2055,7 @@ type LoadBalancerAttributes struct {
 	// in the Elastic Load Balancing Developer Guide.
 	CrossZoneLoadBalancing *CrossZoneLoadBalancing `type:"structure"`
 
-	metadataLoadBalancerAttributes `json:"-", xml:"-"`
+	metadataLoadBalancerAttributes `json:"-" xml:"-"`
 }
 
 type metadataLoadBalancerAttributes struct {
@@ -2126,7 +2126,7 @@ type LoadBalancerDescription struct {
 	// The ID of the VPC for the load balancer.
 	VPCID *string `locationName:"VPCId" type:"string"`
 
-	metadataLoadBalancerDescription `json:"-", xml:"-"`
+	metadataLoadBalancerDescription `json:"-" xml:"-"`
 }
 
 type metadataLoadBalancerDescription struct {
@@ -2140,7 +2140,7 @@ type ModifyLoadBalancerAttributesInput struct {
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string" required:"true"`
 
-	metadataModifyLoadBalancerAttributesInput `json:"-", xml:"-"`
+	metadataModifyLoadBalancerAttributesInput `json:"-" xml:"-"`
 }
 
 type metadataModifyLoadBalancerAttributesInput struct {
@@ -2154,7 +2154,7 @@ type ModifyLoadBalancerAttributesOutput struct {
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string"`
 
-	metadataModifyLoadBalancerAttributesOutput `json:"-", xml:"-"`
+	metadataModifyLoadBalancerAttributesOutput `json:"-" xml:"-"`
 }
 
 type metadataModifyLoadBalancerAttributesOutput struct {
@@ -2172,7 +2172,7 @@ type Policies struct {
 	// The policies other than the stickiness policies.
 	OtherPolicies []*string `type:"list"`
 
-	metadataPolicies `json:"-", xml:"-"`
+	metadataPolicies `json:"-" xml:"-"`
 }
 
 type metadataPolicies struct {
@@ -2187,7 +2187,7 @@ type PolicyAttribute struct {
 	// The value of the attribute.
 	AttributeValue *string `type:"string"`
 
-	metadataPolicyAttribute `json:"-", xml:"-"`
+	metadataPolicyAttribute `json:"-" xml:"-"`
 }
 
 type metadataPolicyAttribute struct {
@@ -2202,7 +2202,7 @@ type PolicyAttributeDescription struct {
 	// The value of the attribute.
 	AttributeValue *string `type:"string"`
 
-	metadataPolicyAttributeDescription `json:"-", xml:"-"`
+	metadataPolicyAttributeDescription `json:"-" xml:"-"`
 }
 
 type metadataPolicyAttributeDescription struct {
@@ -2232,7 +2232,7 @@ type PolicyAttributeTypeDescription struct {
 	// A description of the attribute.
 	Description *string `type:"string"`
 
-	metadataPolicyAttributeTypeDescription `json:"-", xml:"-"`
+	metadataPolicyAttributeTypeDescription `json:"-" xml:"-"`
 }
 
 type metadataPolicyAttributeTypeDescription struct {
@@ -2250,7 +2250,7 @@ type PolicyDescription struct {
 	// The name of the policy type.
 	PolicyTypeName *string `type:"string"`
 
-	metadataPolicyDescription `json:"-", xml:"-"`
+	metadataPolicyDescription `json:"-" xml:"-"`
 }
 
 type metadataPolicyDescription struct {
@@ -2269,7 +2269,7 @@ type PolicyTypeDescription struct {
 	// The name of the policy type.
 	PolicyTypeName *string `type:"string"`
 
-	metadataPolicyTypeDescription `json:"-", xml:"-"`
+	metadataPolicyTypeDescription `json:"-" xml:"-"`
 }
 
 type metadataPolicyTypeDescription struct {
@@ -2283,7 +2283,7 @@ type RegisterInstancesWithLoadBalancerInput struct {
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string" required:"true"`
 
-	metadataRegisterInstancesWithLoadBalancerInput `json:"-", xml:"-"`
+	metadataRegisterInstancesWithLoadBalancerInput `json:"-" xml:"-"`
 }
 
 type metadataRegisterInstancesWithLoadBalancerInput struct {
@@ -2294,7 +2294,7 @@ type RegisterInstancesWithLoadBalancerOutput struct {
 	// The updated list of instances for the load balancer.
 	Instances []*Instance `type:"list"`
 
-	metadataRegisterInstancesWithLoadBalancerOutput `json:"-", xml:"-"`
+	metadataRegisterInstancesWithLoadBalancerOutput `json:"-" xml:"-"`
 }
 
 type metadataRegisterInstancesWithLoadBalancerOutput struct {
@@ -2309,7 +2309,7 @@ type RemoveTagsInput struct {
 	// The list of tag keys to remove.
 	Tags []*TagKeyOnly `type:"list" required:"true"`
 
-	metadataRemoveTagsInput `json:"-", xml:"-"`
+	metadataRemoveTagsInput `json:"-" xml:"-"`
 }
 
 type metadataRemoveTagsInput struct {
@@ -2317,7 +2317,7 @@ type metadataRemoveTagsInput struct {
 }
 
 type RemoveTagsOutput struct {
-	metadataRemoveTagsOutput `json:"-", xml:"-"`
+	metadataRemoveTagsOutput `json:"-" xml:"-"`
 }
 
 type metadataRemoveTagsOutput struct {
@@ -2334,7 +2334,7 @@ type SetLoadBalancerListenerSSLCertificateInput struct {
 	// The Amazon Resource Name (ARN) of the SSL certificate.
 	SSLCertificateID *string `locationName:"SSLCertificateId" type:"string" required:"true"`
 
-	metadataSetLoadBalancerListenerSSLCertificateInput `json:"-", xml:"-"`
+	metadataSetLoadBalancerListenerSSLCertificateInput `json:"-" xml:"-"`
 }
 
 type metadataSetLoadBalancerListenerSSLCertificateInput struct {
@@ -2342,7 +2342,7 @@ type metadataSetLoadBalancerListenerSSLCertificateInput struct {
 }
 
 type SetLoadBalancerListenerSSLCertificateOutput struct {
-	metadataSetLoadBalancerListenerSSLCertificateOutput `json:"-", xml:"-"`
+	metadataSetLoadBalancerListenerSSLCertificateOutput `json:"-" xml:"-"`
 }
 
 type metadataSetLoadBalancerListenerSSLCertificateOutput struct {
@@ -2360,7 +2360,7 @@ type SetLoadBalancerPoliciesForBackendServerInput struct {
 	// are removed from the back-end server.
 	PolicyNames []*string `type:"list" required:"true"`
 
-	metadataSetLoadBalancerPoliciesForBackendServerInput `json:"-", xml:"-"`
+	metadataSetLoadBalancerPoliciesForBackendServerInput `json:"-" xml:"-"`
 }
 
 type metadataSetLoadBalancerPoliciesForBackendServerInput struct {
@@ -2368,7 +2368,7 @@ type metadataSetLoadBalancerPoliciesForBackendServerInput struct {
 }
 
 type SetLoadBalancerPoliciesForBackendServerOutput struct {
-	metadataSetLoadBalancerPoliciesForBackendServerOutput `json:"-", xml:"-"`
+	metadataSetLoadBalancerPoliciesForBackendServerOutput `json:"-" xml:"-"`
 }
 
 type metadataSetLoadBalancerPoliciesForBackendServerOutput struct {
@@ -2386,7 +2386,7 @@ type SetLoadBalancerPoliciesOfListenerInput struct {
 	// from the listener.
 	PolicyNames []*string `type:"list" required:"true"`
 
-	metadataSetLoadBalancerPoliciesOfListenerInput `json:"-", xml:"-"`
+	metadataSetLoadBalancerPoliciesOfListenerInput `json:"-" xml:"-"`
 }
 
 type metadataSetLoadBalancerPoliciesOfListenerInput struct {
@@ -2394,7 +2394,7 @@ type metadataSetLoadBalancerPoliciesOfListenerInput struct {
 }
 
 type SetLoadBalancerPoliciesOfListenerOutput struct {
-	metadataSetLoadBalancerPoliciesOfListenerOutput `json:"-", xml:"-"`
+	metadataSetLoadBalancerPoliciesOfListenerOutput `json:"-" xml:"-"`
 }
 
 type metadataSetLoadBalancerPoliciesOfListenerOutput struct {
@@ -2409,7 +2409,7 @@ type SourceSecurityGroup struct {
 	// The owner of the security group.
 	OwnerAlias *string `type:"string"`
 
-	metadataSourceSecurityGroup `json:"-", xml:"-"`
+	metadataSourceSecurityGroup `json:"-" xml:"-"`
 }
 
 type metadataSourceSecurityGroup struct {
@@ -2424,7 +2424,7 @@ type Tag struct {
 	// The value of the tag.
 	Value *string `type:"string"`
 
-	metadataTag `json:"-", xml:"-"`
+	metadataTag `json:"-" xml:"-"`
 }
 
 type metadataTag struct {
@@ -2439,7 +2439,7 @@ type TagDescription struct {
 	// The tags.
 	Tags []*Tag `type:"list"`
 
-	metadataTagDescription `json:"-", xml:"-"`
+	metadataTagDescription `json:"-" xml:"-"`
 }
 
 type metadataTagDescription struct {
@@ -2451,7 +2451,7 @@ type TagKeyOnly struct {
 	// The name of the key.
 	Key *string `type:"string"`
 
-	metadataTagKeyOnly `json:"-", xml:"-"`
+	metadataTagKeyOnly `json:"-" xml:"-"`
 }
 
 type metadataTagKeyOnly struct {

--- a/service/emr/api.go
+++ b/service/emr/api.go
@@ -692,7 +692,7 @@ type AddInstanceGroupsInput struct {
 	// Job flow in which to add the instance groups.
 	JobFlowID *string `locationName:"JobFlowId" type:"string" required:"true"`
 
-	metadataAddInstanceGroupsInput `json:"-", xml:"-"`
+	metadataAddInstanceGroupsInput `json:"-" xml:"-"`
 }
 
 type metadataAddInstanceGroupsInput struct {
@@ -707,7 +707,7 @@ type AddInstanceGroupsOutput struct {
 	// The job flow ID in which the instance groups are added.
 	JobFlowID *string `locationName:"JobFlowId" type:"string"`
 
-	metadataAddInstanceGroupsOutput `json:"-", xml:"-"`
+	metadataAddInstanceGroupsOutput `json:"-" xml:"-"`
 }
 
 type metadataAddInstanceGroupsOutput struct {
@@ -723,7 +723,7 @@ type AddJobFlowStepsInput struct {
 	// A list of StepConfig to be executed by the job flow.
 	Steps []*StepConfig `type:"list" required:"true"`
 
-	metadataAddJobFlowStepsInput `json:"-", xml:"-"`
+	metadataAddJobFlowStepsInput `json:"-" xml:"-"`
 }
 
 type metadataAddJobFlowStepsInput struct {
@@ -735,7 +735,7 @@ type AddJobFlowStepsOutput struct {
 	// The identifiers of the list of steps added to the job flow.
 	StepIDs []*string `locationName:"StepIds" type:"list"`
 
-	metadataAddJobFlowStepsOutput `json:"-", xml:"-"`
+	metadataAddJobFlowStepsOutput `json:"-" xml:"-"`
 }
 
 type metadataAddJobFlowStepsOutput struct {
@@ -754,7 +754,7 @@ type AddTagsInput struct {
 	// of 256 characters.
 	Tags []*Tag `type:"list" required:"true"`
 
-	metadataAddTagsInput `json:"-", xml:"-"`
+	metadataAddTagsInput `json:"-" xml:"-"`
 }
 
 type metadataAddTagsInput struct {
@@ -763,7 +763,7 @@ type metadataAddTagsInput struct {
 
 // This output indicates the result of adding tags to a resource.
 type AddTagsOutput struct {
-	metadataAddTagsOutput `json:"-", xml:"-"`
+	metadataAddTagsOutput `json:"-" xml:"-"`
 }
 
 type metadataAddTagsOutput struct {
@@ -796,7 +796,7 @@ type Application struct {
 	// The version of the application.
 	Version *string `type:"string"`
 
-	metadataApplication `json:"-", xml:"-"`
+	metadataApplication `json:"-" xml:"-"`
 }
 
 type metadataApplication struct {
@@ -811,7 +811,7 @@ type BootstrapActionConfig struct {
 	// The script run by the bootstrap action.
 	ScriptBootstrapAction *ScriptBootstrapActionConfig `type:"structure" required:"true"`
 
-	metadataBootstrapActionConfig `json:"-", xml:"-"`
+	metadataBootstrapActionConfig `json:"-" xml:"-"`
 }
 
 type metadataBootstrapActionConfig struct {
@@ -823,7 +823,7 @@ type BootstrapActionDetail struct {
 	// A description of the bootstrap action.
 	BootstrapActionConfig *BootstrapActionConfig `type:"structure"`
 
-	metadataBootstrapActionDetail `json:"-", xml:"-"`
+	metadataBootstrapActionDetail `json:"-" xml:"-"`
 }
 
 type metadataBootstrapActionDetail struct {
@@ -892,7 +892,7 @@ type Cluster struct {
 	// action.
 	VisibleToAllUsers *bool `type:"boolean"`
 
-	metadataCluster `json:"-", xml:"-"`
+	metadataCluster `json:"-" xml:"-"`
 }
 
 type metadataCluster struct {
@@ -907,7 +907,7 @@ type ClusterStateChangeReason struct {
 	// The descriptive message for the state change reason.
 	Message *string `type:"string"`
 
-	metadataClusterStateChangeReason `json:"-", xml:"-"`
+	metadataClusterStateChangeReason `json:"-" xml:"-"`
 }
 
 type metadataClusterStateChangeReason struct {
@@ -926,7 +926,7 @@ type ClusterStatus struct {
 	// cluster.
 	Timeline *ClusterTimeline `type:"structure"`
 
-	metadataClusterStatus `json:"-", xml:"-"`
+	metadataClusterStatus `json:"-" xml:"-"`
 }
 
 type metadataClusterStatus struct {
@@ -952,7 +952,7 @@ type ClusterSummary struct {
 	// The details about the current status of the cluster.
 	Status *ClusterStatus `type:"structure"`
 
-	metadataClusterSummary `json:"-", xml:"-"`
+	metadataClusterSummary `json:"-" xml:"-"`
 }
 
 type metadataClusterSummary struct {
@@ -970,7 +970,7 @@ type ClusterTimeline struct {
 	// The date and time when the cluster was ready to execute steps.
 	ReadyDateTime *time.Time `type:"timestamp" timestampFormat:"unix"`
 
-	metadataClusterTimeline `json:"-", xml:"-"`
+	metadataClusterTimeline `json:"-" xml:"-"`
 }
 
 type metadataClusterTimeline struct {
@@ -988,7 +988,7 @@ type Command struct {
 	// The Amazon S3 location of the command script.
 	ScriptPath *string `type:"string"`
 
-	metadataCommand `json:"-", xml:"-"`
+	metadataCommand `json:"-" xml:"-"`
 }
 
 type metadataCommand struct {
@@ -1000,7 +1000,7 @@ type DescribeClusterInput struct {
 	// The identifier of the cluster to describe.
 	ClusterID *string `locationName:"ClusterId" type:"string" required:"true"`
 
-	metadataDescribeClusterInput `json:"-", xml:"-"`
+	metadataDescribeClusterInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeClusterInput struct {
@@ -1012,7 +1012,7 @@ type DescribeClusterOutput struct {
 	// This output contains the details for the requested cluster.
 	Cluster *Cluster `type:"structure"`
 
-	metadataDescribeClusterOutput `json:"-", xml:"-"`
+	metadataDescribeClusterOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeClusterOutput struct {
@@ -1033,7 +1033,7 @@ type DescribeJobFlowsInput struct {
 	// Return only job flows whose state is contained in this list.
 	JobFlowStates []*string `type:"list"`
 
-	metadataDescribeJobFlowsInput `json:"-", xml:"-"`
+	metadataDescribeJobFlowsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeJobFlowsInput struct {
@@ -1045,7 +1045,7 @@ type DescribeJobFlowsOutput struct {
 	// A list of job flows matching the parameters supplied.
 	JobFlows []*JobFlowDetail `type:"list"`
 
-	metadataDescribeJobFlowsOutput `json:"-", xml:"-"`
+	metadataDescribeJobFlowsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeJobFlowsOutput struct {
@@ -1060,7 +1060,7 @@ type DescribeStepInput struct {
 	// The identifier of the step to describe.
 	StepID *string `locationName:"StepId" type:"string" required:"true"`
 
-	metadataDescribeStepInput `json:"-", xml:"-"`
+	metadataDescribeStepInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeStepInput struct {
@@ -1072,7 +1072,7 @@ type DescribeStepOutput struct {
 	// The step details for the requested step identifier.
 	Step *Step `type:"structure"`
 
-	metadataDescribeStepOutput `json:"-", xml:"-"`
+	metadataDescribeStepOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeStepOutput struct {
@@ -1117,7 +1117,7 @@ type EC2InstanceAttributes struct {
 	// of the job flow assume this role.
 	IAMInstanceProfile *string `locationName:"IamInstanceProfile" type:"string"`
 
-	metadataEC2InstanceAttributes `json:"-", xml:"-"`
+	metadataEC2InstanceAttributes `json:"-" xml:"-"`
 }
 
 type metadataEC2InstanceAttributes struct {
@@ -1143,7 +1143,7 @@ type HadoopJARStepConfig struct {
 	// properties to pass key value pairs to your main function.
 	Properties []*KeyValue `type:"list"`
 
-	metadataHadoopJARStepConfig `json:"-", xml:"-"`
+	metadataHadoopJARStepConfig `json:"-" xml:"-"`
 }
 
 type metadataHadoopJARStepConfig struct {
@@ -1169,7 +1169,7 @@ type HadoopStepConfig struct {
 	// these properties to pass key value pairs to your main function.
 	Properties *map[string]*string `type:"map"`
 
-	metadataHadoopStepConfig `json:"-", xml:"-"`
+	metadataHadoopStepConfig `json:"-" xml:"-"`
 }
 
 type metadataHadoopStepConfig struct {
@@ -1199,7 +1199,7 @@ type Instance struct {
 	// The current status of the instance.
 	Status *InstanceStatus `type:"structure"`
 
-	metadataInstance `json:"-", xml:"-"`
+	metadataInstance `json:"-" xml:"-"`
 }
 
 type metadataInstance struct {
@@ -1238,7 +1238,7 @@ type InstanceGroup struct {
 	// The current status of the instance group.
 	Status *InstanceGroupStatus `type:"structure"`
 
-	metadataInstanceGroup `json:"-", xml:"-"`
+	metadataInstanceGroup `json:"-" xml:"-"`
 }
 
 type metadataInstanceGroup struct {
@@ -1266,7 +1266,7 @@ type InstanceGroupConfig struct {
 	// Friendly name given to the instance group.
 	Name *string `type:"string"`
 
-	metadataInstanceGroupConfig `json:"-", xml:"-"`
+	metadataInstanceGroupConfig `json:"-" xml:"-"`
 }
 
 type metadataInstanceGroupConfig struct {
@@ -1319,7 +1319,7 @@ type InstanceGroupDetail struct {
 	// and FAILED.
 	State *string `type:"string" required:"true"`
 
-	metadataInstanceGroupDetail `json:"-", xml:"-"`
+	metadataInstanceGroupDetail `json:"-" xml:"-"`
 }
 
 type metadataInstanceGroupDetail struct {
@@ -1339,7 +1339,7 @@ type InstanceGroupModifyConfig struct {
 	// Unique ID of the instance group to expand or shrink.
 	InstanceGroupID *string `locationName:"InstanceGroupId" type:"string" required:"true"`
 
-	metadataInstanceGroupModifyConfig `json:"-", xml:"-"`
+	metadataInstanceGroupModifyConfig `json:"-" xml:"-"`
 }
 
 type metadataInstanceGroupModifyConfig struct {
@@ -1354,7 +1354,7 @@ type InstanceGroupStateChangeReason struct {
 	// The status change reason description.
 	Message *string `type:"string"`
 
-	metadataInstanceGroupStateChangeReason `json:"-", xml:"-"`
+	metadataInstanceGroupStateChangeReason `json:"-" xml:"-"`
 }
 
 type metadataInstanceGroupStateChangeReason struct {
@@ -1372,7 +1372,7 @@ type InstanceGroupStatus struct {
 	// The timeline of the instance group status over time.
 	Timeline *InstanceGroupTimeline `type:"structure"`
 
-	metadataInstanceGroupStatus `json:"-", xml:"-"`
+	metadataInstanceGroupStatus `json:"-" xml:"-"`
 }
 
 type metadataInstanceGroupStatus struct {
@@ -1390,7 +1390,7 @@ type InstanceGroupTimeline struct {
 	// The date and time when the instance group became ready to perform tasks.
 	ReadyDateTime *time.Time `type:"timestamp" timestampFormat:"unix"`
 
-	metadataInstanceGroupTimeline `json:"-", xml:"-"`
+	metadataInstanceGroupTimeline `json:"-" xml:"-"`
 }
 
 type metadataInstanceGroupTimeline struct {
@@ -1405,7 +1405,7 @@ type InstanceStateChangeReason struct {
 	// The status change reason description.
 	Message *string `type:"string"`
 
-	metadataInstanceStateChangeReason `json:"-", xml:"-"`
+	metadataInstanceStateChangeReason `json:"-" xml:"-"`
 }
 
 type metadataInstanceStateChangeReason struct {
@@ -1423,7 +1423,7 @@ type InstanceStatus struct {
 	// The timeline of the instance status over time.
 	Timeline *InstanceTimeline `type:"structure"`
 
-	metadataInstanceStatus `json:"-", xml:"-"`
+	metadataInstanceStatus `json:"-" xml:"-"`
 }
 
 type metadataInstanceStatus struct {
@@ -1441,7 +1441,7 @@ type InstanceTimeline struct {
 	// The date and time when the instance was ready to perform tasks.
 	ReadyDateTime *time.Time `type:"timestamp" timestampFormat:"unix"`
 
-	metadataInstanceTimeline `json:"-", xml:"-"`
+	metadataInstanceTimeline `json:"-" xml:"-"`
 }
 
 type metadataInstanceTimeline struct {
@@ -1498,7 +1498,7 @@ type JobFlowDetail struct {
 	// SetVisibleToAllUsers action.
 	VisibleToAllUsers *bool `type:"boolean"`
 
-	metadataJobFlowDetail `json:"-", xml:"-"`
+	metadataJobFlowDetail `json:"-" xml:"-"`
 }
 
 type metadataJobFlowDetail struct {
@@ -1526,7 +1526,7 @@ type JobFlowExecutionStatusDetail struct {
 	// The state of the job flow.
 	State *string `type:"string" required:"true"`
 
-	metadataJobFlowExecutionStatusDetail `json:"-", xml:"-"`
+	metadataJobFlowExecutionStatusDetail `json:"-" xml:"-"`
 }
 
 type metadataJobFlowExecutionStatusDetail struct {
@@ -1595,7 +1595,7 @@ type JobFlowInstancesConfig struct {
 	// a job flow error.
 	TerminationProtected *bool `type:"boolean"`
 
-	metadataJobFlowInstancesConfig `json:"-", xml:"-"`
+	metadataJobFlowInstancesConfig `json:"-" xml:"-"`
 }
 
 type metadataJobFlowInstancesConfig struct {
@@ -1654,7 +1654,7 @@ type JobFlowInstancesDetail struct {
 	// error.
 	TerminationProtected *bool `type:"boolean"`
 
-	metadataJobFlowInstancesDetail `json:"-", xml:"-"`
+	metadataJobFlowInstancesDetail `json:"-" xml:"-"`
 }
 
 type metadataJobFlowInstancesDetail struct {
@@ -1669,7 +1669,7 @@ type KeyValue struct {
 	// The value part of the identified key.
 	Value *string `type:"string"`
 
-	metadataKeyValue `json:"-", xml:"-"`
+	metadataKeyValue `json:"-" xml:"-"`
 }
 
 type metadataKeyValue struct {
@@ -1684,7 +1684,7 @@ type ListBootstrapActionsInput struct {
 	// The pagination token that indicates the next set of results to retrieve .
 	Marker *string `type:"string"`
 
-	metadataListBootstrapActionsInput `json:"-", xml:"-"`
+	metadataListBootstrapActionsInput `json:"-" xml:"-"`
 }
 
 type metadataListBootstrapActionsInput struct {
@@ -1699,7 +1699,7 @@ type ListBootstrapActionsOutput struct {
 	// The pagination token that indicates the next set of results to retrieve .
 	Marker *string `type:"string"`
 
-	metadataListBootstrapActionsOutput `json:"-", xml:"-"`
+	metadataListBootstrapActionsOutput `json:"-" xml:"-"`
 }
 
 type metadataListBootstrapActionsOutput struct {
@@ -1721,7 +1721,7 @@ type ListClustersInput struct {
 	// The pagination token that indicates the next set of results to retrieve.
 	Marker *string `type:"string"`
 
-	metadataListClustersInput `json:"-", xml:"-"`
+	metadataListClustersInput `json:"-" xml:"-"`
 }
 
 type metadataListClustersInput struct {
@@ -1737,7 +1737,7 @@ type ListClustersOutput struct {
 	// The pagination token that indicates the next set of results to retrieve.
 	Marker *string `type:"string"`
 
-	metadataListClustersOutput `json:"-", xml:"-"`
+	metadataListClustersOutput `json:"-" xml:"-"`
 }
 
 type metadataListClustersOutput struct {
@@ -1752,7 +1752,7 @@ type ListInstanceGroupsInput struct {
 	// The pagination token that indicates the next set of results to retrieve.
 	Marker *string `type:"string"`
 
-	metadataListInstanceGroupsInput `json:"-", xml:"-"`
+	metadataListInstanceGroupsInput `json:"-" xml:"-"`
 }
 
 type metadataListInstanceGroupsInput struct {
@@ -1767,7 +1767,7 @@ type ListInstanceGroupsOutput struct {
 	// The pagination token that indicates the next set of results to retrieve.
 	Marker *string `type:"string"`
 
-	metadataListInstanceGroupsOutput `json:"-", xml:"-"`
+	metadataListInstanceGroupsOutput `json:"-" xml:"-"`
 }
 
 type metadataListInstanceGroupsOutput struct {
@@ -1788,7 +1788,7 @@ type ListInstancesInput struct {
 	// The pagination token that indicates the next set of results to retrieve.
 	Marker *string `type:"string"`
 
-	metadataListInstancesInput `json:"-", xml:"-"`
+	metadataListInstancesInput `json:"-" xml:"-"`
 }
 
 type metadataListInstancesInput struct {
@@ -1803,7 +1803,7 @@ type ListInstancesOutput struct {
 	// The pagination token that indicates the next set of results to retrieve.
 	Marker *string `type:"string"`
 
-	metadataListInstancesOutput `json:"-", xml:"-"`
+	metadataListInstancesOutput `json:"-" xml:"-"`
 }
 
 type metadataListInstancesOutput struct {
@@ -1824,7 +1824,7 @@ type ListStepsInput struct {
 	// The filter to limit the step list based on certain states.
 	StepStates []*string `type:"list"`
 
-	metadataListStepsInput `json:"-", xml:"-"`
+	metadataListStepsInput `json:"-" xml:"-"`
 }
 
 type metadataListStepsInput struct {
@@ -1839,7 +1839,7 @@ type ListStepsOutput struct {
 	// The filtered list of steps for the cluster.
 	Steps []*StepSummary `type:"list"`
 
-	metadataListStepsOutput `json:"-", xml:"-"`
+	metadataListStepsOutput `json:"-" xml:"-"`
 }
 
 type metadataListStepsOutput struct {
@@ -1851,7 +1851,7 @@ type ModifyInstanceGroupsInput struct {
 	// Instance groups to change.
 	InstanceGroups []*InstanceGroupModifyConfig `type:"list"`
 
-	metadataModifyInstanceGroupsInput `json:"-", xml:"-"`
+	metadataModifyInstanceGroupsInput `json:"-" xml:"-"`
 }
 
 type metadataModifyInstanceGroupsInput struct {
@@ -1859,7 +1859,7 @@ type metadataModifyInstanceGroupsInput struct {
 }
 
 type ModifyInstanceGroupsOutput struct {
-	metadataModifyInstanceGroupsOutput `json:"-", xml:"-"`
+	metadataModifyInstanceGroupsOutput `json:"-" xml:"-"`
 }
 
 type metadataModifyInstanceGroupsOutput struct {
@@ -1871,7 +1871,7 @@ type PlacementType struct {
 	// The Amazon EC2 Availability Zone for the job flow.
 	AvailabilityZone *string `type:"string" required:"true"`
 
-	metadataPlacementType `json:"-", xml:"-"`
+	metadataPlacementType `json:"-" xml:"-"`
 }
 
 type metadataPlacementType struct {
@@ -1887,7 +1887,7 @@ type RemoveTagsInput struct {
 	// A list of tag keys to remove from a resource.
 	TagKeys []*string `type:"list" required:"true"`
 
-	metadataRemoveTagsInput `json:"-", xml:"-"`
+	metadataRemoveTagsInput `json:"-" xml:"-"`
 }
 
 type metadataRemoveTagsInput struct {
@@ -1896,7 +1896,7 @@ type metadataRemoveTagsInput struct {
 
 // This output indicates the result of removing tags from a resource.
 type RemoveTagsOutput struct {
-	metadataRemoveTagsOutput `json:"-", xml:"-"`
+	metadataRemoveTagsOutput `json:"-" xml:"-"`
 }
 
 type metadataRemoveTagsOutput struct {
@@ -1981,7 +1981,7 @@ type RunJobFlowInput struct {
 	// flow can view and manage it.
 	VisibleToAllUsers *bool `type:"boolean"`
 
-	metadataRunJobFlowInput `json:"-", xml:"-"`
+	metadataRunJobFlowInput `json:"-" xml:"-"`
 }
 
 type metadataRunJobFlowInput struct {
@@ -1993,7 +1993,7 @@ type RunJobFlowOutput struct {
 	// An unique identifier for the job flow.
 	JobFlowID *string `locationName:"JobFlowId" type:"string"`
 
-	metadataRunJobFlowOutput `json:"-", xml:"-"`
+	metadataRunJobFlowOutput `json:"-" xml:"-"`
 }
 
 type metadataRunJobFlowOutput struct {
@@ -2009,7 +2009,7 @@ type ScriptBootstrapActionConfig struct {
 	// location in Amazon S3 or on a local file system.
 	Path *string `type:"string" required:"true"`
 
-	metadataScriptBootstrapActionConfig `json:"-", xml:"-"`
+	metadataScriptBootstrapActionConfig `json:"-" xml:"-"`
 }
 
 type metadataScriptBootstrapActionConfig struct {
@@ -2028,7 +2028,7 @@ type SetTerminationProtectionInput struct {
 	// user intervention, or job-flow error.
 	TerminationProtected *bool `type:"boolean" required:"true"`
 
-	metadataSetTerminationProtectionInput `json:"-", xml:"-"`
+	metadataSetTerminationProtectionInput `json:"-" xml:"-"`
 }
 
 type metadataSetTerminationProtectionInput struct {
@@ -2036,7 +2036,7 @@ type metadataSetTerminationProtectionInput struct {
 }
 
 type SetTerminationProtectionOutput struct {
-	metadataSetTerminationProtectionOutput `json:"-", xml:"-"`
+	metadataSetTerminationProtectionOutput `json:"-" xml:"-"`
 }
 
 type metadataSetTerminationProtectionOutput struct {
@@ -2055,7 +2055,7 @@ type SetVisibleToAllUsersInput struct {
 	// created a job flow can view and manage it.
 	VisibleToAllUsers *bool `type:"boolean" required:"true"`
 
-	metadataSetVisibleToAllUsersInput `json:"-", xml:"-"`
+	metadataSetVisibleToAllUsersInput `json:"-" xml:"-"`
 }
 
 type metadataSetVisibleToAllUsersInput struct {
@@ -2063,7 +2063,7 @@ type metadataSetVisibleToAllUsersInput struct {
 }
 
 type SetVisibleToAllUsersOutput struct {
-	metadataSetVisibleToAllUsersOutput `json:"-", xml:"-"`
+	metadataSetVisibleToAllUsersOutput `json:"-" xml:"-"`
 }
 
 type metadataSetVisibleToAllUsersOutput struct {
@@ -2088,7 +2088,7 @@ type Step struct {
 	// The current execution status details of the cluster step.
 	Status *StepStatus `type:"structure"`
 
-	metadataStep `json:"-", xml:"-"`
+	metadataStep `json:"-" xml:"-"`
 }
 
 type metadataStep struct {
@@ -2106,7 +2106,7 @@ type StepConfig struct {
 	// The name of the job flow step.
 	Name *string `type:"string" required:"true"`
 
-	metadataStepConfig `json:"-", xml:"-"`
+	metadataStepConfig `json:"-" xml:"-"`
 }
 
 type metadataStepConfig struct {
@@ -2121,7 +2121,7 @@ type StepDetail struct {
 	// The step configuration.
 	StepConfig *StepConfig `type:"structure" required:"true"`
 
-	metadataStepDetail `json:"-", xml:"-"`
+	metadataStepDetail `json:"-" xml:"-"`
 }
 
 type metadataStepDetail struct {
@@ -2145,7 +2145,7 @@ type StepExecutionStatusDetail struct {
 	// The state of the job flow step.
 	State *string `type:"string" required:"true"`
 
-	metadataStepExecutionStatusDetail `json:"-", xml:"-"`
+	metadataStepExecutionStatusDetail `json:"-" xml:"-"`
 }
 
 type metadataStepExecutionStatusDetail struct {
@@ -2160,7 +2160,7 @@ type StepStateChangeReason struct {
 	// The descriptive message for the state change reason.
 	Message *string `type:"string"`
 
-	metadataStepStateChangeReason `json:"-", xml:"-"`
+	metadataStepStateChangeReason `json:"-" xml:"-"`
 }
 
 type metadataStepStateChangeReason struct {
@@ -2178,7 +2178,7 @@ type StepStatus struct {
 	// The timeline of the cluster step status over time.
 	Timeline *StepTimeline `type:"structure"`
 
-	metadataStepStatus `json:"-", xml:"-"`
+	metadataStepStatus `json:"-" xml:"-"`
 }
 
 type metadataStepStatus struct {
@@ -2203,7 +2203,7 @@ type StepSummary struct {
 	// The current execution status details of the cluster step.
 	Status *StepStatus `type:"structure"`
 
-	metadataStepSummary `json:"-", xml:"-"`
+	metadataStepSummary `json:"-" xml:"-"`
 }
 
 type metadataStepSummary struct {
@@ -2221,7 +2221,7 @@ type StepTimeline struct {
 	// The date and time when the cluster step execution started.
 	StartDateTime *time.Time `type:"timestamp" timestampFormat:"unix"`
 
-	metadataStepTimeline `json:"-", xml:"-"`
+	metadataStepTimeline `json:"-" xml:"-"`
 }
 
 type metadataStepTimeline struct {
@@ -2238,7 +2238,7 @@ type SupportedProductConfig struct {
 	// The name of the product configuration.
 	Name *string `type:"string"`
 
-	metadataSupportedProductConfig `json:"-", xml:"-"`
+	metadataSupportedProductConfig `json:"-" xml:"-"`
 }
 
 type metadataSupportedProductConfig struct {
@@ -2259,7 +2259,7 @@ type Tag struct {
 	// Tagging Amazon EMR Resources (http://docs.aws.amazon.com/ElasticMapReduce/latest/DeveloperGuide/emr-plan-tags.html).
 	Value *string `type:"string"`
 
-	metadataTag `json:"-", xml:"-"`
+	metadataTag `json:"-" xml:"-"`
 }
 
 type metadataTag struct {
@@ -2271,7 +2271,7 @@ type TerminateJobFlowsInput struct {
 	// A list of job flows to be shutdown.
 	JobFlowIDs []*string `locationName:"JobFlowIds" type:"list" required:"true"`
 
-	metadataTerminateJobFlowsInput `json:"-", xml:"-"`
+	metadataTerminateJobFlowsInput `json:"-" xml:"-"`
 }
 
 type metadataTerminateJobFlowsInput struct {
@@ -2279,7 +2279,7 @@ type metadataTerminateJobFlowsInput struct {
 }
 
 type TerminateJobFlowsOutput struct {
-	metadataTerminateJobFlowsOutput `json:"-", xml:"-"`
+	metadataTerminateJobFlowsOutput `json:"-" xml:"-"`
 }
 
 type metadataTerminateJobFlowsOutput struct {

--- a/service/glacier/api.go
+++ b/service/glacier/api.go
@@ -1324,7 +1324,7 @@ type AbortMultipartUploadInput struct {
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataAbortMultipartUploadInput `json:"-", xml:"-"`
+	metadataAbortMultipartUploadInput `json:"-" xml:"-"`
 }
 
 type metadataAbortMultipartUploadInput struct {
@@ -1332,7 +1332,7 @@ type metadataAbortMultipartUploadInput struct {
 }
 
 type AbortMultipartUploadOutput struct {
-	metadataAbortMultipartUploadOutput `json:"-", xml:"-"`
+	metadataAbortMultipartUploadOutput `json:"-" xml:"-"`
 }
 
 type metadataAbortMultipartUploadOutput struct {
@@ -1354,7 +1354,7 @@ type ArchiveCreationOutput struct {
 	// The relative URI path of the newly added archive resource.
 	Location *string `location:"header" locationName:"Location" type:"string"`
 
-	metadataArchiveCreationOutput `json:"-", xml:"-"`
+	metadataArchiveCreationOutput `json:"-" xml:"-"`
 }
 
 type metadataArchiveCreationOutput struct {
@@ -1389,7 +1389,7 @@ type CompleteMultipartUploadInput struct {
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataCompleteMultipartUploadInput `json:"-", xml:"-"`
+	metadataCompleteMultipartUploadInput `json:"-" xml:"-"`
 }
 
 type metadataCompleteMultipartUploadInput struct {
@@ -1407,7 +1407,7 @@ type CreateVaultInput struct {
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataCreateVaultInput `json:"-", xml:"-"`
+	metadataCreateVaultInput `json:"-" xml:"-"`
 }
 
 type metadataCreateVaultInput struct {
@@ -1419,7 +1419,7 @@ type CreateVaultOutput struct {
 	// The URI of the vault that was created.
 	Location *string `location:"header" locationName:"Location" type:"string"`
 
-	metadataCreateVaultOutput `json:"-", xml:"-"`
+	metadataCreateVaultOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateVaultOutput struct {
@@ -1429,7 +1429,7 @@ type metadataCreateVaultOutput struct {
 type DataRetrievalPolicy struct {
 	Rules []*DataRetrievalRule `type:"list"`
 
-	metadataDataRetrievalPolicy `json:"-", xml:"-"`
+	metadataDataRetrievalPolicy `json:"-" xml:"-"`
 }
 
 type metadataDataRetrievalPolicy struct {
@@ -1441,7 +1441,7 @@ type DataRetrievalRule struct {
 
 	Strategy *string `type:"string"`
 
-	metadataDataRetrievalRule `json:"-", xml:"-"`
+	metadataDataRetrievalRule `json:"-" xml:"-"`
 }
 
 type metadataDataRetrievalRule struct {
@@ -1462,7 +1462,7 @@ type DeleteArchiveInput struct {
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataDeleteArchiveInput `json:"-", xml:"-"`
+	metadataDeleteArchiveInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteArchiveInput struct {
@@ -1470,7 +1470,7 @@ type metadataDeleteArchiveInput struct {
 }
 
 type DeleteArchiveOutput struct {
-	metadataDeleteArchiveOutput `json:"-", xml:"-"`
+	metadataDeleteArchiveOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteArchiveOutput struct {
@@ -1488,7 +1488,7 @@ type DeleteVaultInput struct {
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataDeleteVaultInput `json:"-", xml:"-"`
+	metadataDeleteVaultInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteVaultInput struct {
@@ -1507,7 +1507,7 @@ type DeleteVaultNotificationsInput struct {
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataDeleteVaultNotificationsInput `json:"-", xml:"-"`
+	metadataDeleteVaultNotificationsInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteVaultNotificationsInput struct {
@@ -1515,7 +1515,7 @@ type metadataDeleteVaultNotificationsInput struct {
 }
 
 type DeleteVaultNotificationsOutput struct {
-	metadataDeleteVaultNotificationsOutput `json:"-", xml:"-"`
+	metadataDeleteVaultNotificationsOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteVaultNotificationsOutput struct {
@@ -1523,7 +1523,7 @@ type metadataDeleteVaultNotificationsOutput struct {
 }
 
 type DeleteVaultOutput struct {
-	metadataDeleteVaultOutput `json:"-", xml:"-"`
+	metadataDeleteVaultOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteVaultOutput struct {
@@ -1544,7 +1544,7 @@ type DescribeJobInput struct {
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataDescribeJobInput `json:"-", xml:"-"`
+	metadataDescribeJobInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeJobInput struct {
@@ -1562,7 +1562,7 @@ type DescribeVaultInput struct {
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataDescribeVaultInput `json:"-", xml:"-"`
+	metadataDescribeVaultInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeVaultInput struct {
@@ -1595,7 +1595,7 @@ type DescribeVaultOutput struct {
 	// The name of the vault.
 	VaultName *string `type:"string"`
 
-	metadataDescribeVaultOutput `json:"-", xml:"-"`
+	metadataDescribeVaultOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeVaultOutput struct {
@@ -1605,7 +1605,7 @@ type metadataDescribeVaultOutput struct {
 type GetDataRetrievalPolicyInput struct {
 	AccountID *string `location:"uri" locationName:"accountId" type:"string" required:"true"`
 
-	metadataGetDataRetrievalPolicyInput `json:"-", xml:"-"`
+	metadataGetDataRetrievalPolicyInput `json:"-" xml:"-"`
 }
 
 type metadataGetDataRetrievalPolicyInput struct {
@@ -1615,7 +1615,7 @@ type metadataGetDataRetrievalPolicyInput struct {
 type GetDataRetrievalPolicyOutput struct {
 	Policy *DataRetrievalPolicy `type:"structure"`
 
-	metadataGetDataRetrievalPolicyOutput `json:"-", xml:"-"`
+	metadataGetDataRetrievalPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataGetDataRetrievalPolicyOutput struct {
@@ -1641,7 +1641,7 @@ type GetJobOutputInput struct {
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataGetJobOutputInput `json:"-", xml:"-"`
+	metadataGetJobOutputInput `json:"-" xml:"-"`
 }
 
 type metadataGetJobOutputInput struct {
@@ -1688,7 +1688,7 @@ type GetJobOutputOutput struct {
 	// a range was specified in the request.
 	Status *int64 `location:"statusCode" locationName:"status" type:"integer"`
 
-	metadataGetJobOutputOutput `json:"-", xml:"-"`
+	metadataGetJobOutputOutput `json:"-" xml:"-"`
 }
 
 type metadataGetJobOutputOutput struct {
@@ -1707,7 +1707,7 @@ type GetVaultNotificationsInput struct {
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataGetVaultNotificationsInput `json:"-", xml:"-"`
+	metadataGetVaultNotificationsInput `json:"-" xml:"-"`
 }
 
 type metadataGetVaultNotificationsInput struct {
@@ -1719,7 +1719,7 @@ type GetVaultNotificationsOutput struct {
 	// Returns the notification configuration set on the vault.
 	VaultNotificationConfig *VaultNotificationConfig `locationName:"vaultNotificationConfig" type:"structure"`
 
-	metadataGetVaultNotificationsOutput `json:"-", xml:"-"`
+	metadataGetVaultNotificationsOutput `json:"-" xml:"-"`
 }
 
 type metadataGetVaultNotificationsOutput struct {
@@ -1806,7 +1806,7 @@ type GlacierJobDescription struct {
 	// was requested.
 	VaultARN *string `type:"string"`
 
-	metadataGlacierJobDescription `json:"-", xml:"-"`
+	metadataGlacierJobDescription `json:"-" xml:"-"`
 }
 
 type metadataGlacierJobDescription struct {
@@ -1827,7 +1827,7 @@ type InitiateJobInput struct {
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataInitiateJobInput `json:"-", xml:"-"`
+	metadataInitiateJobInput `json:"-" xml:"-"`
 }
 
 type metadataInitiateJobInput struct {
@@ -1842,7 +1842,7 @@ type InitiateJobOutput struct {
 	// The relative URI path of the job.
 	Location *string `location:"header" locationName:"Location" type:"string"`
 
-	metadataInitiateJobOutput `json:"-", xml:"-"`
+	metadataInitiateJobOutput `json:"-" xml:"-"`
 }
 
 type metadataInitiateJobOutput struct {
@@ -1872,7 +1872,7 @@ type InitiateMultipartUploadInput struct {
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataInitiateMultipartUploadInput `json:"-", xml:"-"`
+	metadataInitiateMultipartUploadInput `json:"-" xml:"-"`
 }
 
 type metadataInitiateMultipartUploadInput struct {
@@ -1888,7 +1888,7 @@ type InitiateMultipartUploadOutput struct {
 	// location.
 	UploadID *string `location:"header" locationName:"x-amz-multipart-upload-id" type:"string"`
 
-	metadataInitiateMultipartUploadOutput `json:"-", xml:"-"`
+	metadataInitiateMultipartUploadOutput `json:"-" xml:"-"`
 }
 
 type metadataInitiateMultipartUploadOutput struct {
@@ -1924,7 +1924,7 @@ type InventoryRetrievalJobDescription struct {
 	// date format, for example, 2013-03-20T17:03:43Z.
 	StartDate *string `type:"string"`
 
-	metadataInventoryRetrievalJobDescription `json:"-", xml:"-"`
+	metadataInventoryRetrievalJobDescription `json:"-" xml:"-"`
 }
 
 type metadataInventoryRetrievalJobDescription struct {
@@ -1953,7 +1953,7 @@ type InventoryRetrievalJobInput struct {
 	// date format, for example, 2013-03-20T17:03:43Z.
 	StartDate *string `type:"string"`
 
-	metadataInventoryRetrievalJobInput `json:"-", xml:"-"`
+	metadataInventoryRetrievalJobInput `json:"-" xml:"-"`
 }
 
 type metadataInventoryRetrievalJobInput struct {
@@ -2002,7 +2002,7 @@ type JobParameters struct {
 	// of a vault. Valid values are "archive-retrieval" and "inventory-retrieval".
 	Type *string `type:"string"`
 
-	metadataJobParameters `json:"-", xml:"-"`
+	metadataJobParameters `json:"-" xml:"-"`
 }
 
 type metadataJobParameters struct {
@@ -2037,7 +2037,7 @@ type ListJobsInput struct {
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataListJobsInput `json:"-", xml:"-"`
+	metadataListJobsInput `json:"-" xml:"-"`
 }
 
 type metadataListJobsInput struct {
@@ -2054,7 +2054,7 @@ type ListJobsOutput struct {
 	// list. If there are no more jobs, this value is null.
 	Marker *string `type:"string"`
 
-	metadataListJobsOutput `json:"-", xml:"-"`
+	metadataListJobsOutput `json:"-" xml:"-"`
 }
 
 type metadataListJobsOutput struct {
@@ -2084,7 +2084,7 @@ type ListMultipartUploadsInput struct {
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataListMultipartUploadsInput `json:"-", xml:"-"`
+	metadataListMultipartUploadsInput `json:"-" xml:"-"`
 }
 
 type metadataListMultipartUploadsInput struct {
@@ -2101,7 +2101,7 @@ type ListMultipartUploadsOutput struct {
 	// A list of in-progress multipart uploads.
 	UploadsList []*UploadListElement `type:"list"`
 
-	metadataListMultipartUploadsOutput `json:"-", xml:"-"`
+	metadataListMultipartUploadsOutput `json:"-" xml:"-"`
 }
 
 type metadataListMultipartUploadsOutput struct {
@@ -2134,7 +2134,7 @@ type ListPartsInput struct {
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataListPartsInput `json:"-", xml:"-"`
+	metadataListPartsInput `json:"-" xml:"-"`
 }
 
 type metadataListPartsInput struct {
@@ -2168,7 +2168,7 @@ type ListPartsOutput struct {
 	// was initiated.
 	VaultARN *string `type:"string"`
 
-	metadataListPartsOutput `json:"-", xml:"-"`
+	metadataListPartsOutput `json:"-" xml:"-"`
 }
 
 type metadataListPartsOutput struct {
@@ -2192,7 +2192,7 @@ type ListVaultsInput struct {
 	// the listing of vaults should begin.
 	Marker *string `location:"querystring" locationName:"marker" type:"string"`
 
-	metadataListVaultsInput `json:"-", xml:"-"`
+	metadataListVaultsInput `json:"-" xml:"-"`
 }
 
 type metadataListVaultsInput struct {
@@ -2208,7 +2208,7 @@ type ListVaultsOutput struct {
 	// List of vaults.
 	VaultList []*DescribeVaultOutput `type:"list"`
 
-	metadataListVaultsOutput `json:"-", xml:"-"`
+	metadataListVaultsOutput `json:"-" xml:"-"`
 }
 
 type metadataListVaultsOutput struct {
@@ -2224,7 +2224,7 @@ type PartListElement struct {
 	// field is never null.
 	SHA256TreeHash *string `type:"string"`
 
-	metadataPartListElement `json:"-", xml:"-"`
+	metadataPartListElement `json:"-" xml:"-"`
 }
 
 type metadataPartListElement struct {
@@ -2236,7 +2236,7 @@ type SetDataRetrievalPolicyInput struct {
 
 	Policy *DataRetrievalPolicy `type:"structure"`
 
-	metadataSetDataRetrievalPolicyInput `json:"-", xml:"-"`
+	metadataSetDataRetrievalPolicyInput `json:"-" xml:"-"`
 }
 
 type metadataSetDataRetrievalPolicyInput struct {
@@ -2244,7 +2244,7 @@ type metadataSetDataRetrievalPolicyInput struct {
 }
 
 type SetDataRetrievalPolicyOutput struct {
-	metadataSetDataRetrievalPolicyOutput `json:"-", xml:"-"`
+	metadataSetDataRetrievalPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataSetDataRetrievalPolicyOutput struct {
@@ -2266,7 +2266,7 @@ type SetVaultNotificationsInput struct {
 	// Provides options for specifying notification configuration.
 	VaultNotificationConfig *VaultNotificationConfig `locationName:"vaultNotificationConfig" type:"structure"`
 
-	metadataSetVaultNotificationsInput `json:"-", xml:"-"`
+	metadataSetVaultNotificationsInput `json:"-" xml:"-"`
 }
 
 type metadataSetVaultNotificationsInput struct {
@@ -2274,7 +2274,7 @@ type metadataSetVaultNotificationsInput struct {
 }
 
 type SetVaultNotificationsOutput struct {
-	metadataSetVaultNotificationsOutput `json:"-", xml:"-"`
+	metadataSetVaultNotificationsOutput `json:"-" xml:"-"`
 }
 
 type metadataSetVaultNotificationsOutput struct {
@@ -2301,7 +2301,7 @@ type UploadArchiveInput struct {
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataUploadArchiveInput `json:"-", xml:"-"`
+	metadataUploadArchiveInput `json:"-" xml:"-"`
 }
 
 type metadataUploadArchiveInput struct {
@@ -2328,7 +2328,7 @@ type UploadListElement struct {
 	// The Amazon Resource Name (ARN) of the vault that contains the archive.
 	VaultARN *string `type:"string"`
 
-	metadataUploadListElement `json:"-", xml:"-"`
+	metadataUploadListElement `json:"-" xml:"-"`
 }
 
 type metadataUploadListElement struct {
@@ -2361,7 +2361,7 @@ type UploadMultipartPartInput struct {
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataUploadMultipartPartInput `json:"-", xml:"-"`
+	metadataUploadMultipartPartInput `json:"-" xml:"-"`
 }
 
 type metadataUploadMultipartPartInput struct {
@@ -2373,7 +2373,7 @@ type UploadMultipartPartOutput struct {
 	// The SHA256 tree hash that Amazon Glacier computed for the uploaded part.
 	Checksum *string `location:"header" locationName:"x-amz-sha256-tree-hash" type:"string"`
 
-	metadataUploadMultipartPartOutput `json:"-", xml:"-"`
+	metadataUploadMultipartPartOutput `json:"-" xml:"-"`
 }
 
 type metadataUploadMultipartPartOutput struct {
@@ -2390,7 +2390,7 @@ type VaultNotificationConfig struct {
 	// Name (ARN).
 	SNSTopic *string `type:"string"`
 
-	metadataVaultNotificationConfig `json:"-", xml:"-"`
+	metadataVaultNotificationConfig `json:"-" xml:"-"`
 }
 
 type metadataVaultNotificationConfig struct {

--- a/service/iam/api.go
+++ b/service/iam/api.go
@@ -4170,7 +4170,7 @@ type AccessKey struct {
 	// The name of the IAM user that the access key is associated with.
 	UserName *string `type:"string" required:"true"`
 
-	metadataAccessKey `json:"-", xml:"-"`
+	metadataAccessKey `json:"-" xml:"-"`
 }
 
 type metadataAccessKey struct {
@@ -4196,7 +4196,7 @@ type AccessKeyLastUsed struct {
 	// used.
 	ServiceName *string `type:"string" required:"true"`
 
-	metadataAccessKeyLastUsed `json:"-", xml:"-"`
+	metadataAccessKeyLastUsed `json:"-" xml:"-"`
 }
 
 type metadataAccessKeyLastUsed struct {
@@ -4220,7 +4220,7 @@ type AccessKeyMetadata struct {
 	// The name of the IAM user that the key is associated with.
 	UserName *string `type:"string"`
 
-	metadataAccessKeyMetadata `json:"-", xml:"-"`
+	metadataAccessKeyMetadata `json:"-" xml:"-"`
 }
 
 type metadataAccessKeyMetadata struct {
@@ -4236,7 +4236,7 @@ type AddClientIDToOpenIDConnectProviderInput struct {
 	// the ListOpenIDConnectProviders action.
 	OpenIDConnectProviderARN *string `locationName:"OpenIDConnectProviderArn" type:"string" required:"true"`
 
-	metadataAddClientIDToOpenIDConnectProviderInput `json:"-", xml:"-"`
+	metadataAddClientIDToOpenIDConnectProviderInput `json:"-" xml:"-"`
 }
 
 type metadataAddClientIDToOpenIDConnectProviderInput struct {
@@ -4244,7 +4244,7 @@ type metadataAddClientIDToOpenIDConnectProviderInput struct {
 }
 
 type AddClientIDToOpenIDConnectProviderOutput struct {
-	metadataAddClientIDToOpenIDConnectProviderOutput `json:"-", xml:"-"`
+	metadataAddClientIDToOpenIDConnectProviderOutput `json:"-" xml:"-"`
 }
 
 type metadataAddClientIDToOpenIDConnectProviderOutput struct {
@@ -4258,7 +4258,7 @@ type AddRoleToInstanceProfileInput struct {
 	// The name of the role to add.
 	RoleName *string `type:"string" required:"true"`
 
-	metadataAddRoleToInstanceProfileInput `json:"-", xml:"-"`
+	metadataAddRoleToInstanceProfileInput `json:"-" xml:"-"`
 }
 
 type metadataAddRoleToInstanceProfileInput struct {
@@ -4266,7 +4266,7 @@ type metadataAddRoleToInstanceProfileInput struct {
 }
 
 type AddRoleToInstanceProfileOutput struct {
-	metadataAddRoleToInstanceProfileOutput `json:"-", xml:"-"`
+	metadataAddRoleToInstanceProfileOutput `json:"-" xml:"-"`
 }
 
 type metadataAddRoleToInstanceProfileOutput struct {
@@ -4280,7 +4280,7 @@ type AddUserToGroupInput struct {
 	// The name of the user to add.
 	UserName *string `type:"string" required:"true"`
 
-	metadataAddUserToGroupInput `json:"-", xml:"-"`
+	metadataAddUserToGroupInput `json:"-" xml:"-"`
 }
 
 type metadataAddUserToGroupInput struct {
@@ -4288,7 +4288,7 @@ type metadataAddUserToGroupInput struct {
 }
 
 type AddUserToGroupOutput struct {
-	metadataAddUserToGroupOutput `json:"-", xml:"-"`
+	metadataAddUserToGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataAddUserToGroupOutput struct {
@@ -4306,7 +4306,7 @@ type AttachGroupPolicyInput struct {
 	// in the AWS General Reference.
 	PolicyARN *string `locationName:"PolicyArn" type:"string" required:"true"`
 
-	metadataAttachGroupPolicyInput `json:"-", xml:"-"`
+	metadataAttachGroupPolicyInput `json:"-" xml:"-"`
 }
 
 type metadataAttachGroupPolicyInput struct {
@@ -4314,7 +4314,7 @@ type metadataAttachGroupPolicyInput struct {
 }
 
 type AttachGroupPolicyOutput struct {
-	metadataAttachGroupPolicyOutput `json:"-", xml:"-"`
+	metadataAttachGroupPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataAttachGroupPolicyOutput struct {
@@ -4332,7 +4332,7 @@ type AttachRolePolicyInput struct {
 	// The name (friendly name, not ARN) of the role to attach the policy to.
 	RoleName *string `type:"string" required:"true"`
 
-	metadataAttachRolePolicyInput `json:"-", xml:"-"`
+	metadataAttachRolePolicyInput `json:"-" xml:"-"`
 }
 
 type metadataAttachRolePolicyInput struct {
@@ -4340,7 +4340,7 @@ type metadataAttachRolePolicyInput struct {
 }
 
 type AttachRolePolicyOutput struct {
-	metadataAttachRolePolicyOutput `json:"-", xml:"-"`
+	metadataAttachRolePolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataAttachRolePolicyOutput struct {
@@ -4358,7 +4358,7 @@ type AttachUserPolicyInput struct {
 	// The name (friendly name, not ARN) of the user to attach the policy to.
 	UserName *string `type:"string" required:"true"`
 
-	metadataAttachUserPolicyInput `json:"-", xml:"-"`
+	metadataAttachUserPolicyInput `json:"-" xml:"-"`
 }
 
 type metadataAttachUserPolicyInput struct {
@@ -4366,7 +4366,7 @@ type metadataAttachUserPolicyInput struct {
 }
 
 type AttachUserPolicyOutput struct {
-	metadataAttachUserPolicyOutput `json:"-", xml:"-"`
+	metadataAttachUserPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataAttachUserPolicyOutput struct {
@@ -4394,7 +4394,7 @@ type AttachedPolicy struct {
 	// The friendly name of the attached policy.
 	PolicyName *string `type:"string"`
 
-	metadataAttachedPolicy `json:"-", xml:"-"`
+	metadataAttachedPolicy `json:"-" xml:"-"`
 }
 
 type metadataAttachedPolicy struct {
@@ -4409,7 +4409,7 @@ type ChangePasswordInput struct {
 	// The IAM user's current password.
 	OldPassword *string `type:"string" required:"true"`
 
-	metadataChangePasswordInput `json:"-", xml:"-"`
+	metadataChangePasswordInput `json:"-" xml:"-"`
 }
 
 type metadataChangePasswordInput struct {
@@ -4417,7 +4417,7 @@ type metadataChangePasswordInput struct {
 }
 
 type ChangePasswordOutput struct {
-	metadataChangePasswordOutput `json:"-", xml:"-"`
+	metadataChangePasswordOutput `json:"-" xml:"-"`
 }
 
 type metadataChangePasswordOutput struct {
@@ -4428,7 +4428,7 @@ type CreateAccessKeyInput struct {
 	// The user name that the new key will belong to.
 	UserName *string `type:"string"`
 
-	metadataCreateAccessKeyInput `json:"-", xml:"-"`
+	metadataCreateAccessKeyInput `json:"-" xml:"-"`
 }
 
 type metadataCreateAccessKeyInput struct {
@@ -4440,7 +4440,7 @@ type CreateAccessKeyOutput struct {
 	// Information about the access key.
 	AccessKey *AccessKey `type:"structure" required:"true"`
 
-	metadataCreateAccessKeyOutput `json:"-", xml:"-"`
+	metadataCreateAccessKeyOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateAccessKeyOutput struct {
@@ -4451,7 +4451,7 @@ type CreateAccountAliasInput struct {
 	// The account alias to create.
 	AccountAlias *string `type:"string" required:"true"`
 
-	metadataCreateAccountAliasInput `json:"-", xml:"-"`
+	metadataCreateAccountAliasInput `json:"-" xml:"-"`
 }
 
 type metadataCreateAccountAliasInput struct {
@@ -4459,7 +4459,7 @@ type metadataCreateAccountAliasInput struct {
 }
 
 type CreateAccountAliasOutput struct {
-	metadataCreateAccountAliasOutput `json:"-", xml:"-"`
+	metadataCreateAccountAliasOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateAccountAliasOutput struct {
@@ -4478,7 +4478,7 @@ type CreateGroupInput struct {
 	// (/).
 	Path *string `type:"string"`
 
-	metadataCreateGroupInput `json:"-", xml:"-"`
+	metadataCreateGroupInput `json:"-" xml:"-"`
 }
 
 type metadataCreateGroupInput struct {
@@ -4490,7 +4490,7 @@ type CreateGroupOutput struct {
 	// Information about the group.
 	Group *Group `type:"structure" required:"true"`
 
-	metadataCreateGroupOutput `json:"-", xml:"-"`
+	metadataCreateGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateGroupOutput struct {
@@ -4509,7 +4509,7 @@ type CreateInstanceProfileInput struct {
 	// (/).
 	Path *string `type:"string"`
 
-	metadataCreateInstanceProfileInput `json:"-", xml:"-"`
+	metadataCreateInstanceProfileInput `json:"-" xml:"-"`
 }
 
 type metadataCreateInstanceProfileInput struct {
@@ -4521,7 +4521,7 @@ type CreateInstanceProfileOutput struct {
 	// Information about the instance profile.
 	InstanceProfile *InstanceProfile `type:"structure" required:"true"`
 
-	metadataCreateInstanceProfileOutput `json:"-", xml:"-"`
+	metadataCreateInstanceProfileOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateInstanceProfileOutput struct {
@@ -4538,7 +4538,7 @@ type CreateLoginProfileInput struct {
 	// The name of the user to create a password for.
 	UserName *string `type:"string" required:"true"`
 
-	metadataCreateLoginProfileInput `json:"-", xml:"-"`
+	metadataCreateLoginProfileInput `json:"-" xml:"-"`
 }
 
 type metadataCreateLoginProfileInput struct {
@@ -4550,7 +4550,7 @@ type CreateLoginProfileOutput struct {
 	// The user name and password create date.
 	LoginProfile *LoginProfile `type:"structure" required:"true"`
 
-	metadataCreateLoginProfileOutput `json:"-", xml:"-"`
+	metadataCreateLoginProfileOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateLoginProfileOutput struct {
@@ -4603,7 +4603,7 @@ type CreateOpenIDConnectProviderInput struct {
 	// provider in the AWS account, you will get an error.
 	URL *string `locationName:"Url" type:"string" required:"true"`
 
-	metadataCreateOpenIDConnectProviderInput `json:"-", xml:"-"`
+	metadataCreateOpenIDConnectProviderInput `json:"-" xml:"-"`
 }
 
 type metadataCreateOpenIDConnectProviderInput struct {
@@ -4616,7 +4616,7 @@ type CreateOpenIDConnectProviderOutput struct {
 	// created. For more information, see OpenIDConnectProviderListEntry.
 	OpenIDConnectProviderARN *string `locationName:"OpenIDConnectProviderArn" type:"string"`
 
-	metadataCreateOpenIDConnectProviderOutput `json:"-", xml:"-"`
+	metadataCreateOpenIDConnectProviderOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateOpenIDConnectProviderOutput struct {
@@ -4650,7 +4650,7 @@ type CreatePolicyInput struct {
 	// The name of the policy document.
 	PolicyName *string `type:"string" required:"true"`
 
-	metadataCreatePolicyInput `json:"-", xml:"-"`
+	metadataCreatePolicyInput `json:"-" xml:"-"`
 }
 
 type metadataCreatePolicyInput struct {
@@ -4662,7 +4662,7 @@ type CreatePolicyOutput struct {
 	// Information about the policy.
 	Policy *Policy `type:"structure"`
 
-	metadataCreatePolicyOutput `json:"-", xml:"-"`
+	metadataCreatePolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataCreatePolicyOutput struct {
@@ -4693,7 +4693,7 @@ type CreatePolicyVersionInput struct {
 	// in the Using IAM guide.
 	SetAsDefault *bool `type:"boolean"`
 
-	metadataCreatePolicyVersionInput `json:"-", xml:"-"`
+	metadataCreatePolicyVersionInput `json:"-" xml:"-"`
 }
 
 type metadataCreatePolicyVersionInput struct {
@@ -4705,7 +4705,7 @@ type CreatePolicyVersionOutput struct {
 	// Information about the policy version.
 	PolicyVersion *PolicyVersion `type:"structure"`
 
-	metadataCreatePolicyVersionOutput `json:"-", xml:"-"`
+	metadataCreatePolicyVersionOutput `json:"-" xml:"-"`
 }
 
 type metadataCreatePolicyVersionOutput struct {
@@ -4727,7 +4727,7 @@ type CreateRoleInput struct {
 	// The name of the role to create.
 	RoleName *string `type:"string" required:"true"`
 
-	metadataCreateRoleInput `json:"-", xml:"-"`
+	metadataCreateRoleInput `json:"-" xml:"-"`
 }
 
 type metadataCreateRoleInput struct {
@@ -4739,7 +4739,7 @@ type CreateRoleOutput struct {
 	// Information about the role.
 	Role *Role `type:"structure" required:"true"`
 
-	metadataCreateRoleOutput `json:"-", xml:"-"`
+	metadataCreateRoleOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateRoleOutput struct {
@@ -4761,7 +4761,7 @@ type CreateSAMLProviderInput struct {
 	// in the Using Temporary Security Credentials guide.
 	SAMLMetadataDocument *string `type:"string" required:"true"`
 
-	metadataCreateSAMLProviderInput `json:"-", xml:"-"`
+	metadataCreateSAMLProviderInput `json:"-" xml:"-"`
 }
 
 type metadataCreateSAMLProviderInput struct {
@@ -4773,7 +4773,7 @@ type CreateSAMLProviderOutput struct {
 	// The Amazon Resource Name (ARN) of the SAML provider.
 	SAMLProviderARN *string `locationName:"SAMLProviderArn" type:"string"`
 
-	metadataCreateSAMLProviderOutput `json:"-", xml:"-"`
+	metadataCreateSAMLProviderOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateSAMLProviderOutput struct {
@@ -4792,7 +4792,7 @@ type CreateUserInput struct {
 	// The name of the user to create.
 	UserName *string `type:"string" required:"true"`
 
-	metadataCreateUserInput `json:"-", xml:"-"`
+	metadataCreateUserInput `json:"-" xml:"-"`
 }
 
 type metadataCreateUserInput struct {
@@ -4804,7 +4804,7 @@ type CreateUserOutput struct {
 	// Information about the user.
 	User *User `type:"structure"`
 
-	metadataCreateUserOutput `json:"-", xml:"-"`
+	metadataCreateUserOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateUserOutput struct {
@@ -4824,7 +4824,7 @@ type CreateVirtualMFADeviceInput struct {
 	// virtual MFA device.
 	VirtualMFADeviceName *string `type:"string" required:"true"`
 
-	metadataCreateVirtualMFADeviceInput `json:"-", xml:"-"`
+	metadataCreateVirtualMFADeviceInput `json:"-" xml:"-"`
 }
 
 type metadataCreateVirtualMFADeviceInput struct {
@@ -4836,7 +4836,7 @@ type CreateVirtualMFADeviceOutput struct {
 	// A newly created virtual MFA device.
 	VirtualMFADevice *VirtualMFADevice `type:"structure" required:"true"`
 
-	metadataCreateVirtualMFADeviceOutput `json:"-", xml:"-"`
+	metadataCreateVirtualMFADeviceOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateVirtualMFADeviceOutput struct {
@@ -4851,7 +4851,7 @@ type DeactivateMFADeviceInput struct {
 	// The name of the user whose MFA device you want to deactivate.
 	UserName *string `type:"string" required:"true"`
 
-	metadataDeactivateMFADeviceInput `json:"-", xml:"-"`
+	metadataDeactivateMFADeviceInput `json:"-" xml:"-"`
 }
 
 type metadataDeactivateMFADeviceInput struct {
@@ -4859,7 +4859,7 @@ type metadataDeactivateMFADeviceInput struct {
 }
 
 type DeactivateMFADeviceOutput struct {
-	metadataDeactivateMFADeviceOutput `json:"-", xml:"-"`
+	metadataDeactivateMFADeviceOutput `json:"-" xml:"-"`
 }
 
 type metadataDeactivateMFADeviceOutput struct {
@@ -4874,7 +4874,7 @@ type DeleteAccessKeyInput struct {
 	// The name of the user whose key you want to delete.
 	UserName *string `type:"string"`
 
-	metadataDeleteAccessKeyInput `json:"-", xml:"-"`
+	metadataDeleteAccessKeyInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteAccessKeyInput struct {
@@ -4882,7 +4882,7 @@ type metadataDeleteAccessKeyInput struct {
 }
 
 type DeleteAccessKeyOutput struct {
-	metadataDeleteAccessKeyOutput `json:"-", xml:"-"`
+	metadataDeleteAccessKeyOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteAccessKeyOutput struct {
@@ -4893,7 +4893,7 @@ type DeleteAccountAliasInput struct {
 	// The name of the account alias to delete.
 	AccountAlias *string `type:"string" required:"true"`
 
-	metadataDeleteAccountAliasInput `json:"-", xml:"-"`
+	metadataDeleteAccountAliasInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteAccountAliasInput struct {
@@ -4901,7 +4901,7 @@ type metadataDeleteAccountAliasInput struct {
 }
 
 type DeleteAccountAliasOutput struct {
-	metadataDeleteAccountAliasOutput `json:"-", xml:"-"`
+	metadataDeleteAccountAliasOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteAccountAliasOutput struct {
@@ -4909,7 +4909,7 @@ type metadataDeleteAccountAliasOutput struct {
 }
 
 type DeleteAccountPasswordPolicyInput struct {
-	metadataDeleteAccountPasswordPolicyInput `json:"-", xml:"-"`
+	metadataDeleteAccountPasswordPolicyInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteAccountPasswordPolicyInput struct {
@@ -4917,7 +4917,7 @@ type metadataDeleteAccountPasswordPolicyInput struct {
 }
 
 type DeleteAccountPasswordPolicyOutput struct {
-	metadataDeleteAccountPasswordPolicyOutput `json:"-", xml:"-"`
+	metadataDeleteAccountPasswordPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteAccountPasswordPolicyOutput struct {
@@ -4928,7 +4928,7 @@ type DeleteGroupInput struct {
 	// The name of the group to delete.
 	GroupName *string `type:"string" required:"true"`
 
-	metadataDeleteGroupInput `json:"-", xml:"-"`
+	metadataDeleteGroupInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteGroupInput struct {
@@ -4936,7 +4936,7 @@ type metadataDeleteGroupInput struct {
 }
 
 type DeleteGroupOutput struct {
-	metadataDeleteGroupOutput `json:"-", xml:"-"`
+	metadataDeleteGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteGroupOutput struct {
@@ -4951,7 +4951,7 @@ type DeleteGroupPolicyInput struct {
 	// The name identifying the policy document to delete.
 	PolicyName *string `type:"string" required:"true"`
 
-	metadataDeleteGroupPolicyInput `json:"-", xml:"-"`
+	metadataDeleteGroupPolicyInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteGroupPolicyInput struct {
@@ -4959,7 +4959,7 @@ type metadataDeleteGroupPolicyInput struct {
 }
 
 type DeleteGroupPolicyOutput struct {
-	metadataDeleteGroupPolicyOutput `json:"-", xml:"-"`
+	metadataDeleteGroupPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteGroupPolicyOutput struct {
@@ -4970,7 +4970,7 @@ type DeleteInstanceProfileInput struct {
 	// The name of the instance profile to delete.
 	InstanceProfileName *string `type:"string" required:"true"`
 
-	metadataDeleteInstanceProfileInput `json:"-", xml:"-"`
+	metadataDeleteInstanceProfileInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteInstanceProfileInput struct {
@@ -4978,7 +4978,7 @@ type metadataDeleteInstanceProfileInput struct {
 }
 
 type DeleteInstanceProfileOutput struct {
-	metadataDeleteInstanceProfileOutput `json:"-", xml:"-"`
+	metadataDeleteInstanceProfileOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteInstanceProfileOutput struct {
@@ -4989,7 +4989,7 @@ type DeleteLoginProfileInput struct {
 	// The name of the user whose password you want to delete.
 	UserName *string `type:"string" required:"true"`
 
-	metadataDeleteLoginProfileInput `json:"-", xml:"-"`
+	metadataDeleteLoginProfileInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteLoginProfileInput struct {
@@ -4997,7 +4997,7 @@ type metadataDeleteLoginProfileInput struct {
 }
 
 type DeleteLoginProfileOutput struct {
-	metadataDeleteLoginProfileOutput `json:"-", xml:"-"`
+	metadataDeleteLoginProfileOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteLoginProfileOutput struct {
@@ -5010,7 +5010,7 @@ type DeleteOpenIDConnectProviderInput struct {
 	// action.
 	OpenIDConnectProviderARN *string `locationName:"OpenIDConnectProviderArn" type:"string" required:"true"`
 
-	metadataDeleteOpenIDConnectProviderInput `json:"-", xml:"-"`
+	metadataDeleteOpenIDConnectProviderInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteOpenIDConnectProviderInput struct {
@@ -5018,7 +5018,7 @@ type metadataDeleteOpenIDConnectProviderInput struct {
 }
 
 type DeleteOpenIDConnectProviderOutput struct {
-	metadataDeleteOpenIDConnectProviderOutput `json:"-", xml:"-"`
+	metadataDeleteOpenIDConnectProviderOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteOpenIDConnectProviderOutput struct {
@@ -5033,7 +5033,7 @@ type DeletePolicyInput struct {
 	// in the AWS General Reference.
 	PolicyARN *string `locationName:"PolicyArn" type:"string" required:"true"`
 
-	metadataDeletePolicyInput `json:"-", xml:"-"`
+	metadataDeletePolicyInput `json:"-" xml:"-"`
 }
 
 type metadataDeletePolicyInput struct {
@@ -5041,7 +5041,7 @@ type metadataDeletePolicyInput struct {
 }
 
 type DeletePolicyOutput struct {
-	metadataDeletePolicyOutput `json:"-", xml:"-"`
+	metadataDeletePolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataDeletePolicyOutput struct {
@@ -5063,7 +5063,7 @@ type DeletePolicyVersionInput struct {
 	// in the Using IAM guide.
 	VersionID *string `locationName:"VersionId" type:"string" required:"true"`
 
-	metadataDeletePolicyVersionInput `json:"-", xml:"-"`
+	metadataDeletePolicyVersionInput `json:"-" xml:"-"`
 }
 
 type metadataDeletePolicyVersionInput struct {
@@ -5071,7 +5071,7 @@ type metadataDeletePolicyVersionInput struct {
 }
 
 type DeletePolicyVersionOutput struct {
-	metadataDeletePolicyVersionOutput `json:"-", xml:"-"`
+	metadataDeletePolicyVersionOutput `json:"-" xml:"-"`
 }
 
 type metadataDeletePolicyVersionOutput struct {
@@ -5082,7 +5082,7 @@ type DeleteRoleInput struct {
 	// The name of the role to delete.
 	RoleName *string `type:"string" required:"true"`
 
-	metadataDeleteRoleInput `json:"-", xml:"-"`
+	metadataDeleteRoleInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteRoleInput struct {
@@ -5090,7 +5090,7 @@ type metadataDeleteRoleInput struct {
 }
 
 type DeleteRoleOutput struct {
-	metadataDeleteRoleOutput `json:"-", xml:"-"`
+	metadataDeleteRoleOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteRoleOutput struct {
@@ -5105,7 +5105,7 @@ type DeleteRolePolicyInput struct {
 	// embedded in.
 	RoleName *string `type:"string" required:"true"`
 
-	metadataDeleteRolePolicyInput `json:"-", xml:"-"`
+	metadataDeleteRolePolicyInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteRolePolicyInput struct {
@@ -5113,7 +5113,7 @@ type metadataDeleteRolePolicyInput struct {
 }
 
 type DeleteRolePolicyOutput struct {
-	metadataDeleteRolePolicyOutput `json:"-", xml:"-"`
+	metadataDeleteRolePolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteRolePolicyOutput struct {
@@ -5124,7 +5124,7 @@ type DeleteSAMLProviderInput struct {
 	// The Amazon Resource Name (ARN) of the SAML provider to delete.
 	SAMLProviderARN *string `locationName:"SAMLProviderArn" type:"string" required:"true"`
 
-	metadataDeleteSAMLProviderInput `json:"-", xml:"-"`
+	metadataDeleteSAMLProviderInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteSAMLProviderInput struct {
@@ -5132,7 +5132,7 @@ type metadataDeleteSAMLProviderInput struct {
 }
 
 type DeleteSAMLProviderOutput struct {
-	metadataDeleteSAMLProviderOutput `json:"-", xml:"-"`
+	metadataDeleteSAMLProviderOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteSAMLProviderOutput struct {
@@ -5143,7 +5143,7 @@ type DeleteServerCertificateInput struct {
 	// The name of the server certificate you want to delete.
 	ServerCertificateName *string `type:"string" required:"true"`
 
-	metadataDeleteServerCertificateInput `json:"-", xml:"-"`
+	metadataDeleteServerCertificateInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteServerCertificateInput struct {
@@ -5151,7 +5151,7 @@ type metadataDeleteServerCertificateInput struct {
 }
 
 type DeleteServerCertificateOutput struct {
-	metadataDeleteServerCertificateOutput `json:"-", xml:"-"`
+	metadataDeleteServerCertificateOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteServerCertificateOutput struct {
@@ -5165,7 +5165,7 @@ type DeleteSigningCertificateInput struct {
 	// The name of the user the signing certificate belongs to.
 	UserName *string `type:"string"`
 
-	metadataDeleteSigningCertificateInput `json:"-", xml:"-"`
+	metadataDeleteSigningCertificateInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteSigningCertificateInput struct {
@@ -5173,7 +5173,7 @@ type metadataDeleteSigningCertificateInput struct {
 }
 
 type DeleteSigningCertificateOutput struct {
-	metadataDeleteSigningCertificateOutput `json:"-", xml:"-"`
+	metadataDeleteSigningCertificateOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteSigningCertificateOutput struct {
@@ -5184,7 +5184,7 @@ type DeleteUserInput struct {
 	// The name of the user to delete.
 	UserName *string `type:"string" required:"true"`
 
-	metadataDeleteUserInput `json:"-", xml:"-"`
+	metadataDeleteUserInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteUserInput struct {
@@ -5192,7 +5192,7 @@ type metadataDeleteUserInput struct {
 }
 
 type DeleteUserOutput struct {
-	metadataDeleteUserOutput `json:"-", xml:"-"`
+	metadataDeleteUserOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteUserOutput struct {
@@ -5207,7 +5207,7 @@ type DeleteUserPolicyInput struct {
 	// embedded in.
 	UserName *string `type:"string" required:"true"`
 
-	metadataDeleteUserPolicyInput `json:"-", xml:"-"`
+	metadataDeleteUserPolicyInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteUserPolicyInput struct {
@@ -5215,7 +5215,7 @@ type metadataDeleteUserPolicyInput struct {
 }
 
 type DeleteUserPolicyOutput struct {
-	metadataDeleteUserPolicyOutput `json:"-", xml:"-"`
+	metadataDeleteUserPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteUserPolicyOutput struct {
@@ -5227,7 +5227,7 @@ type DeleteVirtualMFADeviceInput struct {
 	// devices, the serial number is the same as the ARN.
 	SerialNumber *string `type:"string" required:"true"`
 
-	metadataDeleteVirtualMFADeviceInput `json:"-", xml:"-"`
+	metadataDeleteVirtualMFADeviceInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteVirtualMFADeviceInput struct {
@@ -5235,7 +5235,7 @@ type metadataDeleteVirtualMFADeviceInput struct {
 }
 
 type DeleteVirtualMFADeviceOutput struct {
-	metadataDeleteVirtualMFADeviceOutput `json:"-", xml:"-"`
+	metadataDeleteVirtualMFADeviceOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteVirtualMFADeviceOutput struct {
@@ -5253,7 +5253,7 @@ type DetachGroupPolicyInput struct {
 	// in the AWS General Reference.
 	PolicyARN *string `locationName:"PolicyArn" type:"string" required:"true"`
 
-	metadataDetachGroupPolicyInput `json:"-", xml:"-"`
+	metadataDetachGroupPolicyInput `json:"-" xml:"-"`
 }
 
 type metadataDetachGroupPolicyInput struct {
@@ -5261,7 +5261,7 @@ type metadataDetachGroupPolicyInput struct {
 }
 
 type DetachGroupPolicyOutput struct {
-	metadataDetachGroupPolicyOutput `json:"-", xml:"-"`
+	metadataDetachGroupPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataDetachGroupPolicyOutput struct {
@@ -5279,7 +5279,7 @@ type DetachRolePolicyInput struct {
 	// The name (friendly name, not ARN) of the role to detach the policy from.
 	RoleName *string `type:"string" required:"true"`
 
-	metadataDetachRolePolicyInput `json:"-", xml:"-"`
+	metadataDetachRolePolicyInput `json:"-" xml:"-"`
 }
 
 type metadataDetachRolePolicyInput struct {
@@ -5287,7 +5287,7 @@ type metadataDetachRolePolicyInput struct {
 }
 
 type DetachRolePolicyOutput struct {
-	metadataDetachRolePolicyOutput `json:"-", xml:"-"`
+	metadataDetachRolePolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataDetachRolePolicyOutput struct {
@@ -5305,7 +5305,7 @@ type DetachUserPolicyInput struct {
 	// The name (friendly name, not ARN) of the user to detach the policy from.
 	UserName *string `type:"string" required:"true"`
 
-	metadataDetachUserPolicyInput `json:"-", xml:"-"`
+	metadataDetachUserPolicyInput `json:"-" xml:"-"`
 }
 
 type metadataDetachUserPolicyInput struct {
@@ -5313,7 +5313,7 @@ type metadataDetachUserPolicyInput struct {
 }
 
 type DetachUserPolicyOutput struct {
-	metadataDetachUserPolicyOutput `json:"-", xml:"-"`
+	metadataDetachUserPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataDetachUserPolicyOutput struct {
@@ -5334,7 +5334,7 @@ type EnableMFADeviceInput struct {
 	// The name of the user for whom you want to enable the MFA device.
 	UserName *string `type:"string" required:"true"`
 
-	metadataEnableMFADeviceInput `json:"-", xml:"-"`
+	metadataEnableMFADeviceInput `json:"-" xml:"-"`
 }
 
 type metadataEnableMFADeviceInput struct {
@@ -5342,7 +5342,7 @@ type metadataEnableMFADeviceInput struct {
 }
 
 type EnableMFADeviceOutput struct {
-	metadataEnableMFADeviceOutput `json:"-", xml:"-"`
+	metadataEnableMFADeviceOutput `json:"-" xml:"-"`
 }
 
 type metadataEnableMFADeviceOutput struct {
@@ -5350,7 +5350,7 @@ type metadataEnableMFADeviceOutput struct {
 }
 
 type GenerateCredentialReportInput struct {
-	metadataGenerateCredentialReportInput `json:"-", xml:"-"`
+	metadataGenerateCredentialReportInput `json:"-" xml:"-"`
 }
 
 type metadataGenerateCredentialReportInput struct {
@@ -5365,7 +5365,7 @@ type GenerateCredentialReportOutput struct {
 	// Information about the state of the credential report.
 	State *string `type:"string"`
 
-	metadataGenerateCredentialReportOutput `json:"-", xml:"-"`
+	metadataGenerateCredentialReportOutput `json:"-" xml:"-"`
 }
 
 type metadataGenerateCredentialReportOutput struct {
@@ -5376,7 +5376,7 @@ type GetAccessKeyLastUsedInput struct {
 	// The identifier of an access key.
 	AccessKeyID *string `locationName:"AccessKeyId" type:"string" required:"true"`
 
-	metadataGetAccessKeyLastUsedInput `json:"-", xml:"-"`
+	metadataGetAccessKeyLastUsedInput `json:"-" xml:"-"`
 }
 
 type metadataGetAccessKeyLastUsedInput struct {
@@ -5393,7 +5393,7 @@ type GetAccessKeyLastUsedOutput struct {
 	// The name of the AWS IAM user that owns this access key.
 	UserName *string `type:"string"`
 
-	metadataGetAccessKeyLastUsedOutput `json:"-", xml:"-"`
+	metadataGetAccessKeyLastUsedOutput `json:"-" xml:"-"`
 }
 
 type metadataGetAccessKeyLastUsedOutput struct {
@@ -5416,7 +5416,7 @@ type GetAccountAuthorizationDetailsInput struct {
 	// optional. If you do not include it, it defaults to 100.
 	MaxItems *int64 `type:"integer"`
 
-	metadataGetAccountAuthorizationDetailsInput `json:"-", xml:"-"`
+	metadataGetAccountAuthorizationDetailsInput `json:"-" xml:"-"`
 }
 
 type metadataGetAccountAuthorizationDetailsInput struct {
@@ -5446,7 +5446,7 @@ type GetAccountAuthorizationDetailsOutput struct {
 	// A list containing information about IAM users.
 	UserDetailList []*UserDetail `type:"list"`
 
-	metadataGetAccountAuthorizationDetailsOutput `json:"-", xml:"-"`
+	metadataGetAccountAuthorizationDetailsOutput `json:"-" xml:"-"`
 }
 
 type metadataGetAccountAuthorizationDetailsOutput struct {
@@ -5454,7 +5454,7 @@ type metadataGetAccountAuthorizationDetailsOutput struct {
 }
 
 type GetAccountPasswordPolicyInput struct {
-	metadataGetAccountPasswordPolicyInput `json:"-", xml:"-"`
+	metadataGetAccountPasswordPolicyInput `json:"-" xml:"-"`
 }
 
 type metadataGetAccountPasswordPolicyInput struct {
@@ -5469,7 +5469,7 @@ type GetAccountPasswordPolicyOutput struct {
 	// action.
 	PasswordPolicy *PasswordPolicy `type:"structure" required:"true"`
 
-	metadataGetAccountPasswordPolicyOutput `json:"-", xml:"-"`
+	metadataGetAccountPasswordPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataGetAccountPasswordPolicyOutput struct {
@@ -5477,7 +5477,7 @@ type metadataGetAccountPasswordPolicyOutput struct {
 }
 
 type GetAccountSummaryInput struct {
-	metadataGetAccountSummaryInput `json:"-", xml:"-"`
+	metadataGetAccountSummaryInput `json:"-" xml:"-"`
 }
 
 type metadataGetAccountSummaryInput struct {
@@ -5631,7 +5631,7 @@ type GetAccountSummaryOutput struct {
 	// The maximum number of policy versions allowed for each managed policy.
 	SummaryMap *map[string]*int64 `type:"map"`
 
-	metadataGetAccountSummaryOutput `json:"-", xml:"-"`
+	metadataGetAccountSummaryOutput `json:"-" xml:"-"`
 }
 
 type metadataGetAccountSummaryOutput struct {
@@ -5639,7 +5639,7 @@ type metadataGetAccountSummaryOutput struct {
 }
 
 type GetCredentialReportInput struct {
-	metadataGetCredentialReportInput `json:"-", xml:"-"`
+	metadataGetCredentialReportInput `json:"-" xml:"-"`
 }
 
 type metadataGetCredentialReportInput struct {
@@ -5658,7 +5658,7 @@ type GetCredentialReportOutput struct {
 	// The format (MIME type) of the credential report.
 	ReportFormat *string `type:"string"`
 
-	metadataGetCredentialReportOutput `json:"-", xml:"-"`
+	metadataGetCredentialReportOutput `json:"-" xml:"-"`
 }
 
 type metadataGetCredentialReportOutput struct {
@@ -5680,7 +5680,7 @@ type GetGroupInput struct {
 	// optional. If you do not include it, it defaults to 100.
 	MaxItems *int64 `type:"integer"`
 
-	metadataGetGroupInput `json:"-", xml:"-"`
+	metadataGetGroupInput `json:"-" xml:"-"`
 }
 
 type metadataGetGroupInput struct {
@@ -5704,7 +5704,7 @@ type GetGroupOutput struct {
 	// A list of users in the group.
 	Users []*User `type:"list" required:"true"`
 
-	metadataGetGroupOutput `json:"-", xml:"-"`
+	metadataGetGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataGetGroupOutput struct {
@@ -5718,7 +5718,7 @@ type GetGroupPolicyInput struct {
 	// The name of the policy document to get.
 	PolicyName *string `type:"string" required:"true"`
 
-	metadataGetGroupPolicyInput `json:"-", xml:"-"`
+	metadataGetGroupPolicyInput `json:"-" xml:"-"`
 }
 
 type metadataGetGroupPolicyInput struct {
@@ -5736,7 +5736,7 @@ type GetGroupPolicyOutput struct {
 	// The name of the policy.
 	PolicyName *string `type:"string" required:"true"`
 
-	metadataGetGroupPolicyOutput `json:"-", xml:"-"`
+	metadataGetGroupPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataGetGroupPolicyOutput struct {
@@ -5747,7 +5747,7 @@ type GetInstanceProfileInput struct {
 	// The name of the instance profile to get information about.
 	InstanceProfileName *string `type:"string" required:"true"`
 
-	metadataGetInstanceProfileInput `json:"-", xml:"-"`
+	metadataGetInstanceProfileInput `json:"-" xml:"-"`
 }
 
 type metadataGetInstanceProfileInput struct {
@@ -5759,7 +5759,7 @@ type GetInstanceProfileOutput struct {
 	// Information about the instance profile.
 	InstanceProfile *InstanceProfile `type:"structure" required:"true"`
 
-	metadataGetInstanceProfileOutput `json:"-", xml:"-"`
+	metadataGetInstanceProfileOutput `json:"-" xml:"-"`
 }
 
 type metadataGetInstanceProfileOutput struct {
@@ -5770,7 +5770,7 @@ type GetLoginProfileInput struct {
 	// The name of the user whose login profile you want to retrieve.
 	UserName *string `type:"string" required:"true"`
 
-	metadataGetLoginProfileInput `json:"-", xml:"-"`
+	metadataGetLoginProfileInput `json:"-" xml:"-"`
 }
 
 type metadataGetLoginProfileInput struct {
@@ -5782,7 +5782,7 @@ type GetLoginProfileOutput struct {
 	// The user name and password create date for the user.
 	LoginProfile *LoginProfile `type:"structure" required:"true"`
 
-	metadataGetLoginProfileOutput `json:"-", xml:"-"`
+	metadataGetLoginProfileOutput `json:"-" xml:"-"`
 }
 
 type metadataGetLoginProfileOutput struct {
@@ -5795,7 +5795,7 @@ type GetOpenIDConnectProviderInput struct {
 	// the ListOpenIDConnectProviders action.
 	OpenIDConnectProviderARN *string `locationName:"OpenIDConnectProviderArn" type:"string" required:"true"`
 
-	metadataGetOpenIDConnectProviderInput `json:"-", xml:"-"`
+	metadataGetOpenIDConnectProviderInput `json:"-" xml:"-"`
 }
 
 type metadataGetOpenIDConnectProviderInput struct {
@@ -5820,7 +5820,7 @@ type GetOpenIDConnectProviderOutput struct {
 	// information, see CreateOpenIDConnectProvider.
 	URL *string `locationName:"Url" type:"string"`
 
-	metadataGetOpenIDConnectProviderOutput `json:"-", xml:"-"`
+	metadataGetOpenIDConnectProviderOutput `json:"-" xml:"-"`
 }
 
 type metadataGetOpenIDConnectProviderOutput struct {
@@ -5835,7 +5835,7 @@ type GetPolicyInput struct {
 	// in the AWS General Reference.
 	PolicyARN *string `locationName:"PolicyArn" type:"string" required:"true"`
 
-	metadataGetPolicyInput `json:"-", xml:"-"`
+	metadataGetPolicyInput `json:"-" xml:"-"`
 }
 
 type metadataGetPolicyInput struct {
@@ -5847,7 +5847,7 @@ type GetPolicyOutput struct {
 	// Information about the policy.
 	Policy *Policy `type:"structure"`
 
-	metadataGetPolicyOutput `json:"-", xml:"-"`
+	metadataGetPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataGetPolicyOutput struct {
@@ -5865,7 +5865,7 @@ type GetPolicyVersionInput struct {
 	// Identifies the policy version to retrieve.
 	VersionID *string `locationName:"VersionId" type:"string" required:"true"`
 
-	metadataGetPolicyVersionInput `json:"-", xml:"-"`
+	metadataGetPolicyVersionInput `json:"-" xml:"-"`
 }
 
 type metadataGetPolicyVersionInput struct {
@@ -5881,7 +5881,7 @@ type GetPolicyVersionOutput struct {
 	// in the Using IAM guide.
 	PolicyVersion *PolicyVersion `type:"structure"`
 
-	metadataGetPolicyVersionOutput `json:"-", xml:"-"`
+	metadataGetPolicyVersionOutput `json:"-" xml:"-"`
 }
 
 type metadataGetPolicyVersionOutput struct {
@@ -5892,7 +5892,7 @@ type GetRoleInput struct {
 	// The name of the role to get information about.
 	RoleName *string `type:"string" required:"true"`
 
-	metadataGetRoleInput `json:"-", xml:"-"`
+	metadataGetRoleInput `json:"-" xml:"-"`
 }
 
 type metadataGetRoleInput struct {
@@ -5904,7 +5904,7 @@ type GetRoleOutput struct {
 	// Information about the role.
 	Role *Role `type:"structure" required:"true"`
 
-	metadataGetRoleOutput `json:"-", xml:"-"`
+	metadataGetRoleOutput `json:"-" xml:"-"`
 }
 
 type metadataGetRoleOutput struct {
@@ -5918,7 +5918,7 @@ type GetRolePolicyInput struct {
 	// The name of the role associated with the policy.
 	RoleName *string `type:"string" required:"true"`
 
-	metadataGetRolePolicyInput `json:"-", xml:"-"`
+	metadataGetRolePolicyInput `json:"-" xml:"-"`
 }
 
 type metadataGetRolePolicyInput struct {
@@ -5936,7 +5936,7 @@ type GetRolePolicyOutput struct {
 	// The role the policy is associated with.
 	RoleName *string `type:"string" required:"true"`
 
-	metadataGetRolePolicyOutput `json:"-", xml:"-"`
+	metadataGetRolePolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataGetRolePolicyOutput struct {
@@ -5947,7 +5947,7 @@ type GetSAMLProviderInput struct {
 	// The Amazon Resource Name (ARN) of the SAML provider to get information about.
 	SAMLProviderARN *string `locationName:"SAMLProviderArn" type:"string" required:"true"`
 
-	metadataGetSAMLProviderInput `json:"-", xml:"-"`
+	metadataGetSAMLProviderInput `json:"-" xml:"-"`
 }
 
 type metadataGetSAMLProviderInput struct {
@@ -5965,7 +5965,7 @@ type GetSAMLProviderOutput struct {
 	// The expiration date and time for the SAML provider.
 	ValidUntil *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataGetSAMLProviderOutput `json:"-", xml:"-"`
+	metadataGetSAMLProviderOutput `json:"-" xml:"-"`
 }
 
 type metadataGetSAMLProviderOutput struct {
@@ -5976,7 +5976,7 @@ type GetServerCertificateInput struct {
 	// The name of the server certificate you want to retrieve information about.
 	ServerCertificateName *string `type:"string" required:"true"`
 
-	metadataGetServerCertificateInput `json:"-", xml:"-"`
+	metadataGetServerCertificateInput `json:"-" xml:"-"`
 }
 
 type metadataGetServerCertificateInput struct {
@@ -5988,7 +5988,7 @@ type GetServerCertificateOutput struct {
 	// Information about the server certificate.
 	ServerCertificate *ServerCertificate `type:"structure" required:"true"`
 
-	metadataGetServerCertificateOutput `json:"-", xml:"-"`
+	metadataGetServerCertificateOutput `json:"-" xml:"-"`
 }
 
 type metadataGetServerCertificateOutput struct {
@@ -6002,7 +6002,7 @@ type GetUserInput struct {
 	// making the request.
 	UserName *string `type:"string"`
 
-	metadataGetUserInput `json:"-", xml:"-"`
+	metadataGetUserInput `json:"-" xml:"-"`
 }
 
 type metadataGetUserInput struct {
@@ -6014,7 +6014,7 @@ type GetUserOutput struct {
 	// Information about the user.
 	User *User `type:"structure" required:"true"`
 
-	metadataGetUserOutput `json:"-", xml:"-"`
+	metadataGetUserOutput `json:"-" xml:"-"`
 }
 
 type metadataGetUserOutput struct {
@@ -6028,7 +6028,7 @@ type GetUserPolicyInput struct {
 	// The name of the user who the policy is associated with.
 	UserName *string `type:"string" required:"true"`
 
-	metadataGetUserPolicyInput `json:"-", xml:"-"`
+	metadataGetUserPolicyInput `json:"-" xml:"-"`
 }
 
 type metadataGetUserPolicyInput struct {
@@ -6046,7 +6046,7 @@ type GetUserPolicyOutput struct {
 	// The user the policy is associated with.
 	UserName *string `type:"string" required:"true"`
 
-	metadataGetUserPolicyOutput `json:"-", xml:"-"`
+	metadataGetUserPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataGetUserPolicyOutput struct {
@@ -6081,7 +6081,7 @@ type Group struct {
 	// in the Using IAM guide.
 	Path *string `type:"string" required:"true"`
 
-	metadataGroup `json:"-", xml:"-"`
+	metadataGroup `json:"-" xml:"-"`
 }
 
 type metadataGroup struct {
@@ -6123,7 +6123,7 @@ type GroupDetail struct {
 	// in the Using IAM guide.
 	Path *string `type:"string"`
 
-	metadataGroupDetail `json:"-", xml:"-"`
+	metadataGroupDetail `json:"-" xml:"-"`
 }
 
 type metadataGroupDetail struct {
@@ -6167,7 +6167,7 @@ type InstanceProfile struct {
 	// The role associated with the instance profile.
 	Roles []*Role `type:"list" required:"true"`
 
-	metadataInstanceProfile `json:"-", xml:"-"`
+	metadataInstanceProfile `json:"-" xml:"-"`
 }
 
 type metadataInstanceProfile struct {
@@ -6189,7 +6189,7 @@ type ListAccessKeysInput struct {
 	// The name of the user.
 	UserName *string `type:"string"`
 
-	metadataListAccessKeysInput `json:"-", xml:"-"`
+	metadataListAccessKeysInput `json:"-" xml:"-"`
 }
 
 type metadataListAccessKeysInput struct {
@@ -6210,7 +6210,7 @@ type ListAccessKeysOutput struct {
 	// use for the Marker parameter in a subsequent pagination request.
 	Marker *string `type:"string"`
 
-	metadataListAccessKeysOutput `json:"-", xml:"-"`
+	metadataListAccessKeysOutput `json:"-" xml:"-"`
 }
 
 type metadataListAccessKeysOutput struct {
@@ -6229,7 +6229,7 @@ type ListAccountAliasesInput struct {
 	// This parameter is optional. If you do not include it, it defaults to 100.
 	MaxItems *int64 `type:"integer"`
 
-	metadataListAccountAliasesInput `json:"-", xml:"-"`
+	metadataListAccountAliasesInput `json:"-" xml:"-"`
 }
 
 type metadataListAccountAliasesInput struct {
@@ -6252,7 +6252,7 @@ type ListAccountAliasesOutput struct {
 	// value of the Marker element in the response you just received.
 	Marker *string `type:"string"`
 
-	metadataListAccountAliasesOutput `json:"-", xml:"-"`
+	metadataListAccountAliasesOutput `json:"-" xml:"-"`
 }
 
 type metadataListAccountAliasesOutput struct {
@@ -6279,7 +6279,7 @@ type ListAttachedGroupPoliciesInput struct {
 	// it is not included, it defaults to a slash (/), listing all policies.
 	PathPrefix *string `type:"string"`
 
-	metadataListAttachedGroupPoliciesInput `json:"-", xml:"-"`
+	metadataListAttachedGroupPoliciesInput `json:"-" xml:"-"`
 }
 
 type metadataListAttachedGroupPoliciesInput struct {
@@ -6300,7 +6300,7 @@ type ListAttachedGroupPoliciesOutput struct {
 	// use for the Marker parameter in a subsequent pagination request.
 	Marker *string `type:"string"`
 
-	metadataListAttachedGroupPoliciesOutput `json:"-", xml:"-"`
+	metadataListAttachedGroupPoliciesOutput `json:"-" xml:"-"`
 }
 
 type metadataListAttachedGroupPoliciesOutput struct {
@@ -6326,7 +6326,7 @@ type ListAttachedRolePoliciesInput struct {
 	// The name (friendly name, not ARN) of the role to list attached policies for.
 	RoleName *string `type:"string" required:"true"`
 
-	metadataListAttachedRolePoliciesInput `json:"-", xml:"-"`
+	metadataListAttachedRolePoliciesInput `json:"-" xml:"-"`
 }
 
 type metadataListAttachedRolePoliciesInput struct {
@@ -6347,7 +6347,7 @@ type ListAttachedRolePoliciesOutput struct {
 	// use for the Marker parameter in a subsequent pagination request.
 	Marker *string `type:"string"`
 
-	metadataListAttachedRolePoliciesOutput `json:"-", xml:"-"`
+	metadataListAttachedRolePoliciesOutput `json:"-" xml:"-"`
 }
 
 type metadataListAttachedRolePoliciesOutput struct {
@@ -6373,7 +6373,7 @@ type ListAttachedUserPoliciesInput struct {
 	// The name (friendly name, not ARN) of the user to list attached policies for.
 	UserName *string `type:"string" required:"true"`
 
-	metadataListAttachedUserPoliciesInput `json:"-", xml:"-"`
+	metadataListAttachedUserPoliciesInput `json:"-" xml:"-"`
 }
 
 type metadataListAttachedUserPoliciesInput struct {
@@ -6394,7 +6394,7 @@ type ListAttachedUserPoliciesOutput struct {
 	// use for the Marker parameter in a subsequent pagination request.
 	Marker *string `type:"string"`
 
-	metadataListAttachedUserPoliciesOutput `json:"-", xml:"-"`
+	metadataListAttachedUserPoliciesOutput `json:"-" xml:"-"`
 }
 
 type metadataListAttachedUserPoliciesOutput struct {
@@ -6431,7 +6431,7 @@ type ListEntitiesForPolicyInput struct {
 	// in the AWS General Reference.
 	PolicyARN *string `locationName:"PolicyArn" type:"string" required:"true"`
 
-	metadataListEntitiesForPolicyInput `json:"-", xml:"-"`
+	metadataListEntitiesForPolicyInput `json:"-" xml:"-"`
 }
 
 type metadataListEntitiesForPolicyInput struct {
@@ -6458,7 +6458,7 @@ type ListEntitiesForPolicyOutput struct {
 	// A list of users that the policy is attached to.
 	PolicyUsers []*PolicyUser `type:"list"`
 
-	metadataListEntitiesForPolicyOutput `json:"-", xml:"-"`
+	metadataListEntitiesForPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataListEntitiesForPolicyOutput struct {
@@ -6480,7 +6480,7 @@ type ListGroupPoliciesInput struct {
 	// is optional. If you do not include it, it defaults to 100.
 	MaxItems *int64 `type:"integer"`
 
-	metadataListGroupPoliciesInput `json:"-", xml:"-"`
+	metadataListGroupPoliciesInput `json:"-" xml:"-"`
 }
 
 type metadataListGroupPoliciesInput struct {
@@ -6501,7 +6501,7 @@ type ListGroupPoliciesOutput struct {
 	// A list of policy names.
 	PolicyNames []*string `type:"list" required:"true"`
 
-	metadataListGroupPoliciesOutput `json:"-", xml:"-"`
+	metadataListGroupPoliciesOutput `json:"-" xml:"-"`
 }
 
 type metadataListGroupPoliciesOutput struct {
@@ -6523,7 +6523,7 @@ type ListGroupsForUserInput struct {
 	// The name of the user to list groups for.
 	UserName *string `type:"string" required:"true"`
 
-	metadataListGroupsForUserInput `json:"-", xml:"-"`
+	metadataListGroupsForUserInput `json:"-" xml:"-"`
 }
 
 type metadataListGroupsForUserInput struct {
@@ -6544,7 +6544,7 @@ type ListGroupsForUserOutput struct {
 	// use for the Marker parameter in a subsequent pagination request.
 	Marker *string `type:"string"`
 
-	metadataListGroupsForUserOutput `json:"-", xml:"-"`
+	metadataListGroupsForUserOutput `json:"-" xml:"-"`
 }
 
 type metadataListGroupsForUserOutput struct {
@@ -6570,7 +6570,7 @@ type ListGroupsInput struct {
 	// (/), listing all groups.
 	PathPrefix *string `type:"string"`
 
-	metadataListGroupsInput `json:"-", xml:"-"`
+	metadataListGroupsInput `json:"-" xml:"-"`
 }
 
 type metadataListGroupsInput struct {
@@ -6591,7 +6591,7 @@ type ListGroupsOutput struct {
 	// use for the Marker parameter in a subsequent pagination request.
 	Marker *string `type:"string"`
 
-	metadataListGroupsOutput `json:"-", xml:"-"`
+	metadataListGroupsOutput `json:"-" xml:"-"`
 }
 
 type metadataListGroupsOutput struct {
@@ -6614,7 +6614,7 @@ type ListInstanceProfilesForRoleInput struct {
 	// The name of the role to list instance profiles for.
 	RoleName *string `type:"string" required:"true"`
 
-	metadataListInstanceProfilesForRoleInput `json:"-", xml:"-"`
+	metadataListInstanceProfilesForRoleInput `json:"-" xml:"-"`
 }
 
 type metadataListInstanceProfilesForRoleInput struct {
@@ -6636,7 +6636,7 @@ type ListInstanceProfilesForRoleOutput struct {
 	// use for the Marker parameter in a subsequent pagination request.
 	Marker *string `type:"string"`
 
-	metadataListInstanceProfilesForRoleOutput `json:"-", xml:"-"`
+	metadataListInstanceProfilesForRoleOutput `json:"-" xml:"-"`
 }
 
 type metadataListInstanceProfilesForRoleOutput struct {
@@ -6663,7 +6663,7 @@ type ListInstanceProfilesInput struct {
 	// (/), listing all instance profiles.
 	PathPrefix *string `type:"string"`
 
-	metadataListInstanceProfilesInput `json:"-", xml:"-"`
+	metadataListInstanceProfilesInput `json:"-" xml:"-"`
 }
 
 type metadataListInstanceProfilesInput struct {
@@ -6685,7 +6685,7 @@ type ListInstanceProfilesOutput struct {
 	// use for the Marker parameter in a subsequent pagination request.
 	Marker *string `type:"string"`
 
-	metadataListInstanceProfilesOutput `json:"-", xml:"-"`
+	metadataListInstanceProfilesOutput `json:"-" xml:"-"`
 }
 
 type metadataListInstanceProfilesOutput struct {
@@ -6707,7 +6707,7 @@ type ListMFADevicesInput struct {
 	// The name of the user whose MFA devices you want to list.
 	UserName *string `type:"string"`
 
-	metadataListMFADevicesInput `json:"-", xml:"-"`
+	metadataListMFADevicesInput `json:"-" xml:"-"`
 }
 
 type metadataListMFADevicesInput struct {
@@ -6728,7 +6728,7 @@ type ListMFADevicesOutput struct {
 	// use for the Marker parameter in a subsequent pagination request.
 	Marker *string `type:"string"`
 
-	metadataListMFADevicesOutput `json:"-", xml:"-"`
+	metadataListMFADevicesOutput `json:"-" xml:"-"`
 }
 
 type metadataListMFADevicesOutput struct {
@@ -6736,7 +6736,7 @@ type metadataListMFADevicesOutput struct {
 }
 
 type ListOpenIDConnectProvidersInput struct {
-	metadataListOpenIDConnectProvidersInput `json:"-", xml:"-"`
+	metadataListOpenIDConnectProvidersInput `json:"-" xml:"-"`
 }
 
 type metadataListOpenIDConnectProvidersInput struct {
@@ -6748,7 +6748,7 @@ type ListOpenIDConnectProvidersOutput struct {
 	// The list of IAM OpenID Connect providers in the AWS account.
 	OpenIDConnectProviderList []*OpenIDConnectProviderListEntry `type:"list"`
 
-	metadataListOpenIDConnectProvidersOutput `json:"-", xml:"-"`
+	metadataListOpenIDConnectProvidersOutput `json:"-" xml:"-"`
 }
 
 type metadataListOpenIDConnectProvidersOutput struct {
@@ -6787,7 +6787,7 @@ type ListPoliciesInput struct {
 	// all policies are returned.
 	Scope *string `type:"string"`
 
-	metadataListPoliciesInput `json:"-", xml:"-"`
+	metadataListPoliciesInput `json:"-" xml:"-"`
 }
 
 type metadataListPoliciesInput struct {
@@ -6808,7 +6808,7 @@ type ListPoliciesOutput struct {
 	// A list of policies.
 	Policies []*Policy `type:"list"`
 
-	metadataListPoliciesOutput `json:"-", xml:"-"`
+	metadataListPoliciesOutput `json:"-" xml:"-"`
 }
 
 type metadataListPoliciesOutput struct {
@@ -6835,7 +6835,7 @@ type ListPolicyVersionsInput struct {
 	// in the AWS General Reference.
 	PolicyARN *string `locationName:"PolicyArn" type:"string" required:"true"`
 
-	metadataListPolicyVersionsInput `json:"-", xml:"-"`
+	metadataListPolicyVersionsInput `json:"-" xml:"-"`
 }
 
 type metadataListPolicyVersionsInput struct {
@@ -6861,7 +6861,7 @@ type ListPolicyVersionsOutput struct {
 	// in the Using IAM guide.
 	Versions []*PolicyVersion `type:"list"`
 
-	metadataListPolicyVersionsOutput `json:"-", xml:"-"`
+	metadataListPolicyVersionsOutput `json:"-" xml:"-"`
 }
 
 type metadataListPolicyVersionsOutput struct {
@@ -6883,7 +6883,7 @@ type ListRolePoliciesInput struct {
 	// The name of the role to list policies for.
 	RoleName *string `type:"string" required:"true"`
 
-	metadataListRolePoliciesInput `json:"-", xml:"-"`
+	metadataListRolePoliciesInput `json:"-" xml:"-"`
 }
 
 type metadataListRolePoliciesInput struct {
@@ -6904,7 +6904,7 @@ type ListRolePoliciesOutput struct {
 	// A list of policy names.
 	PolicyNames []*string `type:"list" required:"true"`
 
-	metadataListRolePoliciesOutput `json:"-", xml:"-"`
+	metadataListRolePoliciesOutput `json:"-" xml:"-"`
 }
 
 type metadataListRolePoliciesOutput struct {
@@ -6930,7 +6930,7 @@ type ListRolesInput struct {
 	// (/), listing all roles.
 	PathPrefix *string `type:"string"`
 
-	metadataListRolesInput `json:"-", xml:"-"`
+	metadataListRolesInput `json:"-" xml:"-"`
 }
 
 type metadataListRolesInput struct {
@@ -6951,7 +6951,7 @@ type ListRolesOutput struct {
 	// A list of roles.
 	Roles []*Role `type:"list" required:"true"`
 
-	metadataListRolesOutput `json:"-", xml:"-"`
+	metadataListRolesOutput `json:"-" xml:"-"`
 }
 
 type metadataListRolesOutput struct {
@@ -6959,7 +6959,7 @@ type metadataListRolesOutput struct {
 }
 
 type ListSAMLProvidersInput struct {
-	metadataListSAMLProvidersInput `json:"-", xml:"-"`
+	metadataListSAMLProvidersInput `json:"-" xml:"-"`
 }
 
 type metadataListSAMLProvidersInput struct {
@@ -6971,7 +6971,7 @@ type ListSAMLProvidersOutput struct {
 	// The list of SAML providers for this account.
 	SAMLProviderList []*SAMLProviderListEntry `type:"list"`
 
-	metadataListSAMLProvidersOutput `json:"-", xml:"-"`
+	metadataListSAMLProvidersOutput `json:"-" xml:"-"`
 }
 
 type metadataListSAMLProvidersOutput struct {
@@ -6998,7 +6998,7 @@ type ListServerCertificatesInput struct {
 	// (/), listing all server certificates.
 	PathPrefix *string `type:"string"`
 
-	metadataListServerCertificatesInput `json:"-", xml:"-"`
+	metadataListServerCertificatesInput `json:"-" xml:"-"`
 }
 
 type metadataListServerCertificatesInput struct {
@@ -7020,7 +7020,7 @@ type ListServerCertificatesOutput struct {
 	// A list of server certificates.
 	ServerCertificateMetadataList []*ServerCertificateMetadata `type:"list" required:"true"`
 
-	metadataListServerCertificatesOutput `json:"-", xml:"-"`
+	metadataListServerCertificatesOutput `json:"-" xml:"-"`
 }
 
 type metadataListServerCertificatesOutput struct {
@@ -7042,7 +7042,7 @@ type ListSigningCertificatesInput struct {
 	// The name of the user.
 	UserName *string `type:"string"`
 
-	metadataListSigningCertificatesInput `json:"-", xml:"-"`
+	metadataListSigningCertificatesInput `json:"-" xml:"-"`
 }
 
 type metadataListSigningCertificatesInput struct {
@@ -7063,7 +7063,7 @@ type ListSigningCertificatesOutput struct {
 	// use for the Marker parameter in a subsequent pagination request.
 	Marker *string `type:"string"`
 
-	metadataListSigningCertificatesOutput `json:"-", xml:"-"`
+	metadataListSigningCertificatesOutput `json:"-" xml:"-"`
 }
 
 type metadataListSigningCertificatesOutput struct {
@@ -7085,7 +7085,7 @@ type ListUserPoliciesInput struct {
 	// The name of the user to list policies for.
 	UserName *string `type:"string" required:"true"`
 
-	metadataListUserPoliciesInput `json:"-", xml:"-"`
+	metadataListUserPoliciesInput `json:"-" xml:"-"`
 }
 
 type metadataListUserPoliciesInput struct {
@@ -7106,7 +7106,7 @@ type ListUserPoliciesOutput struct {
 	// A list of policy names.
 	PolicyNames []*string `type:"list" required:"true"`
 
-	metadataListUserPoliciesOutput `json:"-", xml:"-"`
+	metadataListUserPoliciesOutput `json:"-" xml:"-"`
 }
 
 type metadataListUserPoliciesOutput struct {
@@ -7132,7 +7132,7 @@ type ListUsersInput struct {
 	// (/), listing all user names.
 	PathPrefix *string `type:"string"`
 
-	metadataListUsersInput `json:"-", xml:"-"`
+	metadataListUsersInput `json:"-" xml:"-"`
 }
 
 type metadataListUsersInput struct {
@@ -7153,7 +7153,7 @@ type ListUsersOutput struct {
 	// A list of users.
 	Users []*User `type:"list" required:"true"`
 
-	metadataListUsersOutput `json:"-", xml:"-"`
+	metadataListUsersOutput `json:"-" xml:"-"`
 }
 
 type metadataListUsersOutput struct {
@@ -7177,7 +7177,7 @@ type ListVirtualMFADevicesInput struct {
 	// This parameter is optional. If you do not include it, it defaults to 100.
 	MaxItems *int64 `type:"integer"`
 
-	metadataListVirtualMFADevicesInput `json:"-", xml:"-"`
+	metadataListVirtualMFADevicesInput `json:"-" xml:"-"`
 }
 
 type metadataListVirtualMFADevicesInput struct {
@@ -7199,7 +7199,7 @@ type ListVirtualMFADevicesOutput struct {
 	// value that was passed in the request.
 	VirtualMFADevices []*VirtualMFADevice `type:"list" required:"true"`
 
-	metadataListVirtualMFADevicesOutput `json:"-", xml:"-"`
+	metadataListVirtualMFADevicesOutput `json:"-" xml:"-"`
 }
 
 type metadataListVirtualMFADevicesOutput struct {
@@ -7221,7 +7221,7 @@ type LoginProfile struct {
 	// Console.
 	UserName *string `type:"string" required:"true"`
 
-	metadataLoginProfile `json:"-", xml:"-"`
+	metadataLoginProfile `json:"-" xml:"-"`
 }
 
 type metadataLoginProfile struct {
@@ -7242,7 +7242,7 @@ type MFADevice struct {
 	// The user with whom the MFA device is associated.
 	UserName *string `type:"string" required:"true"`
 
-	metadataMFADevice `json:"-", xml:"-"`
+	metadataMFADevice `json:"-" xml:"-"`
 }
 
 type metadataMFADevice struct {
@@ -7316,7 +7316,7 @@ type ManagedPolicyDetail struct {
 	// created.
 	UpdateDate *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataManagedPolicyDetail `json:"-", xml:"-"`
+	metadataManagedPolicyDetail `json:"-" xml:"-"`
 }
 
 type metadataManagedPolicyDetail struct {
@@ -7332,7 +7332,7 @@ type OpenIDConnectProviderListEntry struct {
 	// in the AWS General Reference.
 	ARN *string `locationName:"Arn" type:"string"`
 
-	metadataOpenIDConnectProviderListEntry `json:"-", xml:"-"`
+	metadataOpenIDConnectProviderListEntry `json:"-" xml:"-"`
 }
 
 type metadataOpenIDConnectProviderListEntry struct {
@@ -7377,7 +7377,7 @@ type PasswordPolicy struct {
 	// Specifies whether to require uppercase characters for IAM user passwords.
 	RequireUppercaseCharacters *bool `type:"boolean"`
 
-	metadataPasswordPolicy `json:"-", xml:"-"`
+	metadataPasswordPolicy `json:"-" xml:"-"`
 }
 
 type metadataPasswordPolicy struct {
@@ -7444,7 +7444,7 @@ type Policy struct {
 	// created.
 	UpdateDate *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataPolicy `json:"-", xml:"-"`
+	metadataPolicy `json:"-" xml:"-"`
 }
 
 type metadataPolicy struct {
@@ -7464,7 +7464,7 @@ type PolicyDetail struct {
 	// The name of the policy.
 	PolicyName *string `type:"string"`
 
-	metadataPolicyDetail `json:"-", xml:"-"`
+	metadataPolicyDetail `json:"-" xml:"-"`
 }
 
 type metadataPolicyDetail struct {
@@ -7483,7 +7483,7 @@ type PolicyGroup struct {
 	// The name (friendly name, not ARN) identifying the group.
 	GroupName *string `type:"string"`
 
-	metadataPolicyGroup `json:"-", xml:"-"`
+	metadataPolicyGroup `json:"-" xml:"-"`
 }
 
 type metadataPolicyGroup struct {
@@ -7502,7 +7502,7 @@ type PolicyRole struct {
 	// The name (friendly name, not ARN) identifying the role.
 	RoleName *string `type:"string"`
 
-	metadataPolicyRole `json:"-", xml:"-"`
+	metadataPolicyRole `json:"-" xml:"-"`
 }
 
 type metadataPolicyRole struct {
@@ -7521,7 +7521,7 @@ type PolicyUser struct {
 	// The name (friendly name, not ARN) identifying the user.
 	UserName *string `type:"string"`
 
-	metadataPolicyUser `json:"-", xml:"-"`
+	metadataPolicyUser `json:"-" xml:"-"`
 }
 
 type metadataPolicyUser struct {
@@ -7558,7 +7558,7 @@ type PolicyVersion struct {
 	// a policy is created, the first policy version is v1.
 	VersionID *string `locationName:"VersionId" type:"string"`
 
-	metadataPolicyVersion `json:"-", xml:"-"`
+	metadataPolicyVersion `json:"-" xml:"-"`
 }
 
 type metadataPolicyVersion struct {
@@ -7575,7 +7575,7 @@ type PutGroupPolicyInput struct {
 	// The name of the policy document.
 	PolicyName *string `type:"string" required:"true"`
 
-	metadataPutGroupPolicyInput `json:"-", xml:"-"`
+	metadataPutGroupPolicyInput `json:"-" xml:"-"`
 }
 
 type metadataPutGroupPolicyInput struct {
@@ -7583,7 +7583,7 @@ type metadataPutGroupPolicyInput struct {
 }
 
 type PutGroupPolicyOutput struct {
-	metadataPutGroupPolicyOutput `json:"-", xml:"-"`
+	metadataPutGroupPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataPutGroupPolicyOutput struct {
@@ -7600,7 +7600,7 @@ type PutRolePolicyInput struct {
 	// The name of the role to associate the policy with.
 	RoleName *string `type:"string" required:"true"`
 
-	metadataPutRolePolicyInput `json:"-", xml:"-"`
+	metadataPutRolePolicyInput `json:"-" xml:"-"`
 }
 
 type metadataPutRolePolicyInput struct {
@@ -7608,7 +7608,7 @@ type metadataPutRolePolicyInput struct {
 }
 
 type PutRolePolicyOutput struct {
-	metadataPutRolePolicyOutput `json:"-", xml:"-"`
+	metadataPutRolePolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataPutRolePolicyOutput struct {
@@ -7625,7 +7625,7 @@ type PutUserPolicyInput struct {
 	// The name of the user to associate the policy with.
 	UserName *string `type:"string" required:"true"`
 
-	metadataPutUserPolicyInput `json:"-", xml:"-"`
+	metadataPutUserPolicyInput `json:"-" xml:"-"`
 }
 
 type metadataPutUserPolicyInput struct {
@@ -7633,7 +7633,7 @@ type metadataPutUserPolicyInput struct {
 }
 
 type PutUserPolicyOutput struct {
-	metadataPutUserPolicyOutput `json:"-", xml:"-"`
+	metadataPutUserPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataPutUserPolicyOutput struct {
@@ -7650,7 +7650,7 @@ type RemoveClientIDFromOpenIDConnectProviderInput struct {
 	// using the ListOpenIDConnectProviders action.
 	OpenIDConnectProviderARN *string `locationName:"OpenIDConnectProviderArn" type:"string" required:"true"`
 
-	metadataRemoveClientIDFromOpenIDConnectProviderInput `json:"-", xml:"-"`
+	metadataRemoveClientIDFromOpenIDConnectProviderInput `json:"-" xml:"-"`
 }
 
 type metadataRemoveClientIDFromOpenIDConnectProviderInput struct {
@@ -7658,7 +7658,7 @@ type metadataRemoveClientIDFromOpenIDConnectProviderInput struct {
 }
 
 type RemoveClientIDFromOpenIDConnectProviderOutput struct {
-	metadataRemoveClientIDFromOpenIDConnectProviderOutput `json:"-", xml:"-"`
+	metadataRemoveClientIDFromOpenIDConnectProviderOutput `json:"-" xml:"-"`
 }
 
 type metadataRemoveClientIDFromOpenIDConnectProviderOutput struct {
@@ -7672,7 +7672,7 @@ type RemoveRoleFromInstanceProfileInput struct {
 	// The name of the role to remove.
 	RoleName *string `type:"string" required:"true"`
 
-	metadataRemoveRoleFromInstanceProfileInput `json:"-", xml:"-"`
+	metadataRemoveRoleFromInstanceProfileInput `json:"-" xml:"-"`
 }
 
 type metadataRemoveRoleFromInstanceProfileInput struct {
@@ -7680,7 +7680,7 @@ type metadataRemoveRoleFromInstanceProfileInput struct {
 }
 
 type RemoveRoleFromInstanceProfileOutput struct {
-	metadataRemoveRoleFromInstanceProfileOutput `json:"-", xml:"-"`
+	metadataRemoveRoleFromInstanceProfileOutput `json:"-" xml:"-"`
 }
 
 type metadataRemoveRoleFromInstanceProfileOutput struct {
@@ -7694,7 +7694,7 @@ type RemoveUserFromGroupInput struct {
 	// The name of the user to remove.
 	UserName *string `type:"string" required:"true"`
 
-	metadataRemoveUserFromGroupInput `json:"-", xml:"-"`
+	metadataRemoveUserFromGroupInput `json:"-" xml:"-"`
 }
 
 type metadataRemoveUserFromGroupInput struct {
@@ -7702,7 +7702,7 @@ type metadataRemoveUserFromGroupInput struct {
 }
 
 type RemoveUserFromGroupOutput struct {
-	metadataRemoveUserFromGroupOutput `json:"-", xml:"-"`
+	metadataRemoveUserFromGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataRemoveUserFromGroupOutput struct {
@@ -7722,7 +7722,7 @@ type ResyncMFADeviceInput struct {
 	// The name of the user whose MFA device you want to resynchronize.
 	UserName *string `type:"string" required:"true"`
 
-	metadataResyncMFADeviceInput `json:"-", xml:"-"`
+	metadataResyncMFADeviceInput `json:"-" xml:"-"`
 }
 
 type metadataResyncMFADeviceInput struct {
@@ -7730,7 +7730,7 @@ type metadataResyncMFADeviceInput struct {
 }
 
 type ResyncMFADeviceOutput struct {
-	metadataResyncMFADeviceOutput `json:"-", xml:"-"`
+	metadataResyncMFADeviceOutput `json:"-" xml:"-"`
 }
 
 type metadataResyncMFADeviceOutput struct {
@@ -7774,7 +7774,7 @@ type Role struct {
 	// The friendly name that identifies the role.
 	RoleName *string `type:"string" required:"true"`
 
-	metadataRole `json:"-", xml:"-"`
+	metadataRole `json:"-" xml:"-"`
 }
 
 type metadataRole struct {
@@ -7826,7 +7826,7 @@ type RoleDetail struct {
 	// access (permissions) policies.
 	RolePolicyList []*PolicyDetail `type:"list"`
 
-	metadataRoleDetail `json:"-", xml:"-"`
+	metadataRoleDetail `json:"-" xml:"-"`
 }
 
 type metadataRoleDetail struct {
@@ -7844,7 +7844,7 @@ type SAMLProviderListEntry struct {
 	// The expiration date and time for the SAML provider.
 	ValidUntil *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataSAMLProviderListEntry `json:"-", xml:"-"`
+	metadataSAMLProviderListEntry `json:"-" xml:"-"`
 }
 
 type metadataSAMLProviderListEntry struct {
@@ -7866,7 +7866,7 @@ type ServerCertificate struct {
 	// and ARN.
 	ServerCertificateMetadata *ServerCertificateMetadata `type:"structure" required:"true"`
 
-	metadataServerCertificate `json:"-", xml:"-"`
+	metadataServerCertificate `json:"-" xml:"-"`
 }
 
 type metadataServerCertificate struct {
@@ -7904,7 +7904,7 @@ type ServerCertificateMetadata struct {
 	// The date when the server certificate was uploaded.
 	UploadDate *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataServerCertificateMetadata `json:"-", xml:"-"`
+	metadataServerCertificateMetadata `json:"-" xml:"-"`
 }
 
 type metadataServerCertificateMetadata struct {
@@ -7926,7 +7926,7 @@ type SetDefaultPolicyVersionInput struct {
 	// in the Using IAM guide.
 	VersionID *string `locationName:"VersionId" type:"string" required:"true"`
 
-	metadataSetDefaultPolicyVersionInput `json:"-", xml:"-"`
+	metadataSetDefaultPolicyVersionInput `json:"-" xml:"-"`
 }
 
 type metadataSetDefaultPolicyVersionInput struct {
@@ -7934,7 +7934,7 @@ type metadataSetDefaultPolicyVersionInput struct {
 }
 
 type SetDefaultPolicyVersionOutput struct {
-	metadataSetDefaultPolicyVersionOutput `json:"-", xml:"-"`
+	metadataSetDefaultPolicyVersionOutput `json:"-" xml:"-"`
 }
 
 type metadataSetDefaultPolicyVersionOutput struct {
@@ -7962,7 +7962,7 @@ type SigningCertificate struct {
 	// The name of the user the signing certificate is associated with.
 	UserName *string `type:"string" required:"true"`
 
-	metadataSigningCertificate `json:"-", xml:"-"`
+	metadataSigningCertificate `json:"-" xml:"-"`
 }
 
 type metadataSigningCertificate struct {
@@ -7981,7 +7981,7 @@ type UpdateAccessKeyInput struct {
 	// The name of the user whose key you want to update.
 	UserName *string `type:"string"`
 
-	metadataUpdateAccessKeyInput `json:"-", xml:"-"`
+	metadataUpdateAccessKeyInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateAccessKeyInput struct {
@@ -7989,7 +7989,7 @@ type metadataUpdateAccessKeyInput struct {
 }
 
 type UpdateAccessKeyOutput struct {
-	metadataUpdateAccessKeyOutput `json:"-", xml:"-"`
+	metadataUpdateAccessKeyOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateAccessKeyOutput struct {
@@ -8054,7 +8054,7 @@ type UpdateAccountPasswordPolicyInput struct {
 	// Default value: false
 	RequireUppercaseCharacters *bool `type:"boolean"`
 
-	metadataUpdateAccountPasswordPolicyInput `json:"-", xml:"-"`
+	metadataUpdateAccountPasswordPolicyInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateAccountPasswordPolicyInput struct {
@@ -8062,7 +8062,7 @@ type metadataUpdateAccountPasswordPolicyInput struct {
 }
 
 type UpdateAccountPasswordPolicyOutput struct {
-	metadataUpdateAccountPasswordPolicyOutput `json:"-", xml:"-"`
+	metadataUpdateAccountPasswordPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateAccountPasswordPolicyOutput struct {
@@ -8076,7 +8076,7 @@ type UpdateAssumeRolePolicyInput struct {
 	// The name of the role to update.
 	RoleName *string `type:"string" required:"true"`
 
-	metadataUpdateAssumeRolePolicyInput `json:"-", xml:"-"`
+	metadataUpdateAssumeRolePolicyInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateAssumeRolePolicyInput struct {
@@ -8084,7 +8084,7 @@ type metadataUpdateAssumeRolePolicyInput struct {
 }
 
 type UpdateAssumeRolePolicyOutput struct {
-	metadataUpdateAssumeRolePolicyOutput `json:"-", xml:"-"`
+	metadataUpdateAssumeRolePolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateAssumeRolePolicyOutput struct {
@@ -8102,7 +8102,7 @@ type UpdateGroupInput struct {
 	// New path for the group. Only include this if changing the group's path.
 	NewPath *string `type:"string"`
 
-	metadataUpdateGroupInput `json:"-", xml:"-"`
+	metadataUpdateGroupInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateGroupInput struct {
@@ -8110,7 +8110,7 @@ type metadataUpdateGroupInput struct {
 }
 
 type UpdateGroupOutput struct {
-	metadataUpdateGroupOutput `json:"-", xml:"-"`
+	metadataUpdateGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateGroupOutput struct {
@@ -8127,7 +8127,7 @@ type UpdateLoginProfileInput struct {
 	// The name of the user whose password you want to update.
 	UserName *string `type:"string" required:"true"`
 
-	metadataUpdateLoginProfileInput `json:"-", xml:"-"`
+	metadataUpdateLoginProfileInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateLoginProfileInput struct {
@@ -8135,7 +8135,7 @@ type metadataUpdateLoginProfileInput struct {
 }
 
 type UpdateLoginProfileOutput struct {
-	metadataUpdateLoginProfileOutput `json:"-", xml:"-"`
+	metadataUpdateLoginProfileOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateLoginProfileOutput struct {
@@ -8152,7 +8152,7 @@ type UpdateOpenIDConnectProviderThumbprintInput struct {
 	// IAM OpenID Connect provider. For more information, see CreateOpenIDConnectProvider.
 	ThumbprintList []*string `type:"list" required:"true"`
 
-	metadataUpdateOpenIDConnectProviderThumbprintInput `json:"-", xml:"-"`
+	metadataUpdateOpenIDConnectProviderThumbprintInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateOpenIDConnectProviderThumbprintInput struct {
@@ -8160,7 +8160,7 @@ type metadataUpdateOpenIDConnectProviderThumbprintInput struct {
 }
 
 type UpdateOpenIDConnectProviderThumbprintOutput struct {
-	metadataUpdateOpenIDConnectProviderThumbprintOutput `json:"-", xml:"-"`
+	metadataUpdateOpenIDConnectProviderThumbprintOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateOpenIDConnectProviderThumbprintOutput struct {
@@ -8178,7 +8178,7 @@ type UpdateSAMLProviderInput struct {
 	// The Amazon Resource Name (ARN) of the SAML provider to update.
 	SAMLProviderARN *string `locationName:"SAMLProviderArn" type:"string" required:"true"`
 
-	metadataUpdateSAMLProviderInput `json:"-", xml:"-"`
+	metadataUpdateSAMLProviderInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateSAMLProviderInput struct {
@@ -8190,7 +8190,7 @@ type UpdateSAMLProviderOutput struct {
 	// The Amazon Resource Name (ARN) of the SAML provider that was updated.
 	SAMLProviderARN *string `locationName:"SAMLProviderArn" type:"string"`
 
-	metadataUpdateSAMLProviderOutput `json:"-", xml:"-"`
+	metadataUpdateSAMLProviderOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateSAMLProviderOutput struct {
@@ -8209,7 +8209,7 @@ type UpdateServerCertificateInput struct {
 	// The name of the server certificate that you want to update.
 	ServerCertificateName *string `type:"string" required:"true"`
 
-	metadataUpdateServerCertificateInput `json:"-", xml:"-"`
+	metadataUpdateServerCertificateInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateServerCertificateInput struct {
@@ -8217,7 +8217,7 @@ type metadataUpdateServerCertificateInput struct {
 }
 
 type UpdateServerCertificateOutput struct {
-	metadataUpdateServerCertificateOutput `json:"-", xml:"-"`
+	metadataUpdateServerCertificateOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateServerCertificateOutput struct {
@@ -8236,7 +8236,7 @@ type UpdateSigningCertificateInput struct {
 	// The name of the user the signing certificate belongs to.
 	UserName *string `type:"string"`
 
-	metadataUpdateSigningCertificateInput `json:"-", xml:"-"`
+	metadataUpdateSigningCertificateInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateSigningCertificateInput struct {
@@ -8244,7 +8244,7 @@ type metadataUpdateSigningCertificateInput struct {
 }
 
 type UpdateSigningCertificateOutput struct {
-	metadataUpdateSigningCertificateOutput `json:"-", xml:"-"`
+	metadataUpdateSigningCertificateOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateSigningCertificateOutput struct {
@@ -8264,7 +8264,7 @@ type UpdateUserInput struct {
 	// is the original user name.
 	UserName *string `type:"string" required:"true"`
 
-	metadataUpdateUserInput `json:"-", xml:"-"`
+	metadataUpdateUserInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateUserInput struct {
@@ -8272,7 +8272,7 @@ type metadataUpdateUserInput struct {
 }
 
 type UpdateUserOutput struct {
-	metadataUpdateUserOutput `json:"-", xml:"-"`
+	metadataUpdateUserOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateUserOutput struct {
@@ -8306,7 +8306,7 @@ type UploadServerCertificateInput struct {
 	// The name for the server certificate. Do not include the path in this value.
 	ServerCertificateName *string `type:"string" required:"true"`
 
-	metadataUploadServerCertificateInput `json:"-", xml:"-"`
+	metadataUploadServerCertificateInput `json:"-" xml:"-"`
 }
 
 type metadataUploadServerCertificateInput struct {
@@ -8319,7 +8319,7 @@ type UploadServerCertificateOutput struct {
 	// body, certificate chain, and private key.
 	ServerCertificateMetadata *ServerCertificateMetadata `type:"structure"`
 
-	metadataUploadServerCertificateOutput `json:"-", xml:"-"`
+	metadataUploadServerCertificateOutput `json:"-" xml:"-"`
 }
 
 type metadataUploadServerCertificateOutput struct {
@@ -8333,7 +8333,7 @@ type UploadSigningCertificateInput struct {
 	// The name of the user the signing certificate is for.
 	UserName *string `type:"string"`
 
-	metadataUploadSigningCertificateInput `json:"-", xml:"-"`
+	metadataUploadSigningCertificateInput `json:"-" xml:"-"`
 }
 
 type metadataUploadSigningCertificateInput struct {
@@ -8345,7 +8345,7 @@ type UploadSigningCertificateOutput struct {
 	// Information about the certificate.
 	Certificate *SigningCertificate `type:"structure" required:"true"`
 
-	metadataUploadSigningCertificateOutput `json:"-", xml:"-"`
+	metadataUploadSigningCertificateOutput `json:"-" xml:"-"`
 }
 
 type metadataUploadSigningCertificateOutput struct {
@@ -8397,7 +8397,7 @@ type User struct {
 	// The friendly name identifying the user.
 	UserName *string `type:"string" required:"true"`
 
-	metadataUser `json:"-", xml:"-"`
+	metadataUser `json:"-" xml:"-"`
 }
 
 type metadataUser struct {
@@ -8443,7 +8443,7 @@ type UserDetail struct {
 	// A list of the inline policies embedded in the user.
 	UserPolicyList []*PolicyDetail `type:"list"`
 
-	metadataUserDetail `json:"-", xml:"-"`
+	metadataUserDetail `json:"-" xml:"-"`
 }
 
 type metadataUserDetail struct {
@@ -8479,7 +8479,7 @@ type VirtualMFADevice struct {
 	//    ListUsers
 	User *User `type:"structure"`
 
-	metadataVirtualMFADevice `json:"-", xml:"-"`
+	metadataVirtualMFADevice `json:"-" xml:"-"`
 }
 
 type metadataVirtualMFADevice struct {

--- a/service/kinesis/api.go
+++ b/service/kinesis/api.go
@@ -792,7 +792,7 @@ type AddTagsToStreamInput struct {
 	// The set of key-value pairs to use to create the tags.
 	Tags *map[string]*string `type:"map" required:"true"`
 
-	metadataAddTagsToStreamInput `json:"-", xml:"-"`
+	metadataAddTagsToStreamInput `json:"-" xml:"-"`
 }
 
 type metadataAddTagsToStreamInput struct {
@@ -800,7 +800,7 @@ type metadataAddTagsToStreamInput struct {
 }
 
 type AddTagsToStreamOutput struct {
-	metadataAddTagsToStreamOutput `json:"-", xml:"-"`
+	metadataAddTagsToStreamOutput `json:"-" xml:"-"`
 }
 
 type metadataAddTagsToStreamOutput struct {
@@ -825,7 +825,7 @@ type CreateStreamInput struct {
 	// have the same name.
 	StreamName *string `type:"string" required:"true"`
 
-	metadataCreateStreamInput `json:"-", xml:"-"`
+	metadataCreateStreamInput `json:"-" xml:"-"`
 }
 
 type metadataCreateStreamInput struct {
@@ -833,7 +833,7 @@ type metadataCreateStreamInput struct {
 }
 
 type CreateStreamOutput struct {
-	metadataCreateStreamOutput `json:"-", xml:"-"`
+	metadataCreateStreamOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateStreamOutput struct {
@@ -845,7 +845,7 @@ type DeleteStreamInput struct {
 	// The name of the stream to delete.
 	StreamName *string `type:"string" required:"true"`
 
-	metadataDeleteStreamInput `json:"-", xml:"-"`
+	metadataDeleteStreamInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteStreamInput struct {
@@ -853,7 +853,7 @@ type metadataDeleteStreamInput struct {
 }
 
 type DeleteStreamOutput struct {
-	metadataDeleteStreamOutput `json:"-", xml:"-"`
+	metadataDeleteStreamOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteStreamOutput struct {
@@ -871,7 +871,7 @@ type DescribeStreamInput struct {
 	// The name of the stream to describe.
 	StreamName *string `type:"string" required:"true"`
 
-	metadataDescribeStreamInput `json:"-", xml:"-"`
+	metadataDescribeStreamInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeStreamInput struct {
@@ -884,7 +884,7 @@ type DescribeStreamOutput struct {
 	// that comprise the stream, and states whether there are more shards available.
 	StreamDescription *StreamDescription `type:"structure" required:"true"`
 
-	metadataDescribeStreamOutput `json:"-", xml:"-"`
+	metadataDescribeStreamOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeStreamOutput struct {
@@ -902,7 +902,7 @@ type GetRecordsInput struct {
 	// number of a data record in the shard.
 	ShardIterator *string `type:"string" required:"true"`
 
-	metadataGetRecordsInput `json:"-", xml:"-"`
+	metadataGetRecordsInput `json:"-" xml:"-"`
 }
 
 type metadataGetRecordsInput struct {
@@ -919,7 +919,7 @@ type GetRecordsOutput struct {
 	// The data records retrieved from the shard.
 	Records []*Record `type:"list" required:"true"`
 
-	metadataGetRecordsOutput `json:"-", xml:"-"`
+	metadataGetRecordsOutput `json:"-" xml:"-"`
 }
 
 type metadataGetRecordsOutput struct {
@@ -952,7 +952,7 @@ type GetShardIteratorInput struct {
 	// The name of the stream.
 	StreamName *string `type:"string" required:"true"`
 
-	metadataGetShardIteratorInput `json:"-", xml:"-"`
+	metadataGetShardIteratorInput `json:"-" xml:"-"`
 }
 
 type metadataGetShardIteratorInput struct {
@@ -966,7 +966,7 @@ type GetShardIteratorOutput struct {
 	// record in a shard.
 	ShardIterator *string `type:"string"`
 
-	metadataGetShardIteratorOutput `json:"-", xml:"-"`
+	metadataGetShardIteratorOutput `json:"-" xml:"-"`
 }
 
 type metadataGetShardIteratorOutput struct {
@@ -982,7 +982,7 @@ type HashKeyRange struct {
 	// The starting hash key of the hash key range.
 	StartingHashKey *string `type:"string" required:"true"`
 
-	metadataHashKeyRange `json:"-", xml:"-"`
+	metadataHashKeyRange `json:"-" xml:"-"`
 }
 
 type metadataHashKeyRange struct {
@@ -997,7 +997,7 @@ type ListStreamsInput struct {
 	// The maximum number of streams to list.
 	Limit *int64 `type:"integer"`
 
-	metadataListStreamsInput `json:"-", xml:"-"`
+	metadataListStreamsInput `json:"-" xml:"-"`
 }
 
 type metadataListStreamsInput struct {
@@ -1013,7 +1013,7 @@ type ListStreamsOutput struct {
 	// the ListStreams request.
 	StreamNames []*string `type:"list" required:"true"`
 
-	metadataListStreamsOutput `json:"-", xml:"-"`
+	metadataListStreamsOutput `json:"-" xml:"-"`
 }
 
 type metadataListStreamsOutput struct {
@@ -1034,7 +1034,7 @@ type ListTagsForStreamInput struct {
 	// The name of the stream.
 	StreamName *string `type:"string" required:"true"`
 
-	metadataListTagsForStreamInput `json:"-", xml:"-"`
+	metadataListTagsForStreamInput `json:"-" xml:"-"`
 }
 
 type metadataListTagsForStreamInput struct {
@@ -1051,7 +1051,7 @@ type ListTagsForStreamOutput struct {
 	// ExclusiveStartTagKey and up to the specified Limit.
 	Tags []*Tag `type:"list" required:"true"`
 
-	metadataListTagsForStreamOutput `json:"-", xml:"-"`
+	metadataListTagsForStreamOutput `json:"-" xml:"-"`
 }
 
 type metadataListTagsForStreamOutput struct {
@@ -1069,7 +1069,7 @@ type MergeShardsInput struct {
 	// The name of the stream for the merge.
 	StreamName *string `type:"string" required:"true"`
 
-	metadataMergeShardsInput `json:"-", xml:"-"`
+	metadataMergeShardsInput `json:"-" xml:"-"`
 }
 
 type metadataMergeShardsInput struct {
@@ -1077,7 +1077,7 @@ type metadataMergeShardsInput struct {
 }
 
 type MergeShardsOutput struct {
-	metadataMergeShardsOutput `json:"-", xml:"-"`
+	metadataMergeShardsOutput `json:"-" xml:"-"`
 }
 
 type metadataMergeShardsOutput struct {
@@ -1115,7 +1115,7 @@ type PutRecordInput struct {
 	// The name of the stream to put the data record into.
 	StreamName *string `type:"string" required:"true"`
 
-	metadataPutRecordInput `json:"-", xml:"-"`
+	metadataPutRecordInput `json:"-" xml:"-"`
 }
 
 type metadataPutRecordInput struct {
@@ -1133,7 +1133,7 @@ type PutRecordOutput struct {
 	// The shard ID of the shard where the data record was placed.
 	ShardID *string `locationName:"ShardId" type:"string" required:"true"`
 
-	metadataPutRecordOutput `json:"-", xml:"-"`
+	metadataPutRecordOutput `json:"-" xml:"-"`
 }
 
 type metadataPutRecordOutput struct {
@@ -1148,7 +1148,7 @@ type PutRecordsInput struct {
 	// The stream name associated with the request.
 	StreamName *string `type:"string" required:"true"`
 
-	metadataPutRecordsInput `json:"-", xml:"-"`
+	metadataPutRecordsInput `json:"-" xml:"-"`
 }
 
 type metadataPutRecordsInput struct {
@@ -1167,7 +1167,7 @@ type PutRecordsOutput struct {
 	// ErrorCode and ErrorMessage in the result.
 	Records []*PutRecordsResultEntry `type:"list" required:"true"`
 
-	metadataPutRecordsOutput `json:"-", xml:"-"`
+	metadataPutRecordsOutput `json:"-" xml:"-"`
 }
 
 type metadataPutRecordsOutput struct {
@@ -1195,7 +1195,7 @@ type PutRecordsRequestEntry struct {
 	// the stream.
 	PartitionKey *string `type:"string" required:"true"`
 
-	metadataPutRecordsRequestEntry `json:"-", xml:"-"`
+	metadataPutRecordsRequestEntry `json:"-" xml:"-"`
 }
 
 type metadataPutRecordsRequestEntry struct {
@@ -1224,7 +1224,7 @@ type PutRecordsResultEntry struct {
 	// The shard ID for an individual record result.
 	ShardID *string `locationName:"ShardId" type:"string"`
 
-	metadataPutRecordsResultEntry `json:"-", xml:"-"`
+	metadataPutRecordsResultEntry `json:"-" xml:"-"`
 }
 
 type metadataPutRecordsResultEntry struct {
@@ -1246,7 +1246,7 @@ type Record struct {
 	// The unique identifier for the record in the Amazon Kinesis stream.
 	SequenceNumber *string `type:"string" required:"true"`
 
-	metadataRecord `json:"-", xml:"-"`
+	metadataRecord `json:"-" xml:"-"`
 }
 
 type metadataRecord struct {
@@ -1261,7 +1261,7 @@ type RemoveTagsFromStreamInput struct {
 	// A list of tag keys. Each corresponding tag is removed from the stream.
 	TagKeys []*string `type:"list" required:"true"`
 
-	metadataRemoveTagsFromStreamInput `json:"-", xml:"-"`
+	metadataRemoveTagsFromStreamInput `json:"-" xml:"-"`
 }
 
 type metadataRemoveTagsFromStreamInput struct {
@@ -1269,7 +1269,7 @@ type metadataRemoveTagsFromStreamInput struct {
 }
 
 type RemoveTagsFromStreamOutput struct {
-	metadataRemoveTagsFromStreamOutput `json:"-", xml:"-"`
+	metadataRemoveTagsFromStreamOutput `json:"-" xml:"-"`
 }
 
 type metadataRemoveTagsFromStreamOutput struct {
@@ -1285,7 +1285,7 @@ type SequenceNumberRange struct {
 	// The starting sequence number for the range.
 	StartingSequenceNumber *string `type:"string" required:"true"`
 
-	metadataSequenceNumberRange `json:"-", xml:"-"`
+	metadataSequenceNumberRange `json:"-" xml:"-"`
 }
 
 type metadataSequenceNumberRange struct {
@@ -1310,7 +1310,7 @@ type Shard struct {
 	// The unique identifier of the shard within the Amazon Kinesis stream.
 	ShardID *string `locationName:"ShardId" type:"string" required:"true"`
 
-	metadataShard `json:"-", xml:"-"`
+	metadataShard `json:"-" xml:"-"`
 }
 
 type metadataShard struct {
@@ -1334,7 +1334,7 @@ type SplitShardInput struct {
 	// The name of the stream for the shard split.
 	StreamName *string `type:"string" required:"true"`
 
-	metadataSplitShardInput `json:"-", xml:"-"`
+	metadataSplitShardInput `json:"-" xml:"-"`
 }
 
 type metadataSplitShardInput struct {
@@ -1342,7 +1342,7 @@ type metadataSplitShardInput struct {
 }
 
 type SplitShardOutput struct {
-	metadataSplitShardOutput `json:"-", xml:"-"`
+	metadataSplitShardOutput `json:"-" xml:"-"`
 }
 
 type metadataSplitShardOutput struct {
@@ -1377,7 +1377,7 @@ type StreamDescription struct {
 	// the UPDATING state.
 	StreamStatus *string `type:"string" required:"true"`
 
-	metadataStreamDescription `json:"-", xml:"-"`
+	metadataStreamDescription `json:"-" xml:"-"`
 }
 
 type metadataStreamDescription struct {
@@ -1395,7 +1395,7 @@ type Tag struct {
 	// space, _ . / = + - % @
 	Value *string `type:"string"`
 
-	metadataTag `json:"-", xml:"-"`
+	metadataTag `json:"-" xml:"-"`
 }
 
 type metadataTag struct {

--- a/service/kms/api.go
+++ b/service/kms/api.go
@@ -931,7 +931,7 @@ type AliasListEntry struct {
 	// String that contains the key identifier pointed to by the alias.
 	TargetKeyID *string `locationName:"TargetKeyId" type:"string"`
 
-	metadataAliasListEntry `json:"-", xml:"-"`
+	metadataAliasListEntry `json:"-" xml:"-"`
 }
 
 type metadataAliasListEntry struct {
@@ -948,7 +948,7 @@ type CreateAliasInput struct {
 	// Globally Unique Key ID Example - 12345678-1234-1234-123456789012
 	TargetKeyID *string `locationName:"TargetKeyId" type:"string" required:"true"`
 
-	metadataCreateAliasInput `json:"-", xml:"-"`
+	metadataCreateAliasInput `json:"-" xml:"-"`
 }
 
 type metadataCreateAliasInput struct {
@@ -956,7 +956,7 @@ type metadataCreateAliasInput struct {
 }
 
 type CreateAliasOutput struct {
-	metadataCreateAliasOutput `json:"-", xml:"-"`
+	metadataCreateAliasOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateAliasOutput struct {
@@ -990,7 +990,7 @@ type CreateGrantInput struct {
 	// RetireGrant.
 	RetiringPrincipal *string `type:"string"`
 
-	metadataCreateGrantInput `json:"-", xml:"-"`
+	metadataCreateGrantInput `json:"-" xml:"-"`
 }
 
 type metadataCreateGrantInput struct {
@@ -1004,7 +1004,7 @@ type CreateGrantOutput struct {
 	// For more information, see Grant Tokens (http://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token).
 	GrantToken *string `type:"string"`
 
-	metadataCreateGrantOutput `json:"-", xml:"-"`
+	metadataCreateGrantOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateGrantOutput struct {
@@ -1024,7 +1024,7 @@ type CreateKeyInput struct {
 	// the account. The key is the root of trust.
 	Policy *string `type:"string"`
 
-	metadataCreateKeyInput `json:"-", xml:"-"`
+	metadataCreateKeyInput `json:"-" xml:"-"`
 }
 
 type metadataCreateKeyInput struct {
@@ -1035,7 +1035,7 @@ type CreateKeyOutput struct {
 	// Metadata associated with the key.
 	KeyMetadata *KeyMetadata `type:"structure"`
 
-	metadataCreateKeyOutput `json:"-", xml:"-"`
+	metadataCreateKeyOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateKeyOutput struct {
@@ -1054,7 +1054,7 @@ type DecryptInput struct {
 	// For more information, see Grant Tokens (http://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token).
 	GrantTokens []*string `type:"list"`
 
-	metadataDecryptInput `json:"-", xml:"-"`
+	metadataDecryptInput `json:"-" xml:"-"`
 }
 
 type metadataDecryptInput struct {
@@ -1070,7 +1070,7 @@ type DecryptOutput struct {
 	// master key is not available or if you didn't have permission to use it.
 	Plaintext []byte `type:"blob"`
 
-	metadataDecryptOutput `json:"-", xml:"-"`
+	metadataDecryptOutput `json:"-" xml:"-"`
 }
 
 type metadataDecryptOutput struct {
@@ -1081,7 +1081,7 @@ type DeleteAliasInput struct {
 	// The alias to be deleted.
 	AliasName *string `type:"string" required:"true"`
 
-	metadataDeleteAliasInput `json:"-", xml:"-"`
+	metadataDeleteAliasInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteAliasInput struct {
@@ -1089,7 +1089,7 @@ type metadataDeleteAliasInput struct {
 }
 
 type DeleteAliasOutput struct {
-	metadataDeleteAliasOutput `json:"-", xml:"-"`
+	metadataDeleteAliasOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteAliasOutput struct {
@@ -1105,7 +1105,7 @@ type DescribeKeyInput struct {
 	// Example - alias/MyAliasName
 	KeyID *string `locationName:"KeyId" type:"string" required:"true"`
 
-	metadataDescribeKeyInput `json:"-", xml:"-"`
+	metadataDescribeKeyInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeKeyInput struct {
@@ -1116,7 +1116,7 @@ type DescribeKeyOutput struct {
 	// Metadata associated with the key.
 	KeyMetadata *KeyMetadata `type:"structure"`
 
-	metadataDescribeKeyOutput `json:"-", xml:"-"`
+	metadataDescribeKeyOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeKeyOutput struct {
@@ -1130,7 +1130,7 @@ type DisableKeyInput struct {
 	// Globally Unique Key ID Example - 12345678-1234-1234-123456789012
 	KeyID *string `locationName:"KeyId" type:"string" required:"true"`
 
-	metadataDisableKeyInput `json:"-", xml:"-"`
+	metadataDisableKeyInput `json:"-" xml:"-"`
 }
 
 type metadataDisableKeyInput struct {
@@ -1138,7 +1138,7 @@ type metadataDisableKeyInput struct {
 }
 
 type DisableKeyOutput struct {
-	metadataDisableKeyOutput `json:"-", xml:"-"`
+	metadataDisableKeyOutput `json:"-" xml:"-"`
 }
 
 type metadataDisableKeyOutput struct {
@@ -1152,7 +1152,7 @@ type DisableKeyRotationInput struct {
 	// Globally Unique Key ID Example - 12345678-1234-1234-123456789012
 	KeyID *string `locationName:"KeyId" type:"string" required:"true"`
 
-	metadataDisableKeyRotationInput `json:"-", xml:"-"`
+	metadataDisableKeyRotationInput `json:"-" xml:"-"`
 }
 
 type metadataDisableKeyRotationInput struct {
@@ -1160,7 +1160,7 @@ type metadataDisableKeyRotationInput struct {
 }
 
 type DisableKeyRotationOutput struct {
-	metadataDisableKeyRotationOutput `json:"-", xml:"-"`
+	metadataDisableKeyRotationOutput `json:"-" xml:"-"`
 }
 
 type metadataDisableKeyRotationOutput struct {
@@ -1174,7 +1174,7 @@ type EnableKeyInput struct {
 	// Globally Unique Key ID Example - 12345678-1234-1234-123456789012
 	KeyID *string `locationName:"KeyId" type:"string" required:"true"`
 
-	metadataEnableKeyInput `json:"-", xml:"-"`
+	metadataEnableKeyInput `json:"-" xml:"-"`
 }
 
 type metadataEnableKeyInput struct {
@@ -1182,7 +1182,7 @@ type metadataEnableKeyInput struct {
 }
 
 type EnableKeyOutput struct {
-	metadataEnableKeyOutput `json:"-", xml:"-"`
+	metadataEnableKeyOutput `json:"-" xml:"-"`
 }
 
 type metadataEnableKeyOutput struct {
@@ -1196,7 +1196,7 @@ type EnableKeyRotationInput struct {
 	// Globally Unique Key ID Example - 12345678-1234-1234-123456789012
 	KeyID *string `locationName:"KeyId" type:"string" required:"true"`
 
-	metadataEnableKeyRotationInput `json:"-", xml:"-"`
+	metadataEnableKeyRotationInput `json:"-" xml:"-"`
 }
 
 type metadataEnableKeyRotationInput struct {
@@ -1204,7 +1204,7 @@ type metadataEnableKeyRotationInput struct {
 }
 
 type EnableKeyRotationOutput struct {
-	metadataEnableKeyRotationOutput `json:"-", xml:"-"`
+	metadataEnableKeyRotationOutput `json:"-" xml:"-"`
 }
 
 type metadataEnableKeyRotationOutput struct {
@@ -1232,7 +1232,7 @@ type EncryptInput struct {
 	// Data to be encrypted.
 	Plaintext []byte `type:"blob" required:"true"`
 
-	metadataEncryptInput `json:"-", xml:"-"`
+	metadataEncryptInput `json:"-" xml:"-"`
 }
 
 type metadataEncryptInput struct {
@@ -1247,7 +1247,7 @@ type EncryptOutput struct {
 	// The ID of the key used during encryption.
 	KeyID *string `locationName:"KeyId" type:"string"`
 
-	metadataEncryptOutput `json:"-", xml:"-"`
+	metadataEncryptOutput `json:"-" xml:"-"`
 }
 
 type metadataEncryptOutput struct {
@@ -1280,7 +1280,7 @@ type GenerateDataKeyInput struct {
 	// use the KeySpec parameter instead.
 	NumberOfBytes *int64 `type:"integer"`
 
-	metadataGenerateDataKeyInput `json:"-", xml:"-"`
+	metadataGenerateDataKeyInput `json:"-" xml:"-"`
 }
 
 type metadataGenerateDataKeyInput struct {
@@ -1306,7 +1306,7 @@ type GenerateDataKeyOutput struct {
 	// and then remove it from memory as soon as possible.
 	Plaintext []byte `type:"blob"`
 
-	metadataGenerateDataKeyOutput `json:"-", xml:"-"`
+	metadataGenerateDataKeyOutput `json:"-" xml:"-"`
 }
 
 type metadataGenerateDataKeyOutput struct {
@@ -1338,7 +1338,7 @@ type GenerateDataKeyWithoutPlaintextInput struct {
 	// instead.
 	NumberOfBytes *int64 `type:"integer"`
 
-	metadataGenerateDataKeyWithoutPlaintextInput `json:"-", xml:"-"`
+	metadataGenerateDataKeyWithoutPlaintextInput `json:"-" xml:"-"`
 }
 
 type metadataGenerateDataKeyWithoutPlaintextInput struct {
@@ -1357,7 +1357,7 @@ type GenerateDataKeyWithoutPlaintextOutput struct {
 	// copy of the data key.
 	KeyID *string `locationName:"KeyId" type:"string"`
 
-	metadataGenerateDataKeyWithoutPlaintextOutput `json:"-", xml:"-"`
+	metadataGenerateDataKeyWithoutPlaintextOutput `json:"-" xml:"-"`
 }
 
 type metadataGenerateDataKeyWithoutPlaintextOutput struct {
@@ -1369,7 +1369,7 @@ type GenerateRandomInput struct {
 	// 128, 256, 512, 1024 and so on. The current limit is 1024 bytes.
 	NumberOfBytes *int64 `type:"integer"`
 
-	metadataGenerateRandomInput `json:"-", xml:"-"`
+	metadataGenerateRandomInput `json:"-" xml:"-"`
 }
 
 type metadataGenerateRandomInput struct {
@@ -1380,7 +1380,7 @@ type GenerateRandomOutput struct {
 	// Plaintext that contains the unpredictable byte string.
 	Plaintext []byte `type:"blob"`
 
-	metadataGenerateRandomOutput `json:"-", xml:"-"`
+	metadataGenerateRandomOutput `json:"-" xml:"-"`
 }
 
 type metadataGenerateRandomOutput struct {
@@ -1398,7 +1398,7 @@ type GetKeyPolicyInput struct {
 	// Policy names can be discovered by calling ListKeyPolicies.
 	PolicyName *string `type:"string" required:"true"`
 
-	metadataGetKeyPolicyInput `json:"-", xml:"-"`
+	metadataGetKeyPolicyInput `json:"-" xml:"-"`
 }
 
 type metadataGetKeyPolicyInput struct {
@@ -1409,7 +1409,7 @@ type GetKeyPolicyOutput struct {
 	// A policy document in JSON format.
 	Policy *string `type:"string"`
 
-	metadataGetKeyPolicyOutput `json:"-", xml:"-"`
+	metadataGetKeyPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataGetKeyPolicyOutput struct {
@@ -1423,7 +1423,7 @@ type GetKeyRotationStatusInput struct {
 	// Globally Unique Key ID Example - 12345678-1234-1234-123456789012
 	KeyID *string `locationName:"KeyId" type:"string" required:"true"`
 
-	metadataGetKeyRotationStatusInput `json:"-", xml:"-"`
+	metadataGetKeyRotationStatusInput `json:"-" xml:"-"`
 }
 
 type metadataGetKeyRotationStatusInput struct {
@@ -1434,7 +1434,7 @@ type GetKeyRotationStatusOutput struct {
 	// A Boolean value that specifies whether key rotation is enabled.
 	KeyRotationEnabled *bool `type:"boolean"`
 
-	metadataGetKeyRotationStatusOutput `json:"-", xml:"-"`
+	metadataGetKeyRotationStatusOutput `json:"-" xml:"-"`
 }
 
 type metadataGetKeyRotationStatusOutput struct {
@@ -1450,7 +1450,7 @@ type GrantConstraints struct {
 	// The constraint equals the full encryption context.
 	EncryptionContextSubset *map[string]*string `type:"map"`
 
-	metadataGrantConstraints `json:"-", xml:"-"`
+	metadataGrantConstraints `json:"-" xml:"-"`
 }
 
 type metadataGrantConstraints struct {
@@ -1480,7 +1480,7 @@ type GrantListEntry struct {
 	// The principal that can retire the account.
 	RetiringPrincipal *string `type:"string"`
 
-	metadataGrantListEntry `json:"-", xml:"-"`
+	metadataGrantListEntry `json:"-" xml:"-"`
 }
 
 type metadataGrantListEntry struct {
@@ -1495,7 +1495,7 @@ type KeyListEntry struct {
 	// Unique identifier of the key.
 	KeyID *string `locationName:"KeyId" type:"string"`
 
-	metadataKeyListEntry `json:"-", xml:"-"`
+	metadataKeyListEntry `json:"-" xml:"-"`
 }
 
 type metadataKeyListEntry struct {
@@ -1525,7 +1525,7 @@ type KeyMetadata struct {
 	// A value that specifies what operation(s) the key can perform.
 	KeyUsage *string `type:"string"`
 
-	metadataKeyMetadata `json:"-", xml:"-"`
+	metadataKeyMetadata `json:"-" xml:"-"`
 }
 
 type metadataKeyMetadata struct {
@@ -1543,7 +1543,7 @@ type ListAliasesInput struct {
 	// to the value of the NextMarker element in the response you just received.
 	Marker *string `type:"string"`
 
-	metadataListAliasesInput `json:"-", xml:"-"`
+	metadataListAliasesInput `json:"-" xml:"-"`
 }
 
 type metadataListAliasesInput struct {
@@ -1563,7 +1563,7 @@ type ListAliasesOutput struct {
 	// request parameter to retrieve more aliases in the list.
 	Truncated *bool `type:"boolean"`
 
-	metadataListAliasesOutput `json:"-", xml:"-"`
+	metadataListAliasesOutput `json:"-" xml:"-"`
 }
 
 type metadataListAliasesOutput struct {
@@ -1588,7 +1588,7 @@ type ListGrantsInput struct {
 	// Set it to the value of the NextMarker in the response you just received.
 	Marker *string `type:"string"`
 
-	metadataListGrantsInput `json:"-", xml:"-"`
+	metadataListGrantsInput `json:"-" xml:"-"`
 }
 
 type metadataListGrantsInput struct {
@@ -1608,7 +1608,7 @@ type ListGrantsOutput struct {
 	// request parameter to retrieve more grants in the list.
 	Truncated *bool `type:"boolean"`
 
-	metadataListGrantsOutput `json:"-", xml:"-"`
+	metadataListGrantsOutput `json:"-" xml:"-"`
 }
 
 type metadataListGrantsOutput struct {
@@ -1635,7 +1635,7 @@ type ListKeyPoliciesInput struct {
 	// Set it to the value of the NextMarker in the response you just received.
 	Marker *string `type:"string"`
 
-	metadataListKeyPoliciesInput `json:"-", xml:"-"`
+	metadataListKeyPoliciesInput `json:"-" xml:"-"`
 }
 
 type metadataListKeyPoliciesInput struct {
@@ -1656,7 +1656,7 @@ type ListKeyPoliciesOutput struct {
 	// request parameter to retrieve more policies in the list.
 	Truncated *bool `type:"boolean"`
 
-	metadataListKeyPoliciesOutput `json:"-", xml:"-"`
+	metadataListKeyPoliciesOutput `json:"-" xml:"-"`
 }
 
 type metadataListKeyPoliciesOutput struct {
@@ -1675,7 +1675,7 @@ type ListKeysInput struct {
 	// Set it to the value of the NextMarker in the response you just received.
 	Marker *string `type:"string"`
 
-	metadataListKeysInput `json:"-", xml:"-"`
+	metadataListKeysInput `json:"-" xml:"-"`
 }
 
 type metadataListKeysInput struct {
@@ -1695,7 +1695,7 @@ type ListKeysOutput struct {
 	// request parameter to retrieve more keys in the list.
 	Truncated *bool `type:"boolean"`
 
-	metadataListKeysOutput `json:"-", xml:"-"`
+	metadataListKeysOutput `json:"-" xml:"-"`
 }
 
 type metadataListKeysOutput struct {
@@ -1716,7 +1716,7 @@ type PutKeyPolicyInput struct {
 	// "default".
 	PolicyName *string `type:"string" required:"true"`
 
-	metadataPutKeyPolicyInput `json:"-", xml:"-"`
+	metadataPutKeyPolicyInput `json:"-" xml:"-"`
 }
 
 type metadataPutKeyPolicyInput struct {
@@ -1724,7 +1724,7 @@ type metadataPutKeyPolicyInput struct {
 }
 
 type PutKeyPolicyOutput struct {
-	metadataPutKeyPolicyOutput `json:"-", xml:"-"`
+	metadataPutKeyPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataPutKeyPolicyOutput struct {
@@ -1754,7 +1754,7 @@ type ReEncryptInput struct {
 	// CiphertextBlob parameter.
 	SourceEncryptionContext *map[string]*string `type:"map"`
 
-	metadataReEncryptInput `json:"-", xml:"-"`
+	metadataReEncryptInput `json:"-" xml:"-"`
 }
 
 type metadataReEncryptInput struct {
@@ -1772,7 +1772,7 @@ type ReEncryptOutput struct {
 	// Unique identifier of the key used to originally encrypt the data.
 	SourceKeyID *string `locationName:"SourceKeyId" type:"string"`
 
-	metadataReEncryptOutput `json:"-", xml:"-"`
+	metadataReEncryptOutput `json:"-" xml:"-"`
 }
 
 type metadataReEncryptOutput struct {
@@ -1783,7 +1783,7 @@ type RetireGrantInput struct {
 	// Token that identifies the grant to be retired.
 	GrantToken *string `type:"string" required:"true"`
 
-	metadataRetireGrantInput `json:"-", xml:"-"`
+	metadataRetireGrantInput `json:"-" xml:"-"`
 }
 
 type metadataRetireGrantInput struct {
@@ -1791,7 +1791,7 @@ type metadataRetireGrantInput struct {
 }
 
 type RetireGrantOutput struct {
-	metadataRetireGrantOutput `json:"-", xml:"-"`
+	metadataRetireGrantOutput `json:"-" xml:"-"`
 }
 
 type metadataRetireGrantOutput struct {
@@ -1808,7 +1808,7 @@ type RevokeGrantInput struct {
 	// Globally Unique Key ID Example - 12345678-1234-1234-123456789012
 	KeyID *string `locationName:"KeyId" type:"string" required:"true"`
 
-	metadataRevokeGrantInput `json:"-", xml:"-"`
+	metadataRevokeGrantInput `json:"-" xml:"-"`
 }
 
 type metadataRevokeGrantInput struct {
@@ -1816,7 +1816,7 @@ type metadataRevokeGrantInput struct {
 }
 
 type RevokeGrantOutput struct {
-	metadataRevokeGrantOutput `json:"-", xml:"-"`
+	metadataRevokeGrantOutput `json:"-" xml:"-"`
 }
 
 type metadataRevokeGrantOutput struct {
@@ -1833,7 +1833,7 @@ type UpdateKeyDescriptionInput struct {
 	// Globally Unique Key ID Example - 12345678-1234-1234-123456789012
 	KeyID *string `locationName:"KeyId" type:"string" required:"true"`
 
-	metadataUpdateKeyDescriptionInput `json:"-", xml:"-"`
+	metadataUpdateKeyDescriptionInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateKeyDescriptionInput struct {
@@ -1841,7 +1841,7 @@ type metadataUpdateKeyDescriptionInput struct {
 }
 
 type UpdateKeyDescriptionOutput struct {
-	metadataUpdateKeyDescriptionOutput `json:"-", xml:"-"`
+	metadataUpdateKeyDescriptionOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateKeyDescriptionOutput struct {

--- a/service/lambda/api.go
+++ b/service/lambda/api.go
@@ -722,7 +722,7 @@ type AddPermissionInput struct {
 	// A unique statement identifier.
 	StatementID *string `locationName:"StatementId" type:"string" required:"true"`
 
-	metadataAddPermissionInput `json:"-", xml:"-"`
+	metadataAddPermissionInput `json:"-" xml:"-"`
 }
 
 type metadataAddPermissionInput struct {
@@ -734,7 +734,7 @@ type AddPermissionOutput struct {
 	// the same as a string using "\" as an escape character in the JSON.
 	Statement *string `type:"string"`
 
-	metadataAddPermissionOutput `json:"-", xml:"-"`
+	metadataAddPermissionOutput `json:"-" xml:"-"`
 }
 
 type metadataAddPermissionOutput struct {
@@ -771,7 +771,7 @@ type CreateEventSourceMappingInput struct {
 	// in the Amazon Kinesis API Reference.
 	StartingPosition *string `type:"string" required:"true"`
 
-	metadataCreateEventSourceMappingInput `json:"-", xml:"-"`
+	metadataCreateEventSourceMappingInput `json:"-" xml:"-"`
 }
 
 type metadataCreateEventSourceMappingInput struct {
@@ -823,7 +823,7 @@ type CreateFunctionInput struct {
 	// value based on your expected execution time. The default is 3 seconds.
 	Timeout *int64 `type:"integer"`
 
-	metadataCreateFunctionInput `json:"-", xml:"-"`
+	metadataCreateFunctionInput `json:"-" xml:"-"`
 }
 
 type metadataCreateFunctionInput struct {
@@ -834,7 +834,7 @@ type DeleteEventSourceMappingInput struct {
 	// The event source mapping ID.
 	UUID *string `location:"uri" locationName:"UUID" type:"string" required:"true"`
 
-	metadataDeleteEventSourceMappingInput `json:"-", xml:"-"`
+	metadataDeleteEventSourceMappingInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteEventSourceMappingInput struct {
@@ -852,7 +852,7 @@ type DeleteFunctionInput struct {
 	// the function name, it is limited to 64 character in length.
 	FunctionName *string `location:"uri" locationName:"FunctionName" type:"string" required:"true"`
 
-	metadataDeleteFunctionInput `json:"-", xml:"-"`
+	metadataDeleteFunctionInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteFunctionInput struct {
@@ -860,7 +860,7 @@ type metadataDeleteFunctionInput struct {
 }
 
 type DeleteFunctionOutput struct {
-	metadataDeleteFunctionOutput `json:"-", xml:"-"`
+	metadataDeleteFunctionOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteFunctionOutput struct {
@@ -898,7 +898,7 @@ type EventSourceMappingConfiguration struct {
 	// The AWS Lambda assigned opaque identifier for the mapping.
 	UUID *string `type:"string"`
 
-	metadataEventSourceMappingConfiguration `json:"-", xml:"-"`
+	metadataEventSourceMappingConfiguration `json:"-" xml:"-"`
 }
 
 type metadataEventSourceMappingConfiguration struct {
@@ -912,7 +912,7 @@ type FunctionCode struct {
 	// in the AWS Lambda Developer Guide.
 	ZipFile []byte `type:"blob"`
 
-	metadataFunctionCode `json:"-", xml:"-"`
+	metadataFunctionCode `json:"-" xml:"-"`
 }
 
 type metadataFunctionCode struct {
@@ -928,7 +928,7 @@ type FunctionCodeLocation struct {
 	// The repository from which you can download the function.
 	RepositoryType *string `type:"string"`
 
-	metadataFunctionCodeLocation `json:"-", xml:"-"`
+	metadataFunctionCodeLocation `json:"-" xml:"-"`
 }
 
 type metadataFunctionCodeLocation struct {
@@ -971,7 +971,7 @@ type FunctionConfiguration struct {
 	// value based on your expected execution time. The default is 3 seconds.
 	Timeout *int64 `type:"integer"`
 
-	metadataFunctionConfiguration `json:"-", xml:"-"`
+	metadataFunctionConfiguration `json:"-" xml:"-"`
 }
 
 type metadataFunctionConfiguration struct {
@@ -982,7 +982,7 @@ type GetEventSourceMappingInput struct {
 	// The AWS Lambda assigned ID of the event source mapping.
 	UUID *string `location:"uri" locationName:"UUID" type:"string" required:"true"`
 
-	metadataGetEventSourceMappingInput `json:"-", xml:"-"`
+	metadataGetEventSourceMappingInput `json:"-" xml:"-"`
 }
 
 type metadataGetEventSourceMappingInput struct {
@@ -1001,7 +1001,7 @@ type GetFunctionConfigurationInput struct {
 	// the function name, it is limited to 64 character in length.
 	FunctionName *string `location:"uri" locationName:"FunctionName" type:"string" required:"true"`
 
-	metadataGetFunctionConfigurationInput `json:"-", xml:"-"`
+	metadataGetFunctionConfigurationInput `json:"-" xml:"-"`
 }
 
 type metadataGetFunctionConfigurationInput struct {
@@ -1019,7 +1019,7 @@ type GetFunctionInput struct {
 	// the function name, it is limited to 64 character in length.
 	FunctionName *string `location:"uri" locationName:"FunctionName" type:"string" required:"true"`
 
-	metadataGetFunctionInput `json:"-", xml:"-"`
+	metadataGetFunctionInput `json:"-" xml:"-"`
 }
 
 type metadataGetFunctionInput struct {
@@ -1034,7 +1034,7 @@ type GetFunctionOutput struct {
 	// A complex type that describes function metadata.
 	Configuration *FunctionConfiguration `type:"structure"`
 
-	metadataGetFunctionOutput `json:"-", xml:"-"`
+	metadataGetFunctionOutput `json:"-" xml:"-"`
 }
 
 type metadataGetFunctionOutput struct {
@@ -1052,7 +1052,7 @@ type GetPolicyInput struct {
 	// the function name, it is limited to 64 character in length.
 	FunctionName *string `location:"uri" locationName:"FunctionName" type:"string" required:"true"`
 
-	metadataGetPolicyInput `json:"-", xml:"-"`
+	metadataGetPolicyInput `json:"-" xml:"-"`
 }
 
 type metadataGetPolicyInput struct {
@@ -1064,7 +1064,7 @@ type GetPolicyOutput struct {
 	// the same as a string using "\" as an escape character in the JSON.
 	Policy *string `type:"string"`
 
-	metadataGetPolicyOutput `json:"-", xml:"-"`
+	metadataGetPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataGetPolicyOutput struct {
@@ -1078,7 +1078,7 @@ type InvokeAsyncInput struct {
 	// JSON that you want to provide to your Lambda function as input.
 	InvokeArgs io.ReadSeeker `type:"blob" required:"true"`
 
-	metadataInvokeAsyncInput `json:"-", xml:"-"`
+	metadataInvokeAsyncInput `json:"-" xml:"-"`
 }
 
 type metadataInvokeAsyncInput struct {
@@ -1090,7 +1090,7 @@ type InvokeAsyncOutput struct {
 	// It will be 202 upon success.
 	Status *int64 `location:"statusCode" type:"integer"`
 
-	metadataInvokeAsyncOutput `json:"-", xml:"-"`
+	metadataInvokeAsyncOutput `json:"-" xml:"-"`
 }
 
 type metadataInvokeAsyncOutput struct {
@@ -1135,7 +1135,7 @@ type InvokeInput struct {
 	// JSON that you want to provide to your Lambda function as input.
 	Payload []byte `type:"blob"`
 
-	metadataInvokeInput `json:"-", xml:"-"`
+	metadataInvokeInput `json:"-" xml:"-"`
 }
 
 type metadataInvokeInput struct {
@@ -1171,7 +1171,7 @@ type InvokeOutput struct {
 	// type the status code will be 204.
 	StatusCode *int64 `location:"statusCode" type:"integer"`
 
-	metadataInvokeOutput `json:"-", xml:"-"`
+	metadataInvokeOutput `json:"-" xml:"-"`
 }
 
 type metadataInvokeOutput struct {
@@ -1201,7 +1201,7 @@ type ListEventSourceMappingsInput struct {
 	// in response. This value must be greater than 0.
 	MaxItems *int64 `location:"querystring" locationName:"MaxItems" type:"integer"`
 
-	metadataListEventSourceMappingsInput `json:"-", xml:"-"`
+	metadataListEventSourceMappingsInput `json:"-" xml:"-"`
 }
 
 type metadataListEventSourceMappingsInput struct {
@@ -1216,7 +1216,7 @@ type ListEventSourceMappingsOutput struct {
 	// A string, present if there are more event source mappings.
 	NextMarker *string `type:"string"`
 
-	metadataListEventSourceMappingsOutput `json:"-", xml:"-"`
+	metadataListEventSourceMappingsOutput `json:"-" xml:"-"`
 }
 
 type metadataListEventSourceMappingsOutput struct {
@@ -1232,7 +1232,7 @@ type ListFunctionsInput struct {
 	// return in response. This parameter value must be greater than 0.
 	MaxItems *int64 `location:"querystring" locationName:"MaxItems" type:"integer"`
 
-	metadataListFunctionsInput `json:"-", xml:"-"`
+	metadataListFunctionsInput `json:"-" xml:"-"`
 }
 
 type metadataListFunctionsInput struct {
@@ -1247,7 +1247,7 @@ type ListFunctionsOutput struct {
 	// A string, present if there are more functions.
 	NextMarker *string `type:"string"`
 
-	metadataListFunctionsOutput `json:"-", xml:"-"`
+	metadataListFunctionsOutput `json:"-" xml:"-"`
 }
 
 type metadataListFunctionsOutput struct {
@@ -1268,7 +1268,7 @@ type RemovePermissionInput struct {
 	// Statement ID of the permission to remove.
 	StatementID *string `location:"uri" locationName:"StatementId" type:"string" required:"true"`
 
-	metadataRemovePermissionInput `json:"-", xml:"-"`
+	metadataRemovePermissionInput `json:"-" xml:"-"`
 }
 
 type metadataRemovePermissionInput struct {
@@ -1276,7 +1276,7 @@ type metadataRemovePermissionInput struct {
 }
 
 type RemovePermissionOutput struct {
-	metadataRemovePermissionOutput `json:"-", xml:"-"`
+	metadataRemovePermissionOutput `json:"-" xml:"-"`
 }
 
 type metadataRemovePermissionOutput struct {
@@ -1305,7 +1305,7 @@ type UpdateEventSourceMappingInput struct {
 	// The event source mapping identifier.
 	UUID *string `location:"uri" locationName:"UUID" type:"string" required:"true"`
 
-	metadataUpdateEventSourceMappingInput `json:"-", xml:"-"`
+	metadataUpdateEventSourceMappingInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateEventSourceMappingInput struct {
@@ -1326,7 +1326,7 @@ type UpdateFunctionCodeInput struct {
 	// Based64-encoded .zip file containing your packaged source code.
 	ZipFile []byte `type:"blob" required:"true"`
 
-	metadataUpdateFunctionCodeInput `json:"-", xml:"-"`
+	metadataUpdateFunctionCodeInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateFunctionCodeInput struct {
@@ -1369,7 +1369,7 @@ type UpdateFunctionConfigurationInput struct {
 	// value based on your expected execution time. The default is 3 seconds.
 	Timeout *int64 `type:"integer"`
 
-	metadataUpdateFunctionConfigurationInput `json:"-", xml:"-"`
+	metadataUpdateFunctionConfigurationInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateFunctionConfigurationInput struct {

--- a/service/opsworks/api.go
+++ b/service/opsworks/api.go
@@ -2612,7 +2612,7 @@ type App struct {
 	// The app type.
 	Type *string `type:"string"`
 
-	metadataApp `json:"-", xml:"-"`
+	metadataApp `json:"-" xml:"-"`
 }
 
 type metadataApp struct {
@@ -2627,7 +2627,7 @@ type AssignInstanceInput struct {
 	// a registered instance to a built-in layer.
 	LayerIDs []*string `locationName:"LayerIds" type:"list" required:"true"`
 
-	metadataAssignInstanceInput `json:"-", xml:"-"`
+	metadataAssignInstanceInput `json:"-" xml:"-"`
 }
 
 type metadataAssignInstanceInput struct {
@@ -2635,7 +2635,7 @@ type metadataAssignInstanceInput struct {
 }
 
 type AssignInstanceOutput struct {
-	metadataAssignInstanceOutput `json:"-", xml:"-"`
+	metadataAssignInstanceOutput `json:"-" xml:"-"`
 }
 
 type metadataAssignInstanceOutput struct {
@@ -2649,7 +2649,7 @@ type AssignVolumeInput struct {
 	// The volume ID.
 	VolumeID *string `locationName:"VolumeId" type:"string" required:"true"`
 
-	metadataAssignVolumeInput `json:"-", xml:"-"`
+	metadataAssignVolumeInput `json:"-" xml:"-"`
 }
 
 type metadataAssignVolumeInput struct {
@@ -2657,7 +2657,7 @@ type metadataAssignVolumeInput struct {
 }
 
 type AssignVolumeOutput struct {
-	metadataAssignVolumeOutput `json:"-", xml:"-"`
+	metadataAssignVolumeOutput `json:"-" xml:"-"`
 }
 
 type metadataAssignVolumeOutput struct {
@@ -2671,7 +2671,7 @@ type AssociateElasticIPInput struct {
 	// The instance ID.
 	InstanceID *string `locationName:"InstanceId" type:"string"`
 
-	metadataAssociateElasticIPInput `json:"-", xml:"-"`
+	metadataAssociateElasticIPInput `json:"-" xml:"-"`
 }
 
 type metadataAssociateElasticIPInput struct {
@@ -2679,7 +2679,7 @@ type metadataAssociateElasticIPInput struct {
 }
 
 type AssociateElasticIPOutput struct {
-	metadataAssociateElasticIPOutput `json:"-", xml:"-"`
+	metadataAssociateElasticIPOutput `json:"-" xml:"-"`
 }
 
 type metadataAssociateElasticIPOutput struct {
@@ -2694,7 +2694,7 @@ type AttachElasticLoadBalancerInput struct {
 	// to.
 	LayerID *string `locationName:"LayerId" type:"string" required:"true"`
 
-	metadataAttachElasticLoadBalancerInput `json:"-", xml:"-"`
+	metadataAttachElasticLoadBalancerInput `json:"-" xml:"-"`
 }
 
 type metadataAttachElasticLoadBalancerInput struct {
@@ -2702,7 +2702,7 @@ type metadataAttachElasticLoadBalancerInput struct {
 }
 
 type AttachElasticLoadBalancerOutput struct {
-	metadataAttachElasticLoadBalancerOutput `json:"-", xml:"-"`
+	metadataAttachElasticLoadBalancerOutput `json:"-" xml:"-"`
 }
 
 type metadataAttachElasticLoadBalancerOutput struct {
@@ -2739,7 +2739,7 @@ type AutoScalingThresholds struct {
 	// more instances are added or removed.
 	ThresholdsWaitTime *int64 `type:"integer"`
 
-	metadataAutoScalingThresholds `json:"-", xml:"-"`
+	metadataAutoScalingThresholds `json:"-" xml:"-"`
 }
 
 type metadataAutoScalingThresholds struct {
@@ -2754,7 +2754,7 @@ type ChefConfiguration struct {
 	// Whether to enable Berkshelf.
 	ManageBerkshelf *bool `type:"boolean"`
 
-	metadataChefConfiguration `json:"-", xml:"-"`
+	metadataChefConfiguration `json:"-" xml:"-"`
 }
 
 type metadataChefConfiguration struct {
@@ -2910,7 +2910,7 @@ type CloneStackInput struct {
 	// (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-supported-platforms.html).
 	VPCID *string `locationName:"VpcId" type:"string"`
 
-	metadataCloneStackInput `json:"-", xml:"-"`
+	metadataCloneStackInput `json:"-" xml:"-"`
 }
 
 type metadataCloneStackInput struct {
@@ -2922,7 +2922,7 @@ type CloneStackOutput struct {
 	// The cloned stack ID.
 	StackID *string `locationName:"StackId" type:"string"`
 
-	metadataCloneStackOutput `json:"-", xml:"-"`
+	metadataCloneStackOutput `json:"-" xml:"-"`
 }
 
 type metadataCloneStackOutput struct {
@@ -2966,7 +2966,7 @@ type Command struct {
 	// update_custom_cookbooks execute_recipes
 	Type *string `type:"string"`
 
-	metadataCommand `json:"-", xml:"-"`
+	metadataCommand `json:"-" xml:"-"`
 }
 
 type metadataCommand struct {
@@ -3020,7 +3020,7 @@ type CreateAppInput struct {
 	// layer.
 	Type *string `type:"string" required:"true"`
 
-	metadataCreateAppInput `json:"-", xml:"-"`
+	metadataCreateAppInput `json:"-" xml:"-"`
 }
 
 type metadataCreateAppInput struct {
@@ -3032,7 +3032,7 @@ type CreateAppOutput struct {
 	// The app ID.
 	AppID *string `locationName:"AppId" type:"string"`
 
-	metadataCreateAppOutput `json:"-", xml:"-"`
+	metadataCreateAppOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateAppOutput struct {
@@ -3067,7 +3067,7 @@ type CreateDeploymentInput struct {
 	// The stack ID.
 	StackID *string `locationName:"StackId" type:"string" required:"true"`
 
-	metadataCreateDeploymentInput `json:"-", xml:"-"`
+	metadataCreateDeploymentInput `json:"-" xml:"-"`
 }
 
 type metadataCreateDeploymentInput struct {
@@ -3080,7 +3080,7 @@ type CreateDeploymentOutput struct {
 	// deployment.
 	DeploymentID *string `locationName:"DeploymentId" type:"string"`
 
-	metadataCreateDeploymentOutput `json:"-", xml:"-"`
+	metadataCreateDeploymentOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateDeploymentOutput struct {
@@ -3164,7 +3164,7 @@ type CreateInstanceInput struct {
 	// The instance's virtualization type, paravirtual or hvm.
 	VirtualizationType *string `type:"string"`
 
-	metadataCreateInstanceInput `json:"-", xml:"-"`
+	metadataCreateInstanceInput `json:"-" xml:"-"`
 }
 
 type metadataCreateInstanceInput struct {
@@ -3176,7 +3176,7 @@ type CreateInstanceOutput struct {
 	// The instance ID.
 	InstanceID *string `locationName:"InstanceId" type:"string"`
 
-	metadataCreateInstanceOutput `json:"-", xml:"-"`
+	metadataCreateInstanceOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateInstanceOutput struct {
@@ -3249,7 +3249,7 @@ type CreateLayerInput struct {
 	// A VolumeConfigurations object that describes the layer's Amazon EBS volumes.
 	VolumeConfigurations []*VolumeConfiguration `type:"list"`
 
-	metadataCreateLayerInput `json:"-", xml:"-"`
+	metadataCreateLayerInput `json:"-" xml:"-"`
 }
 
 type metadataCreateLayerInput struct {
@@ -3261,7 +3261,7 @@ type CreateLayerOutput struct {
 	// The layer ID.
 	LayerID *string `locationName:"LayerId" type:"string"`
 
-	metadataCreateLayerOutput `json:"-", xml:"-"`
+	metadataCreateLayerOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateLayerOutput struct {
@@ -3402,7 +3402,7 @@ type CreateStackInput struct {
 	// (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-supported-platforms.html).
 	VPCID *string `locationName:"VpcId" type:"string"`
 
-	metadataCreateStackInput `json:"-", xml:"-"`
+	metadataCreateStackInput `json:"-" xml:"-"`
 }
 
 type metadataCreateStackInput struct {
@@ -3415,7 +3415,7 @@ type CreateStackOutput struct {
 	// when performing actions such as DescribeStacks.
 	StackID *string `locationName:"StackId" type:"string"`
 
-	metadataCreateStackOutput `json:"-", xml:"-"`
+	metadataCreateStackOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateStackOutput struct {
@@ -3440,7 +3440,7 @@ type CreateUserProfileInput struct {
 	// IAM user name.
 	SSHUsername *string `locationName:"SshUsername" type:"string"`
 
-	metadataCreateUserProfileInput `json:"-", xml:"-"`
+	metadataCreateUserProfileInput `json:"-" xml:"-"`
 }
 
 type metadataCreateUserProfileInput struct {
@@ -3452,7 +3452,7 @@ type CreateUserProfileOutput struct {
 	// The user's IAM ARN.
 	IAMUserARN *string `locationName:"IamUserArn" type:"string"`
 
-	metadataCreateUserProfileOutput `json:"-", xml:"-"`
+	metadataCreateUserProfileOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateUserProfileOutput struct {
@@ -3471,7 +3471,7 @@ type DataSource struct {
 	// or RdsDbInstance.
 	Type *string `type:"string"`
 
-	metadataDataSource `json:"-", xml:"-"`
+	metadataDataSource `json:"-" xml:"-"`
 }
 
 type metadataDataSource struct {
@@ -3482,7 +3482,7 @@ type DeleteAppInput struct {
 	// The app ID.
 	AppID *string `locationName:"AppId" type:"string" required:"true"`
 
-	metadataDeleteAppInput `json:"-", xml:"-"`
+	metadataDeleteAppInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteAppInput struct {
@@ -3490,7 +3490,7 @@ type metadataDeleteAppInput struct {
 }
 
 type DeleteAppOutput struct {
-	metadataDeleteAppOutput `json:"-", xml:"-"`
+	metadataDeleteAppOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteAppOutput struct {
@@ -3507,7 +3507,7 @@ type DeleteInstanceInput struct {
 	// The instance ID.
 	InstanceID *string `locationName:"InstanceId" type:"string" required:"true"`
 
-	metadataDeleteInstanceInput `json:"-", xml:"-"`
+	metadataDeleteInstanceInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteInstanceInput struct {
@@ -3515,7 +3515,7 @@ type metadataDeleteInstanceInput struct {
 }
 
 type DeleteInstanceOutput struct {
-	metadataDeleteInstanceOutput `json:"-", xml:"-"`
+	metadataDeleteInstanceOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteInstanceOutput struct {
@@ -3526,7 +3526,7 @@ type DeleteLayerInput struct {
 	// The layer ID.
 	LayerID *string `locationName:"LayerId" type:"string" required:"true"`
 
-	metadataDeleteLayerInput `json:"-", xml:"-"`
+	metadataDeleteLayerInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteLayerInput struct {
@@ -3534,7 +3534,7 @@ type metadataDeleteLayerInput struct {
 }
 
 type DeleteLayerOutput struct {
-	metadataDeleteLayerOutput `json:"-", xml:"-"`
+	metadataDeleteLayerOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteLayerOutput struct {
@@ -3545,7 +3545,7 @@ type DeleteStackInput struct {
 	// The stack ID.
 	StackID *string `locationName:"StackId" type:"string" required:"true"`
 
-	metadataDeleteStackInput `json:"-", xml:"-"`
+	metadataDeleteStackInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteStackInput struct {
@@ -3553,7 +3553,7 @@ type metadataDeleteStackInput struct {
 }
 
 type DeleteStackOutput struct {
-	metadataDeleteStackOutput `json:"-", xml:"-"`
+	metadataDeleteStackOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteStackOutput struct {
@@ -3564,7 +3564,7 @@ type DeleteUserProfileInput struct {
 	// The user's IAM ARN.
 	IAMUserARN *string `locationName:"IamUserArn" type:"string" required:"true"`
 
-	metadataDeleteUserProfileInput `json:"-", xml:"-"`
+	metadataDeleteUserProfileInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteUserProfileInput struct {
@@ -3572,7 +3572,7 @@ type metadataDeleteUserProfileInput struct {
 }
 
 type DeleteUserProfileOutput struct {
-	metadataDeleteUserProfileOutput `json:"-", xml:"-"`
+	metadataDeleteUserProfileOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteUserProfileOutput struct {
@@ -3626,7 +3626,7 @@ type Deployment struct {
 	//  running successful failed
 	Status *string `type:"string"`
 
-	metadataDeployment `json:"-", xml:"-"`
+	metadataDeployment `json:"-" xml:"-"`
 }
 
 type metadataDeployment struct {
@@ -3675,7 +3675,7 @@ type DeploymentCommand struct {
 	// the app's web or application server.  undeploy: Undeploy the app.
 	Name *string `type:"string" required:"true"`
 
-	metadataDeploymentCommand `json:"-", xml:"-"`
+	metadataDeploymentCommand `json:"-" xml:"-"`
 }
 
 type metadataDeploymentCommand struct {
@@ -3686,7 +3686,7 @@ type DeregisterElasticIPInput struct {
 	// The Elastic IP address.
 	ElasticIP *string `locationName:"ElasticIp" type:"string" required:"true"`
 
-	metadataDeregisterElasticIPInput `json:"-", xml:"-"`
+	metadataDeregisterElasticIPInput `json:"-" xml:"-"`
 }
 
 type metadataDeregisterElasticIPInput struct {
@@ -3694,7 +3694,7 @@ type metadataDeregisterElasticIPInput struct {
 }
 
 type DeregisterElasticIPOutput struct {
-	metadataDeregisterElasticIPOutput `json:"-", xml:"-"`
+	metadataDeregisterElasticIPOutput `json:"-" xml:"-"`
 }
 
 type metadataDeregisterElasticIPOutput struct {
@@ -3705,7 +3705,7 @@ type DeregisterInstanceInput struct {
 	// The instance ID.
 	InstanceID *string `locationName:"InstanceId" type:"string" required:"true"`
 
-	metadataDeregisterInstanceInput `json:"-", xml:"-"`
+	metadataDeregisterInstanceInput `json:"-" xml:"-"`
 }
 
 type metadataDeregisterInstanceInput struct {
@@ -3713,7 +3713,7 @@ type metadataDeregisterInstanceInput struct {
 }
 
 type DeregisterInstanceOutput struct {
-	metadataDeregisterInstanceOutput `json:"-", xml:"-"`
+	metadataDeregisterInstanceOutput `json:"-" xml:"-"`
 }
 
 type metadataDeregisterInstanceOutput struct {
@@ -3724,7 +3724,7 @@ type DeregisterRDSDBInstanceInput struct {
 	// The Amazon RDS instance's ARN.
 	RDSDBInstanceARN *string `locationName:"RdsDbInstanceArn" type:"string" required:"true"`
 
-	metadataDeregisterRDSDBInstanceInput `json:"-", xml:"-"`
+	metadataDeregisterRDSDBInstanceInput `json:"-" xml:"-"`
 }
 
 type metadataDeregisterRDSDBInstanceInput struct {
@@ -3732,7 +3732,7 @@ type metadataDeregisterRDSDBInstanceInput struct {
 }
 
 type DeregisterRDSDBInstanceOutput struct {
-	metadataDeregisterRDSDBInstanceOutput `json:"-", xml:"-"`
+	metadataDeregisterRDSDBInstanceOutput `json:"-" xml:"-"`
 }
 
 type metadataDeregisterRDSDBInstanceOutput struct {
@@ -3743,7 +3743,7 @@ type DeregisterVolumeInput struct {
 	// The volume ID.
 	VolumeID *string `locationName:"VolumeId" type:"string" required:"true"`
 
-	metadataDeregisterVolumeInput `json:"-", xml:"-"`
+	metadataDeregisterVolumeInput `json:"-" xml:"-"`
 }
 
 type metadataDeregisterVolumeInput struct {
@@ -3751,7 +3751,7 @@ type metadataDeregisterVolumeInput struct {
 }
 
 type DeregisterVolumeOutput struct {
-	metadataDeregisterVolumeOutput `json:"-", xml:"-"`
+	metadataDeregisterVolumeOutput `json:"-" xml:"-"`
 }
 
 type metadataDeregisterVolumeOutput struct {
@@ -3768,7 +3768,7 @@ type DescribeAppsInput struct {
 	// of the apps in the specified stack.
 	StackID *string `locationName:"StackId" type:"string"`
 
-	metadataDescribeAppsInput `json:"-", xml:"-"`
+	metadataDescribeAppsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeAppsInput struct {
@@ -3780,7 +3780,7 @@ type DescribeAppsOutput struct {
 	// An array of App objects that describe the specified apps.
 	Apps []*App `type:"list"`
 
-	metadataDescribeAppsOutput `json:"-", xml:"-"`
+	metadataDescribeAppsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeAppsOutput struct {
@@ -3801,7 +3801,7 @@ type DescribeCommandsInput struct {
 	// a description of the commands associated with the specified instance.
 	InstanceID *string `locationName:"InstanceId" type:"string"`
 
-	metadataDescribeCommandsInput `json:"-", xml:"-"`
+	metadataDescribeCommandsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeCommandsInput struct {
@@ -3813,7 +3813,7 @@ type DescribeCommandsOutput struct {
 	// An array of Command objects that describe each of the specified commands.
 	Commands []*Command `type:"list"`
 
-	metadataDescribeCommandsOutput `json:"-", xml:"-"`
+	metadataDescribeCommandsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeCommandsOutput struct {
@@ -3834,7 +3834,7 @@ type DescribeDeploymentsInput struct {
 	// a description of the commands associated with the specified stack.
 	StackID *string `locationName:"StackId" type:"string"`
 
-	metadataDescribeDeploymentsInput `json:"-", xml:"-"`
+	metadataDescribeDeploymentsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeDeploymentsInput struct {
@@ -3846,7 +3846,7 @@ type DescribeDeploymentsOutput struct {
 	// An array of Deployment objects that describe the deployments.
 	Deployments []*Deployment `type:"list"`
 
-	metadataDescribeDeploymentsOutput `json:"-", xml:"-"`
+	metadataDescribeDeploymentsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeDeploymentsOutput struct {
@@ -3867,7 +3867,7 @@ type DescribeElasticIPsInput struct {
 	// of the Elastic IP addresses that are registered with the specified stack.
 	StackID *string `locationName:"StackId" type:"string"`
 
-	metadataDescribeElasticIPsInput `json:"-", xml:"-"`
+	metadataDescribeElasticIPsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeElasticIPsInput struct {
@@ -3879,7 +3879,7 @@ type DescribeElasticIPsOutput struct {
 	// An ElasticIps object that describes the specified Elastic IP addresses.
 	ElasticIPs []*ElasticIP `locationName:"ElasticIps" type:"list"`
 
-	metadataDescribeElasticIPsOutput `json:"-", xml:"-"`
+	metadataDescribeElasticIPsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeElasticIPsOutput struct {
@@ -3894,7 +3894,7 @@ type DescribeElasticLoadBalancersInput struct {
 	// A stack ID. The action describes the stack's Elastic Load Balancing instances.
 	StackID *string `locationName:"StackId" type:"string"`
 
-	metadataDescribeElasticLoadBalancersInput `json:"-", xml:"-"`
+	metadataDescribeElasticLoadBalancersInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeElasticLoadBalancersInput struct {
@@ -3907,7 +3907,7 @@ type DescribeElasticLoadBalancersOutput struct {
 	// Load Balancing instances.
 	ElasticLoadBalancers []*ElasticLoadBalancer `type:"list"`
 
-	metadataDescribeElasticLoadBalancersOutput `json:"-", xml:"-"`
+	metadataDescribeElasticLoadBalancersOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeElasticLoadBalancersOutput struct {
@@ -3928,7 +3928,7 @@ type DescribeInstancesInput struct {
 	// of the instances associated with the specified stack.
 	StackID *string `locationName:"StackId" type:"string"`
 
-	metadataDescribeInstancesInput `json:"-", xml:"-"`
+	metadataDescribeInstancesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeInstancesInput struct {
@@ -3940,7 +3940,7 @@ type DescribeInstancesOutput struct {
 	// An array of Instance objects that describe the instances.
 	Instances []*Instance `type:"list"`
 
-	metadataDescribeInstancesOutput `json:"-", xml:"-"`
+	metadataDescribeInstancesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeInstancesOutput struct {
@@ -3956,7 +3956,7 @@ type DescribeLayersInput struct {
 	// The stack ID.
 	StackID *string `locationName:"StackId" type:"string"`
 
-	metadataDescribeLayersInput `json:"-", xml:"-"`
+	metadataDescribeLayersInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeLayersInput struct {
@@ -3968,7 +3968,7 @@ type DescribeLayersOutput struct {
 	// An array of Layer objects that describe the layers.
 	Layers []*Layer `type:"list"`
 
-	metadataDescribeLayersOutput `json:"-", xml:"-"`
+	metadataDescribeLayersOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeLayersOutput struct {
@@ -3979,7 +3979,7 @@ type DescribeLoadBasedAutoScalingInput struct {
 	// An array of layer IDs.
 	LayerIDs []*string `locationName:"LayerIds" type:"list" required:"true"`
 
-	metadataDescribeLoadBasedAutoScalingInput `json:"-", xml:"-"`
+	metadataDescribeLoadBasedAutoScalingInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeLoadBasedAutoScalingInput struct {
@@ -3992,7 +3992,7 @@ type DescribeLoadBasedAutoScalingOutput struct {
 	// layer's configuration.
 	LoadBasedAutoScalingConfigurations []*LoadBasedAutoScalingConfiguration `type:"list"`
 
-	metadataDescribeLoadBasedAutoScalingOutput `json:"-", xml:"-"`
+	metadataDescribeLoadBasedAutoScalingOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeLoadBasedAutoScalingOutput struct {
@@ -4000,7 +4000,7 @@ type metadataDescribeLoadBasedAutoScalingOutput struct {
 }
 
 type DescribeMyUserProfileInput struct {
-	metadataDescribeMyUserProfileInput `json:"-", xml:"-"`
+	metadataDescribeMyUserProfileInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeMyUserProfileInput struct {
@@ -4012,7 +4012,7 @@ type DescribeMyUserProfileOutput struct {
 	// A UserProfile object that describes the user's SSH information.
 	UserProfile *SelfUserProfile `type:"structure"`
 
-	metadataDescribeMyUserProfileOutput `json:"-", xml:"-"`
+	metadataDescribeMyUserProfileOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeMyUserProfileOutput struct {
@@ -4027,7 +4027,7 @@ type DescribePermissionsInput struct {
 	// The stack ID.
 	StackID *string `locationName:"StackId" type:"string"`
 
-	metadataDescribePermissionsInput `json:"-", xml:"-"`
+	metadataDescribePermissionsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribePermissionsInput struct {
@@ -4046,7 +4046,7 @@ type DescribePermissionsOutput struct {
 	// for the specified stack and IAM ARN.
 	Permissions []*Permission `type:"list"`
 
-	metadataDescribePermissionsOutput `json:"-", xml:"-"`
+	metadataDescribePermissionsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribePermissionsOutput struct {
@@ -4066,7 +4066,7 @@ type DescribeRAIDArraysInput struct {
 	// The stack ID.
 	StackID *string `locationName:"StackId" type:"string"`
 
-	metadataDescribeRAIDArraysInput `json:"-", xml:"-"`
+	metadataDescribeRAIDArraysInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeRAIDArraysInput struct {
@@ -4078,7 +4078,7 @@ type DescribeRAIDArraysOutput struct {
 	// A RaidArrays object that describes the specified RAID arrays.
 	RAIDArrays []*RAIDArray `locationName:"RaidArrays" type:"list"`
 
-	metadataDescribeRAIDArraysOutput `json:"-", xml:"-"`
+	metadataDescribeRAIDArraysOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeRAIDArraysOutput struct {
@@ -4093,7 +4093,7 @@ type DescribeRDSDBInstancesInput struct {
 	// descriptions of all registered Amazon RDS instances.
 	StackID *string `locationName:"StackId" type:"string" required:"true"`
 
-	metadataDescribeRDSDBInstancesInput `json:"-", xml:"-"`
+	metadataDescribeRDSDBInstancesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeRDSDBInstancesInput struct {
@@ -4105,7 +4105,7 @@ type DescribeRDSDBInstancesOutput struct {
 	// An a array of RdsDbInstance objects that describe the instances.
 	RDSDBInstances []*RDSDBInstance `locationName:"RdsDbInstances" type:"list"`
 
-	metadataDescribeRDSDBInstancesOutput `json:"-", xml:"-"`
+	metadataDescribeRDSDBInstancesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeRDSDBInstancesOutput struct {
@@ -4126,7 +4126,7 @@ type DescribeServiceErrorsInput struct {
 	// of the errors associated with the specified stack.
 	StackID *string `locationName:"StackId" type:"string"`
 
-	metadataDescribeServiceErrorsInput `json:"-", xml:"-"`
+	metadataDescribeServiceErrorsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeServiceErrorsInput struct {
@@ -4138,7 +4138,7 @@ type DescribeServiceErrorsOutput struct {
 	// An array of ServiceError objects that describe the specified service errors.
 	ServiceErrors []*ServiceError `type:"list"`
 
-	metadataDescribeServiceErrorsOutput `json:"-", xml:"-"`
+	metadataDescribeServiceErrorsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeServiceErrorsOutput struct {
@@ -4149,7 +4149,7 @@ type DescribeStackProvisioningParametersInput struct {
 	// The stack ID
 	StackID *string `locationName:"StackId" type:"string" required:"true"`
 
-	metadataDescribeStackProvisioningParametersInput `json:"-", xml:"-"`
+	metadataDescribeStackProvisioningParametersInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeStackProvisioningParametersInput struct {
@@ -4164,7 +4164,7 @@ type DescribeStackProvisioningParametersOutput struct {
 	// An embedded object that contains the provisioning parameters.
 	Parameters *map[string]*string `type:"map"`
 
-	metadataDescribeStackProvisioningParametersOutput `json:"-", xml:"-"`
+	metadataDescribeStackProvisioningParametersOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeStackProvisioningParametersOutput struct {
@@ -4175,7 +4175,7 @@ type DescribeStackSummaryInput struct {
 	// The stack ID.
 	StackID *string `locationName:"StackId" type:"string" required:"true"`
 
-	metadataDescribeStackSummaryInput `json:"-", xml:"-"`
+	metadataDescribeStackSummaryInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeStackSummaryInput struct {
@@ -4187,7 +4187,7 @@ type DescribeStackSummaryOutput struct {
 	// A StackSummary object that contains the results.
 	StackSummary *StackSummary `type:"structure"`
 
-	metadataDescribeStackSummaryOutput `json:"-", xml:"-"`
+	metadataDescribeStackSummaryOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeStackSummaryOutput struct {
@@ -4199,7 +4199,7 @@ type DescribeStacksInput struct {
 	// this parameter, DescribeStacks returns a description of every stack.
 	StackIDs []*string `locationName:"StackIds" type:"list"`
 
-	metadataDescribeStacksInput `json:"-", xml:"-"`
+	metadataDescribeStacksInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeStacksInput struct {
@@ -4211,7 +4211,7 @@ type DescribeStacksOutput struct {
 	// An array of Stack objects that describe the stacks.
 	Stacks []*Stack `type:"list"`
 
-	metadataDescribeStacksOutput `json:"-", xml:"-"`
+	metadataDescribeStacksOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeStacksOutput struct {
@@ -4222,7 +4222,7 @@ type DescribeTimeBasedAutoScalingInput struct {
 	// An array of instance IDs.
 	InstanceIDs []*string `locationName:"InstanceIds" type:"list" required:"true"`
 
-	metadataDescribeTimeBasedAutoScalingInput `json:"-", xml:"-"`
+	metadataDescribeTimeBasedAutoScalingInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeTimeBasedAutoScalingInput struct {
@@ -4235,7 +4235,7 @@ type DescribeTimeBasedAutoScalingOutput struct {
 	// for the specified instances.
 	TimeBasedAutoScalingConfigurations []*TimeBasedAutoScalingConfiguration `type:"list"`
 
-	metadataDescribeTimeBasedAutoScalingOutput `json:"-", xml:"-"`
+	metadataDescribeTimeBasedAutoScalingOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeTimeBasedAutoScalingOutput struct {
@@ -4246,7 +4246,7 @@ type DescribeUserProfilesInput struct {
 	// An array of IAM user ARNs that identify the users to be described.
 	IAMUserARNs []*string `locationName:"IamUserArns" type:"list"`
 
-	metadataDescribeUserProfilesInput `json:"-", xml:"-"`
+	metadataDescribeUserProfilesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeUserProfilesInput struct {
@@ -4258,7 +4258,7 @@ type DescribeUserProfilesOutput struct {
 	// A Users object that describes the specified users.
 	UserProfiles []*UserProfile `type:"list"`
 
-	metadataDescribeUserProfilesOutput `json:"-", xml:"-"`
+	metadataDescribeUserProfilesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeUserProfilesOutput struct {
@@ -4282,7 +4282,7 @@ type DescribeVolumesInput struct {
 	// of every volume.
 	VolumeIDs []*string `locationName:"VolumeIds" type:"list"`
 
-	metadataDescribeVolumesInput `json:"-", xml:"-"`
+	metadataDescribeVolumesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeVolumesInput struct {
@@ -4294,7 +4294,7 @@ type DescribeVolumesOutput struct {
 	// An array of volume IDs.
 	Volumes []*Volume `type:"list"`
 
-	metadataDescribeVolumesOutput `json:"-", xml:"-"`
+	metadataDescribeVolumesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeVolumesOutput struct {
@@ -4309,7 +4309,7 @@ type DetachElasticLoadBalancerInput struct {
 	// to.
 	LayerID *string `locationName:"LayerId" type:"string" required:"true"`
 
-	metadataDetachElasticLoadBalancerInput `json:"-", xml:"-"`
+	metadataDetachElasticLoadBalancerInput `json:"-" xml:"-"`
 }
 
 type metadataDetachElasticLoadBalancerInput struct {
@@ -4317,7 +4317,7 @@ type metadataDetachElasticLoadBalancerInput struct {
 }
 
 type DetachElasticLoadBalancerOutput struct {
-	metadataDetachElasticLoadBalancerOutput `json:"-", xml:"-"`
+	metadataDetachElasticLoadBalancerOutput `json:"-" xml:"-"`
 }
 
 type metadataDetachElasticLoadBalancerOutput struct {
@@ -4328,7 +4328,7 @@ type DisassociateElasticIPInput struct {
 	// The Elastic IP address.
 	ElasticIP *string `locationName:"ElasticIp" type:"string" required:"true"`
 
-	metadataDisassociateElasticIPInput `json:"-", xml:"-"`
+	metadataDisassociateElasticIPInput `json:"-" xml:"-"`
 }
 
 type metadataDisassociateElasticIPInput struct {
@@ -4336,7 +4336,7 @@ type metadataDisassociateElasticIPInput struct {
 }
 
 type DisassociateElasticIPOutput struct {
-	metadataDisassociateElasticIPOutput `json:"-", xml:"-"`
+	metadataDisassociateElasticIPOutput `json:"-" xml:"-"`
 }
 
 type metadataDisassociateElasticIPOutput struct {
@@ -4360,7 +4360,7 @@ type ElasticIP struct {
 	// The AWS region. For more information, see Regions and Endpoints (http://docs.aws.amazon.com/general/latest/gr/rande.html).
 	Region *string `type:"string"`
 
-	metadataElasticIP `json:"-", xml:"-"`
+	metadataElasticIP `json:"-" xml:"-"`
 }
 
 type metadataElasticIP struct {
@@ -4397,7 +4397,7 @@ type ElasticLoadBalancer struct {
 	// The VPC ID.
 	VPCID *string `locationName:"VpcId" type:"string"`
 
-	metadataElasticLoadBalancer `json:"-", xml:"-"`
+	metadataElasticLoadBalancer `json:"-" xml:"-"`
 }
 
 type metadataElasticLoadBalancer struct {
@@ -4423,7 +4423,7 @@ type EnvironmentVariable struct {
 	// be printable.
 	Value *string `type:"string" required:"true"`
 
-	metadataEnvironmentVariable `json:"-", xml:"-"`
+	metadataEnvironmentVariable `json:"-" xml:"-"`
 }
 
 type metadataEnvironmentVariable struct {
@@ -4434,7 +4434,7 @@ type GetHostnameSuggestionInput struct {
 	// The layer ID.
 	LayerID *string `locationName:"LayerId" type:"string" required:"true"`
 
-	metadataGetHostnameSuggestionInput `json:"-", xml:"-"`
+	metadataGetHostnameSuggestionInput `json:"-" xml:"-"`
 }
 
 type metadataGetHostnameSuggestionInput struct {
@@ -4449,7 +4449,7 @@ type GetHostnameSuggestionOutput struct {
 	// The layer ID.
 	LayerID *string `locationName:"LayerId" type:"string"`
 
-	metadataGetHostnameSuggestionOutput `json:"-", xml:"-"`
+	metadataGetHostnameSuggestionOutput `json:"-" xml:"-"`
 }
 
 type metadataGetHostnameSuggestionOutput struct {
@@ -4576,7 +4576,7 @@ type Instance struct {
 	// The instance's virtualization type, paravirtual or hvm.
 	VirtualizationType *string `type:"string"`
 
-	metadataInstance `json:"-", xml:"-"`
+	metadataInstance `json:"-" xml:"-"`
 }
 
 type metadataInstance struct {
@@ -4592,7 +4592,7 @@ type InstanceIdentity struct {
 	// A signature that can be used to verify the document's accuracy and authenticity.
 	Signature *string `type:"string"`
 
-	metadataInstanceIdentity `json:"-", xml:"-"`
+	metadataInstanceIdentity `json:"-" xml:"-"`
 }
 
 type metadataInstanceIdentity struct {
@@ -4658,7 +4658,7 @@ type InstancesCount struct {
 	// The number of instances in the Unassigning state.
 	Unassigning *int64 `type:"integer"`
 
-	metadataInstancesCount `json:"-", xml:"-"`
+	metadataInstancesCount `json:"-" xml:"-"`
 }
 
 type metadataInstancesCount struct {
@@ -4748,7 +4748,7 @@ type Layer struct {
 	// A VolumeConfigurations object that describes the layer's Amazon EBS volumes.
 	VolumeConfigurations []*VolumeConfiguration `type:"list"`
 
-	metadataLayer `json:"-", xml:"-"`
+	metadataLayer `json:"-" xml:"-"`
 }
 
 type metadataLayer struct {
@@ -4760,7 +4760,7 @@ type LifecycleEventConfiguration struct {
 	// A ShutdownEventConfiguration object that specifies the Shutdown event configuration.
 	Shutdown *ShutdownEventConfiguration `type:"structure"`
 
-	metadataLifecycleEventConfiguration `json:"-", xml:"-"`
+	metadataLifecycleEventConfiguration `json:"-" xml:"-"`
 }
 
 type metadataLifecycleEventConfiguration struct {
@@ -4783,7 +4783,7 @@ type LoadBasedAutoScalingConfiguration struct {
 	// which defines how and when AWS OpsWorks increases the number of instances.
 	UpScaling *AutoScalingThresholds `type:"structure"`
 
-	metadataLoadBasedAutoScalingConfiguration `json:"-", xml:"-"`
+	metadataLoadBasedAutoScalingConfiguration `json:"-" xml:"-"`
 }
 
 type metadataLoadBasedAutoScalingConfiguration struct {
@@ -4811,7 +4811,7 @@ type Permission struct {
 	// A stack ID.
 	StackID *string `locationName:"StackId" type:"string"`
 
-	metadataPermission `json:"-", xml:"-"`
+	metadataPermission `json:"-" xml:"-"`
 }
 
 type metadataPermission struct {
@@ -4860,7 +4860,7 @@ type RAIDArray struct {
 	// The volume type, standard or PIOPS.
 	VolumeType *string `type:"string"`
 
-	metadataRAIDArray `json:"-", xml:"-"`
+	metadataRAIDArray `json:"-" xml:"-"`
 }
 
 type metadataRAIDArray struct {
@@ -4898,7 +4898,7 @@ type RDSDBInstance struct {
 	// The ID of the stack that the instance is registered with.
 	StackID *string `locationName:"StackId" type:"string"`
 
-	metadataRDSDBInstance `json:"-", xml:"-"`
+	metadataRDSDBInstance `json:"-" xml:"-"`
 }
 
 type metadataRDSDBInstance struct {
@@ -4909,7 +4909,7 @@ type RebootInstanceInput struct {
 	// The instance ID.
 	InstanceID *string `locationName:"InstanceId" type:"string" required:"true"`
 
-	metadataRebootInstanceInput `json:"-", xml:"-"`
+	metadataRebootInstanceInput `json:"-" xml:"-"`
 }
 
 type metadataRebootInstanceInput struct {
@@ -4917,7 +4917,7 @@ type metadataRebootInstanceInput struct {
 }
 
 type RebootInstanceOutput struct {
-	metadataRebootInstanceOutput `json:"-", xml:"-"`
+	metadataRebootInstanceOutput `json:"-" xml:"-"`
 }
 
 type metadataRebootInstanceOutput struct {
@@ -4951,7 +4951,7 @@ type Recipes struct {
 	// An array of custom recipe names to be run following a undeploy event.
 	Undeploy []*string `type:"list"`
 
-	metadataRecipes `json:"-", xml:"-"`
+	metadataRecipes `json:"-" xml:"-"`
 }
 
 type metadataRecipes struct {
@@ -4965,7 +4965,7 @@ type RegisterElasticIPInput struct {
 	// The stack ID.
 	StackID *string `locationName:"StackId" type:"string" required:"true"`
 
-	metadataRegisterElasticIPInput `json:"-", xml:"-"`
+	metadataRegisterElasticIPInput `json:"-" xml:"-"`
 }
 
 type metadataRegisterElasticIPInput struct {
@@ -4977,7 +4977,7 @@ type RegisterElasticIPOutput struct {
 	// The Elastic IP address.
 	ElasticIP *string `locationName:"ElasticIp" type:"string"`
 
-	metadataRegisterElasticIPOutput `json:"-", xml:"-"`
+	metadataRegisterElasticIPOutput `json:"-" xml:"-"`
 }
 
 type metadataRegisterElasticIPOutput struct {
@@ -5007,7 +5007,7 @@ type RegisterInstanceInput struct {
 	// The ID of the stack that the instance is to be registered with.
 	StackID *string `locationName:"StackId" type:"string" required:"true"`
 
-	metadataRegisterInstanceInput `json:"-", xml:"-"`
+	metadataRegisterInstanceInput `json:"-" xml:"-"`
 }
 
 type metadataRegisterInstanceInput struct {
@@ -5019,7 +5019,7 @@ type RegisterInstanceOutput struct {
 	// The registered instance's AWS OpsWorks ID.
 	InstanceID *string `locationName:"InstanceId" type:"string"`
 
-	metadataRegisterInstanceOutput `json:"-", xml:"-"`
+	metadataRegisterInstanceOutput `json:"-" xml:"-"`
 }
 
 type metadataRegisterInstanceOutput struct {
@@ -5039,7 +5039,7 @@ type RegisterRDSDBInstanceInput struct {
 	// The stack ID.
 	StackID *string `locationName:"StackId" type:"string" required:"true"`
 
-	metadataRegisterRDSDBInstanceInput `json:"-", xml:"-"`
+	metadataRegisterRDSDBInstanceInput `json:"-" xml:"-"`
 }
 
 type metadataRegisterRDSDBInstanceInput struct {
@@ -5047,7 +5047,7 @@ type metadataRegisterRDSDBInstanceInput struct {
 }
 
 type RegisterRDSDBInstanceOutput struct {
-	metadataRegisterRDSDBInstanceOutput `json:"-", xml:"-"`
+	metadataRegisterRDSDBInstanceOutput `json:"-" xml:"-"`
 }
 
 type metadataRegisterRDSDBInstanceOutput struct {
@@ -5061,7 +5061,7 @@ type RegisterVolumeInput struct {
 	// The stack ID.
 	StackID *string `locationName:"StackId" type:"string" required:"true"`
 
-	metadataRegisterVolumeInput `json:"-", xml:"-"`
+	metadataRegisterVolumeInput `json:"-" xml:"-"`
 }
 
 type metadataRegisterVolumeInput struct {
@@ -5073,7 +5073,7 @@ type RegisterVolumeOutput struct {
 	// The volume ID.
 	VolumeID *string `locationName:"VolumeId" type:"string"`
 
-	metadataRegisterVolumeOutput `json:"-", xml:"-"`
+	metadataRegisterVolumeOutput `json:"-" xml:"-"`
 }
 
 type metadataRegisterVolumeOutput struct {
@@ -5091,7 +5091,7 @@ type ReportedOs struct {
 	// The operating system version.
 	Version *string `type:"string"`
 
-	metadataReportedOs `json:"-", xml:"-"`
+	metadataReportedOs `json:"-" xml:"-"`
 }
 
 type metadataReportedOs struct {
@@ -5110,7 +5110,7 @@ type SSLConfiguration struct {
 	// The private key; the contents of the certificate's domain.kex file.
 	PrivateKey *string `type:"string" required:"true"`
 
-	metadataSSLConfiguration `json:"-", xml:"-"`
+	metadataSSLConfiguration `json:"-" xml:"-"`
 }
 
 type metadataSSLConfiguration struct {
@@ -5131,7 +5131,7 @@ type SelfUserProfile struct {
 	// The user's SSH user name.
 	SSHUsername *string `locationName:"SshUsername" type:"string"`
 
-	metadataSelfUserProfile `json:"-", xml:"-"`
+	metadataSelfUserProfile `json:"-" xml:"-"`
 }
 
 type metadataSelfUserProfile struct {
@@ -5158,7 +5158,7 @@ type ServiceError struct {
 	// The error type.
 	Type *string `type:"string"`
 
-	metadataServiceError `json:"-", xml:"-"`
+	metadataServiceError `json:"-" xml:"-"`
 }
 
 type metadataServiceError struct {
@@ -5182,7 +5182,7 @@ type SetLoadBasedAutoScalingInput struct {
 	// OpsWorks starts a specified number of instances.
 	UpScaling *AutoScalingThresholds `type:"structure"`
 
-	metadataSetLoadBasedAutoScalingInput `json:"-", xml:"-"`
+	metadataSetLoadBasedAutoScalingInput `json:"-" xml:"-"`
 }
 
 type metadataSetLoadBasedAutoScalingInput struct {
@@ -5190,7 +5190,7 @@ type metadataSetLoadBasedAutoScalingInput struct {
 }
 
 type SetLoadBasedAutoScalingOutput struct {
-	metadataSetLoadBasedAutoScalingOutput `json:"-", xml:"-"`
+	metadataSetLoadBasedAutoScalingOutput `json:"-" xml:"-"`
 }
 
 type metadataSetLoadBasedAutoScalingOutput struct {
@@ -5217,7 +5217,7 @@ type SetPermissionInput struct {
 	// The stack ID.
 	StackID *string `locationName:"StackId" type:"string" required:"true"`
 
-	metadataSetPermissionInput `json:"-", xml:"-"`
+	metadataSetPermissionInput `json:"-" xml:"-"`
 }
 
 type metadataSetPermissionInput struct {
@@ -5225,7 +5225,7 @@ type metadataSetPermissionInput struct {
 }
 
 type SetPermissionOutput struct {
-	metadataSetPermissionOutput `json:"-", xml:"-"`
+	metadataSetPermissionOutput `json:"-" xml:"-"`
 }
 
 type metadataSetPermissionOutput struct {
@@ -5239,7 +5239,7 @@ type SetTimeBasedAutoScalingInput struct {
 	// The instance ID.
 	InstanceID *string `locationName:"InstanceId" type:"string" required:"true"`
 
-	metadataSetTimeBasedAutoScalingInput `json:"-", xml:"-"`
+	metadataSetTimeBasedAutoScalingInput `json:"-" xml:"-"`
 }
 
 type metadataSetTimeBasedAutoScalingInput struct {
@@ -5247,7 +5247,7 @@ type metadataSetTimeBasedAutoScalingInput struct {
 }
 
 type SetTimeBasedAutoScalingOutput struct {
-	metadataSetTimeBasedAutoScalingOutput `json:"-", xml:"-"`
+	metadataSetTimeBasedAutoScalingOutput `json:"-" xml:"-"`
 }
 
 type metadataSetTimeBasedAutoScalingOutput struct {
@@ -5264,7 +5264,7 @@ type ShutdownEventConfiguration struct {
 	// event before shutting down an instance.
 	ExecutionTimeout *int64 `type:"integer"`
 
-	metadataShutdownEventConfiguration `json:"-", xml:"-"`
+	metadataShutdownEventConfiguration `json:"-" xml:"-"`
 }
 
 type metadataShutdownEventConfiguration struct {
@@ -5304,7 +5304,7 @@ type Source struct {
 	// to the user name.
 	Username *string `type:"string"`
 
-	metadataSource `json:"-", xml:"-"`
+	metadataSource `json:"-" xml:"-"`
 }
 
 type metadataSource struct {
@@ -5394,7 +5394,7 @@ type Stack struct {
 	// The VPC ID, if the stack is running in a VPC.
 	VPCID *string `locationName:"VpcId" type:"string"`
 
-	metadataStack `json:"-", xml:"-"`
+	metadataStack `json:"-" xml:"-"`
 }
 
 type metadataStack struct {
@@ -5410,7 +5410,7 @@ type StackConfigurationManager struct {
 	// default value is 11.4.
 	Version *string `type:"string"`
 
-	metadataStackConfigurationManager `json:"-", xml:"-"`
+	metadataStackConfigurationManager `json:"-" xml:"-"`
 }
 
 type metadataStackConfigurationManager struct {
@@ -5437,7 +5437,7 @@ type StackSummary struct {
 	// The stack ID.
 	StackID *string `locationName:"StackId" type:"string"`
 
-	metadataStackSummary `json:"-", xml:"-"`
+	metadataStackSummary `json:"-" xml:"-"`
 }
 
 type metadataStackSummary struct {
@@ -5448,7 +5448,7 @@ type StartInstanceInput struct {
 	// The instance ID.
 	InstanceID *string `locationName:"InstanceId" type:"string" required:"true"`
 
-	metadataStartInstanceInput `json:"-", xml:"-"`
+	metadataStartInstanceInput `json:"-" xml:"-"`
 }
 
 type metadataStartInstanceInput struct {
@@ -5456,7 +5456,7 @@ type metadataStartInstanceInput struct {
 }
 
 type StartInstanceOutput struct {
-	metadataStartInstanceOutput `json:"-", xml:"-"`
+	metadataStartInstanceOutput `json:"-" xml:"-"`
 }
 
 type metadataStartInstanceOutput struct {
@@ -5467,7 +5467,7 @@ type StartStackInput struct {
 	// The stack ID.
 	StackID *string `locationName:"StackId" type:"string" required:"true"`
 
-	metadataStartStackInput `json:"-", xml:"-"`
+	metadataStartStackInput `json:"-" xml:"-"`
 }
 
 type metadataStartStackInput struct {
@@ -5475,7 +5475,7 @@ type metadataStartStackInput struct {
 }
 
 type StartStackOutput struct {
-	metadataStartStackOutput `json:"-", xml:"-"`
+	metadataStartStackOutput `json:"-" xml:"-"`
 }
 
 type metadataStartStackOutput struct {
@@ -5486,7 +5486,7 @@ type StopInstanceInput struct {
 	// The instance ID.
 	InstanceID *string `locationName:"InstanceId" type:"string" required:"true"`
 
-	metadataStopInstanceInput `json:"-", xml:"-"`
+	metadataStopInstanceInput `json:"-" xml:"-"`
 }
 
 type metadataStopInstanceInput struct {
@@ -5494,7 +5494,7 @@ type metadataStopInstanceInput struct {
 }
 
 type StopInstanceOutput struct {
-	metadataStopInstanceOutput `json:"-", xml:"-"`
+	metadataStopInstanceOutput `json:"-" xml:"-"`
 }
 
 type metadataStopInstanceOutput struct {
@@ -5505,7 +5505,7 @@ type StopStackInput struct {
 	// The stack ID.
 	StackID *string `locationName:"StackId" type:"string" required:"true"`
 
-	metadataStopStackInput `json:"-", xml:"-"`
+	metadataStopStackInput `json:"-" xml:"-"`
 }
 
 type metadataStopStackInput struct {
@@ -5513,7 +5513,7 @@ type metadataStopStackInput struct {
 }
 
 type StopStackOutput struct {
-	metadataStopStackOutput `json:"-", xml:"-"`
+	metadataStopStackOutput `json:"-" xml:"-"`
 }
 
 type metadataStopStackOutput struct {
@@ -5528,7 +5528,7 @@ type TimeBasedAutoScalingConfiguration struct {
 	// The instance ID.
 	InstanceID *string `locationName:"InstanceId" type:"string"`
 
-	metadataTimeBasedAutoScalingConfiguration `json:"-", xml:"-"`
+	metadataTimeBasedAutoScalingConfiguration `json:"-" xml:"-"`
 }
 
 type metadataTimeBasedAutoScalingConfiguration struct {
@@ -5539,7 +5539,7 @@ type UnassignInstanceInput struct {
 	// The instance ID.
 	InstanceID *string `locationName:"InstanceId" type:"string" required:"true"`
 
-	metadataUnassignInstanceInput `json:"-", xml:"-"`
+	metadataUnassignInstanceInput `json:"-" xml:"-"`
 }
 
 type metadataUnassignInstanceInput struct {
@@ -5547,7 +5547,7 @@ type metadataUnassignInstanceInput struct {
 }
 
 type UnassignInstanceOutput struct {
-	metadataUnassignInstanceOutput `json:"-", xml:"-"`
+	metadataUnassignInstanceOutput `json:"-" xml:"-"`
 }
 
 type metadataUnassignInstanceOutput struct {
@@ -5558,7 +5558,7 @@ type UnassignVolumeInput struct {
 	// The volume ID.
 	VolumeID *string `locationName:"VolumeId" type:"string" required:"true"`
 
-	metadataUnassignVolumeInput `json:"-", xml:"-"`
+	metadataUnassignVolumeInput `json:"-" xml:"-"`
 }
 
 type metadataUnassignVolumeInput struct {
@@ -5566,7 +5566,7 @@ type metadataUnassignVolumeInput struct {
 }
 
 type UnassignVolumeOutput struct {
-	metadataUnassignVolumeOutput `json:"-", xml:"-"`
+	metadataUnassignVolumeOutput `json:"-" xml:"-"`
 }
 
 type metadataUnassignVolumeOutput struct {
@@ -5614,7 +5614,7 @@ type UpdateAppInput struct {
 	// The app type.
 	Type *string `type:"string"`
 
-	metadataUpdateAppInput `json:"-", xml:"-"`
+	metadataUpdateAppInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateAppInput struct {
@@ -5622,7 +5622,7 @@ type metadataUpdateAppInput struct {
 }
 
 type UpdateAppOutput struct {
-	metadataUpdateAppOutput `json:"-", xml:"-"`
+	metadataUpdateAppOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateAppOutput struct {
@@ -5636,7 +5636,7 @@ type UpdateElasticIPInput struct {
 	// The new name.
 	Name *string `type:"string"`
 
-	metadataUpdateElasticIPInput `json:"-", xml:"-"`
+	metadataUpdateElasticIPInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateElasticIPInput struct {
@@ -5644,7 +5644,7 @@ type metadataUpdateElasticIPInput struct {
 }
 
 type UpdateElasticIPOutput struct {
-	metadataUpdateElasticIPOutput `json:"-", xml:"-"`
+	metadataUpdateElasticIPOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateElasticIPOutput struct {
@@ -5712,7 +5712,7 @@ type UpdateInstanceInput struct {
 	// The instance SSH key name.
 	SSHKeyName *string `locationName:"SshKeyName" type:"string"`
 
-	metadataUpdateInstanceInput `json:"-", xml:"-"`
+	metadataUpdateInstanceInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateInstanceInput struct {
@@ -5720,7 +5720,7 @@ type metadataUpdateInstanceInput struct {
 }
 
 type UpdateInstanceOutput struct {
-	metadataUpdateInstanceOutput `json:"-", xml:"-"`
+	metadataUpdateInstanceOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateInstanceOutput struct {
@@ -5786,7 +5786,7 @@ type UpdateLayerInput struct {
 	// A VolumeConfigurations object that describes the layer's Amazon EBS volumes.
 	VolumeConfigurations []*VolumeConfiguration `type:"list"`
 
-	metadataUpdateLayerInput `json:"-", xml:"-"`
+	metadataUpdateLayerInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateLayerInput struct {
@@ -5794,7 +5794,7 @@ type metadataUpdateLayerInput struct {
 }
 
 type UpdateLayerOutput struct {
-	metadataUpdateLayerOutput `json:"-", xml:"-"`
+	metadataUpdateLayerOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateLayerOutput struct {
@@ -5805,7 +5805,7 @@ type UpdateMyUserProfileInput struct {
 	// The user's SSH public key.
 	SSHPublicKey *string `locationName:"SshPublicKey" type:"string"`
 
-	metadataUpdateMyUserProfileInput `json:"-", xml:"-"`
+	metadataUpdateMyUserProfileInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateMyUserProfileInput struct {
@@ -5813,7 +5813,7 @@ type metadataUpdateMyUserProfileInput struct {
 }
 
 type UpdateMyUserProfileOutput struct {
-	metadataUpdateMyUserProfileOutput `json:"-", xml:"-"`
+	metadataUpdateMyUserProfileOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateMyUserProfileOutput struct {
@@ -5830,7 +5830,7 @@ type UpdateRDSDBInstanceInput struct {
 	// The Amazon RDS instance's ARN.
 	RDSDBInstanceARN *string `locationName:"RdsDbInstanceArn" type:"string" required:"true"`
 
-	metadataUpdateRDSDBInstanceInput `json:"-", xml:"-"`
+	metadataUpdateRDSDBInstanceInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateRDSDBInstanceInput struct {
@@ -5838,7 +5838,7 @@ type metadataUpdateRDSDBInstanceInput struct {
 }
 
 type UpdateRDSDBInstanceOutput struct {
-	metadataUpdateRDSDBInstanceOutput `json:"-", xml:"-"`
+	metadataUpdateRDSDBInstanceOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateRDSDBInstanceOutput struct {
@@ -5959,7 +5959,7 @@ type UpdateStackInput struct {
 	//   For more information, see Create a New Stack (http://docs.aws.amazon.com/opsworks/latest/userguide/workingstacks-creating.html).
 	UseOpsWorksSecurityGroups *bool `locationName:"UseOpsworksSecurityGroups" type:"boolean"`
 
-	metadataUpdateStackInput `json:"-", xml:"-"`
+	metadataUpdateStackInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateStackInput struct {
@@ -5967,7 +5967,7 @@ type metadataUpdateStackInput struct {
 }
 
 type UpdateStackOutput struct {
-	metadataUpdateStackOutput `json:"-", xml:"-"`
+	metadataUpdateStackOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateStackOutput struct {
@@ -5992,7 +5992,7 @@ type UpdateUserProfileInput struct {
 	// IAM user name.
 	SSHUsername *string `locationName:"SshUsername" type:"string"`
 
-	metadataUpdateUserProfileInput `json:"-", xml:"-"`
+	metadataUpdateUserProfileInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateUserProfileInput struct {
@@ -6000,7 +6000,7 @@ type metadataUpdateUserProfileInput struct {
 }
 
 type UpdateUserProfileOutput struct {
-	metadataUpdateUserProfileOutput `json:"-", xml:"-"`
+	metadataUpdateUserProfileOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateUserProfileOutput struct {
@@ -6017,7 +6017,7 @@ type UpdateVolumeInput struct {
 	// The volume ID.
 	VolumeID *string `locationName:"VolumeId" type:"string" required:"true"`
 
-	metadataUpdateVolumeInput `json:"-", xml:"-"`
+	metadataUpdateVolumeInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateVolumeInput struct {
@@ -6025,7 +6025,7 @@ type metadataUpdateVolumeInput struct {
 }
 
 type UpdateVolumeOutput struct {
-	metadataUpdateVolumeOutput `json:"-", xml:"-"`
+	metadataUpdateVolumeOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateVolumeOutput struct {
@@ -6050,7 +6050,7 @@ type UserProfile struct {
 	// The user's SSH user name.
 	SSHUsername *string `locationName:"SshUsername" type:"string"`
 
-	metadataUserProfile `json:"-", xml:"-"`
+	metadataUserProfile `json:"-" xml:"-"`
 }
 
 type metadataUserProfile struct {
@@ -6100,7 +6100,7 @@ type Volume struct {
 	// The volume type, standard or PIOPS.
 	VolumeType *string `type:"string"`
 
-	metadataVolume `json:"-", xml:"-"`
+	metadataVolume `json:"-" xml:"-"`
 }
 
 type metadataVolume struct {
@@ -6130,7 +6130,7 @@ type VolumeConfiguration struct {
 	// (SSD)
 	VolumeType *string `type:"string"`
 
-	metadataVolumeConfiguration `json:"-", xml:"-"`
+	metadataVolumeConfiguration `json:"-" xml:"-"`
 }
 
 type metadataVolumeConfiguration struct {
@@ -6173,7 +6173,7 @@ type WeeklyAutoScalingSchedule struct {
 	// The schedule for Wednesday.
 	Wednesday *map[string]*string `type:"map"`
 
-	metadataWeeklyAutoScalingSchedule `json:"-", xml:"-"`
+	metadataWeeklyAutoScalingSchedule `json:"-" xml:"-"`
 }
 
 type metadataWeeklyAutoScalingSchedule struct {

--- a/service/rds/api.go
+++ b/service/rds/api.go
@@ -3183,6 +3183,11 @@ type DBInstance struct {
 	// associated with.
 	CharacterSetName *string `type:"string"`
 
+	// If StorageEncrypted is true, the region-unique, immutable identifier for
+	// the encrypted DB instance. This identifier is found in AWS CloudTrail log
+	// entries whenever the KMS key for the DB instance is accessed.
+	DBIResourceID *string `locationName:"DbiResourceId" type:"string"`
+
 	// Contains the name of the compute and memory capacity class of the DB instance.
 	DBInstanceClass *string `type:"string"`
 
@@ -3222,11 +3227,6 @@ type DBInstance struct {
 	// Specifies information on the subnet group associated with the DB instance,
 	// including the name, description, and subnets in the subnet group.
 	DBSubnetGroup *DBSubnetGroup `type:"structure"`
-
-	// If StorageEncrypted is true, the region-unique, immutable identifier for
-	// the encrypted DB instance. This identifier is found in AWS CloudTrail log
-	// entries whenever the KMS key for the DB instance is accessed.
-	DBiResourceID *string `locationName:"DbiResourceId" type:"string"`
 
 	// Specifies the connection endpoint.
 	Endpoint *Endpoint `type:"structure"`

--- a/service/rds/api.go
+++ b/service/rds/api.go
@@ -2061,7 +2061,7 @@ type AddSourceIdentifierToSubscriptionInput struct {
 	// identifier to.
 	SubscriptionName *string `type:"string" required:"true"`
 
-	metadataAddSourceIdentifierToSubscriptionInput `json:"-", xml:"-"`
+	metadataAddSourceIdentifierToSubscriptionInput `json:"-" xml:"-"`
 }
 
 type metadataAddSourceIdentifierToSubscriptionInput struct {
@@ -2073,7 +2073,7 @@ type AddSourceIdentifierToSubscriptionOutput struct {
 	// action.
 	EventSubscription *EventSubscription `type:"structure"`
 
-	metadataAddSourceIdentifierToSubscriptionOutput `json:"-", xml:"-"`
+	metadataAddSourceIdentifierToSubscriptionOutput `json:"-" xml:"-"`
 }
 
 type metadataAddSourceIdentifierToSubscriptionOutput struct {
@@ -2089,7 +2089,7 @@ type AddTagsToResourceInput struct {
 	// The tags to be assigned to the Amazon RDS resource.
 	Tags []*Tag `locationNameList:"Tag" type:"list" required:"true"`
 
-	metadataAddTagsToResourceInput `json:"-", xml:"-"`
+	metadataAddTagsToResourceInput `json:"-" xml:"-"`
 }
 
 type metadataAddTagsToResourceInput struct {
@@ -2097,7 +2097,7 @@ type metadataAddTagsToResourceInput struct {
 }
 
 type AddTagsToResourceOutput struct {
-	metadataAddTagsToResourceOutput `json:"-", xml:"-"`
+	metadataAddTagsToResourceOutput `json:"-" xml:"-"`
 }
 
 type metadataAddTagsToResourceOutput struct {
@@ -2122,7 +2122,7 @@ type ApplyPendingMaintenanceActionInput struct {
 	// action applies to.
 	ResourceIdentifier *string `type:"string" required:"true"`
 
-	metadataApplyPendingMaintenanceActionInput `json:"-", xml:"-"`
+	metadataApplyPendingMaintenanceActionInput `json:"-" xml:"-"`
 }
 
 type metadataApplyPendingMaintenanceActionInput struct {
@@ -2133,7 +2133,7 @@ type ApplyPendingMaintenanceActionOutput struct {
 	// Describes the pending maintenance actions for a resource.
 	ResourcePendingMaintenanceActions *ResourcePendingMaintenanceActions `type:"structure"`
 
-	metadataApplyPendingMaintenanceActionOutput `json:"-", xml:"-"`
+	metadataApplyPendingMaintenanceActionOutput `json:"-" xml:"-"`
 }
 
 type metadataApplyPendingMaintenanceActionOutput struct {
@@ -2164,7 +2164,7 @@ type AuthorizeDBSecurityGroupIngressInput struct {
 	// must be provided.
 	EC2SecurityGroupOwnerID *string `locationName:"EC2SecurityGroupOwnerId" type:"string"`
 
-	metadataAuthorizeDBSecurityGroupIngressInput `json:"-", xml:"-"`
+	metadataAuthorizeDBSecurityGroupIngressInput `json:"-" xml:"-"`
 }
 
 type metadataAuthorizeDBSecurityGroupIngressInput struct {
@@ -2179,7 +2179,7 @@ type AuthorizeDBSecurityGroupIngressOutput struct {
 	// in the DescribeDBSecurityGroups action.
 	DBSecurityGroup *DBSecurityGroup `type:"structure"`
 
-	metadataAuthorizeDBSecurityGroupIngressOutput `json:"-", xml:"-"`
+	metadataAuthorizeDBSecurityGroupIngressOutput `json:"-" xml:"-"`
 }
 
 type metadataAuthorizeDBSecurityGroupIngressOutput struct {
@@ -2193,7 +2193,7 @@ type AvailabilityZone struct {
 	// The name of the availability zone.
 	Name *string `type:"string"`
 
-	metadataAvailabilityZone `json:"-", xml:"-"`
+	metadataAvailabilityZone `json:"-" xml:"-"`
 }
 
 type metadataAvailabilityZone struct {
@@ -2208,7 +2208,7 @@ type CharacterSet struct {
 	// The name of the character set.
 	CharacterSetName *string `type:"string"`
 
-	metadataCharacterSet `json:"-", xml:"-"`
+	metadataCharacterSet `json:"-" xml:"-"`
 }
 
 type metadataCharacterSet struct {
@@ -2242,7 +2242,7 @@ type CopyDBParameterGroupInput struct {
 	// hyphen or contain two consecutive hyphens  Example: my-db-parameter-group
 	TargetDBParameterGroupIdentifier *string `type:"string" required:"true"`
 
-	metadataCopyDBParameterGroupInput `json:"-", xml:"-"`
+	metadataCopyDBParameterGroupInput `json:"-" xml:"-"`
 }
 
 type metadataCopyDBParameterGroupInput struct {
@@ -2257,7 +2257,7 @@ type CopyDBParameterGroupOutput struct {
 	// action, and as a response element in the DescribeDBParameterGroups action.
 	DBParameterGroup *DBParameterGroup `type:"structure"`
 
-	metadataCopyDBParameterGroupOutput `json:"-", xml:"-"`
+	metadataCopyDBParameterGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataCopyDBParameterGroupOutput struct {
@@ -2291,7 +2291,7 @@ type CopyDBSnapshotInput struct {
 	// hyphen or contain two consecutive hyphens  Example: my-db-snapshot
 	TargetDBSnapshotIdentifier *string `type:"string" required:"true"`
 
-	metadataCopyDBSnapshotInput `json:"-", xml:"-"`
+	metadataCopyDBSnapshotInput `json:"-" xml:"-"`
 }
 
 type metadataCopyDBSnapshotInput struct {
@@ -2305,7 +2305,7 @@ type CopyDBSnapshotOutput struct {
 	// element in the DescribeDBSnapshots action.
 	DBSnapshot *DBSnapshot `type:"structure"`
 
-	metadataCopyDBSnapshotOutput `json:"-", xml:"-"`
+	metadataCopyDBSnapshotOutput `json:"-" xml:"-"`
 }
 
 type metadataCopyDBSnapshotOutput struct {
@@ -2338,7 +2338,7 @@ type CopyOptionGroupInput struct {
 	// hyphen or contain two consecutive hyphens  Example: my-option-group
 	TargetOptionGroupIdentifier *string `type:"string" required:"true"`
 
-	metadataCopyOptionGroupInput `json:"-", xml:"-"`
+	metadataCopyOptionGroupInput `json:"-" xml:"-"`
 }
 
 type metadataCopyOptionGroupInput struct {
@@ -2348,7 +2348,7 @@ type metadataCopyOptionGroupInput struct {
 type CopyOptionGroupOutput struct {
 	OptionGroup *OptionGroup `type:"structure"`
 
-	metadataCopyOptionGroupOutput `json:"-", xml:"-"`
+	metadataCopyOptionGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataCopyOptionGroupOutput struct {
@@ -2715,7 +2715,7 @@ type CreateDBInstanceInput struct {
 	//  Default: The default EC2 VPC security group for the DB subnet group's VPC.
 	VPCSecurityGroupIDs []*string `locationName:"VpcSecurityGroupIds" locationNameList:"VpcSecurityGroupId" type:"list"`
 
-	metadataCreateDBInstanceInput `json:"-", xml:"-"`
+	metadataCreateDBInstanceInput `json:"-" xml:"-"`
 }
 
 type metadataCreateDBInstanceInput struct {
@@ -2729,7 +2729,7 @@ type CreateDBInstanceOutput struct {
 	// as a response element in the DescribeDBInstances action.
 	DBInstance *DBInstance `type:"structure"`
 
-	metadataCreateDBInstanceOutput `json:"-", xml:"-"`
+	metadataCreateDBInstanceOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateDBInstanceOutput struct {
@@ -2837,7 +2837,7 @@ type CreateDBInstanceReadReplicaInput struct {
 	// A list of tags.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataCreateDBInstanceReadReplicaInput `json:"-", xml:"-"`
+	metadataCreateDBInstanceReadReplicaInput `json:"-" xml:"-"`
 }
 
 type metadataCreateDBInstanceReadReplicaInput struct {
@@ -2851,7 +2851,7 @@ type CreateDBInstanceReadReplicaOutput struct {
 	// as a response element in the DescribeDBInstances action.
 	DBInstance *DBInstance `type:"structure"`
 
-	metadataCreateDBInstanceReadReplicaOutput `json:"-", xml:"-"`
+	metadataCreateDBInstanceReadReplicaOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateDBInstanceReadReplicaOutput struct {
@@ -2880,7 +2880,7 @@ type CreateDBParameterGroupInput struct {
 	// A list of tags.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataCreateDBParameterGroupInput `json:"-", xml:"-"`
+	metadataCreateDBParameterGroupInput `json:"-" xml:"-"`
 }
 
 type metadataCreateDBParameterGroupInput struct {
@@ -2895,7 +2895,7 @@ type CreateDBParameterGroupOutput struct {
 	// action, and as a response element in the DescribeDBParameterGroups action.
 	DBParameterGroup *DBParameterGroup `type:"structure"`
 
-	metadataCreateDBParameterGroupOutput `json:"-", xml:"-"`
+	metadataCreateDBParameterGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateDBParameterGroupOutput struct {
@@ -2918,7 +2918,7 @@ type CreateDBSecurityGroupInput struct {
 	// A list of tags.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataCreateDBSecurityGroupInput `json:"-", xml:"-"`
+	metadataCreateDBSecurityGroupInput `json:"-" xml:"-"`
 }
 
 type metadataCreateDBSecurityGroupInput struct {
@@ -2933,7 +2933,7 @@ type CreateDBSecurityGroupOutput struct {
 	// in the DescribeDBSecurityGroups action.
 	DBSecurityGroup *DBSecurityGroup `type:"structure"`
 
-	metadataCreateDBSecurityGroupOutput `json:"-", xml:"-"`
+	metadataCreateDBSecurityGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateDBSecurityGroupOutput struct {
@@ -2961,7 +2961,7 @@ type CreateDBSnapshotInput struct {
 	// A list of tags.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataCreateDBSnapshotInput `json:"-", xml:"-"`
+	metadataCreateDBSnapshotInput `json:"-" xml:"-"`
 }
 
 type metadataCreateDBSnapshotInput struct {
@@ -2975,7 +2975,7 @@ type CreateDBSnapshotOutput struct {
 	// element in the DescribeDBSnapshots action.
 	DBSnapshot *DBSnapshot `type:"structure"`
 
-	metadataCreateDBSnapshotOutput `json:"-", xml:"-"`
+	metadataCreateDBSnapshotOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateDBSnapshotOutput struct {
@@ -3000,7 +3000,7 @@ type CreateDBSubnetGroupInput struct {
 	// A list of tags.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataCreateDBSubnetGroupInput `json:"-", xml:"-"`
+	metadataCreateDBSubnetGroupInput `json:"-" xml:"-"`
 }
 
 type metadataCreateDBSubnetGroupInput struct {
@@ -3015,7 +3015,7 @@ type CreateDBSubnetGroupOutput struct {
 	// action.
 	DBSubnetGroup *DBSubnetGroup `type:"structure"`
 
-	metadataCreateDBSubnetGroupOutput `json:"-", xml:"-"`
+	metadataCreateDBSubnetGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateDBSubnetGroupOutput struct {
@@ -3070,7 +3070,7 @@ type CreateEventSubscriptionInput struct {
 	// A list of tags.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataCreateEventSubscriptionInput `json:"-", xml:"-"`
+	metadataCreateEventSubscriptionInput `json:"-" xml:"-"`
 }
 
 type metadataCreateEventSubscriptionInput struct {
@@ -3082,7 +3082,7 @@ type CreateEventSubscriptionOutput struct {
 	// action.
 	EventSubscription *EventSubscription `type:"structure"`
 
-	metadataCreateEventSubscriptionOutput `json:"-", xml:"-"`
+	metadataCreateEventSubscriptionOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateEventSubscriptionOutput struct {
@@ -3113,7 +3113,7 @@ type CreateOptionGroupInput struct {
 	// A list of tags.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataCreateOptionGroupInput `json:"-", xml:"-"`
+	metadataCreateOptionGroupInput `json:"-" xml:"-"`
 }
 
 type metadataCreateOptionGroupInput struct {
@@ -3123,7 +3123,7 @@ type metadataCreateOptionGroupInput struct {
 type CreateOptionGroupOutput struct {
 	OptionGroup *OptionGroup `type:"structure"`
 
-	metadataCreateOptionGroupOutput `json:"-", xml:"-"`
+	metadataCreateOptionGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateOptionGroupOutput struct {
@@ -3155,7 +3155,7 @@ type DBEngineVersion struct {
 	// parameter of the CreateDBInstance API.
 	SupportedCharacterSets []*CharacterSet `locationNameList:"CharacterSet" type:"list"`
 
-	metadataDBEngineVersion `json:"-", xml:"-"`
+	metadataDBEngineVersion `json:"-" xml:"-"`
 }
 
 type metadataDBEngineVersion struct {
@@ -3320,7 +3320,7 @@ type DBInstance struct {
 	// to.
 	VPCSecurityGroups []*VPCSecurityGroupMembership `locationName:"VpcSecurityGroups" locationNameList:"VpcSecurityGroupMembership" type:"list"`
 
-	metadataDBInstance `json:"-", xml:"-"`
+	metadataDBInstance `json:"-" xml:"-"`
 }
 
 type metadataDBInstance struct {
@@ -3344,7 +3344,7 @@ type DBInstanceStatusInfo struct {
 	// This value is currently "read replication."
 	StatusType *string `type:"string"`
 
-	metadataDBInstanceStatusInfo `json:"-", xml:"-"`
+	metadataDBInstanceStatusInfo `json:"-" xml:"-"`
 }
 
 type metadataDBInstanceStatusInfo struct {
@@ -3367,7 +3367,7 @@ type DBParameterGroup struct {
 	// Provides the customer-specified description for this DB parameter group.
 	Description *string `type:"string"`
 
-	metadataDBParameterGroup `json:"-", xml:"-"`
+	metadataDBParameterGroup `json:"-" xml:"-"`
 }
 
 type metadataDBParameterGroup struct {
@@ -3380,7 +3380,7 @@ type DBParameterGroupNameMessage struct {
 	// The name of the DB parameter group.
 	DBParameterGroupName *string `type:"string"`
 
-	metadataDBParameterGroupNameMessage `json:"-", xml:"-"`
+	metadataDBParameterGroupNameMessage `json:"-" xml:"-"`
 }
 
 type metadataDBParameterGroupNameMessage struct {
@@ -3400,7 +3400,7 @@ type DBParameterGroupStatus struct {
 	// The status of parameter updates.
 	ParameterApplyStatus *string `type:"string"`
 
-	metadataDBParameterGroupStatus `json:"-", xml:"-"`
+	metadataDBParameterGroupStatus `json:"-" xml:"-"`
 }
 
 type metadataDBParameterGroupStatus struct {
@@ -3431,7 +3431,7 @@ type DBSecurityGroup struct {
 	// Provides the VpcId of the DB security group.
 	VPCID *string `locationName:"VpcId" type:"string"`
 
-	metadataDBSecurityGroup `json:"-", xml:"-"`
+	metadataDBSecurityGroup `json:"-" xml:"-"`
 }
 
 type metadataDBSecurityGroup struct {
@@ -3448,7 +3448,7 @@ type DBSecurityGroupMembership struct {
 	// The status of the DB security group.
 	Status *string `type:"string"`
 
-	metadataDBSecurityGroupMembership `json:"-", xml:"-"`
+	metadataDBSecurityGroupMembership `json:"-" xml:"-"`
 }
 
 type metadataDBSecurityGroupMembership struct {
@@ -3530,7 +3530,7 @@ type DBSnapshot struct {
 	// Provides the Vpc Id associated with the DB snapshot.
 	VPCID *string `locationName:"VpcId" type:"string"`
 
-	metadataDBSnapshot `json:"-", xml:"-"`
+	metadataDBSnapshot `json:"-" xml:"-"`
 }
 
 type metadataDBSnapshot struct {
@@ -3558,7 +3558,7 @@ type DBSubnetGroup struct {
 	// Provides the VpcId of the DB subnet group.
 	VPCID *string `locationName:"VpcId" type:"string"`
 
-	metadataDBSubnetGroup `json:"-", xml:"-"`
+	metadataDBSubnetGroup `json:"-" xml:"-"`
 }
 
 type metadataDBSubnetGroup struct {
@@ -3596,7 +3596,7 @@ type DeleteDBInstanceInput struct {
 	// is false. Default: false
 	SkipFinalSnapshot *bool `type:"boolean"`
 
-	metadataDeleteDBInstanceInput `json:"-", xml:"-"`
+	metadataDeleteDBInstanceInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteDBInstanceInput struct {
@@ -3610,7 +3610,7 @@ type DeleteDBInstanceOutput struct {
 	// as a response element in the DescribeDBInstances action.
 	DBInstance *DBInstance `type:"structure"`
 
-	metadataDeleteDBInstanceOutput `json:"-", xml:"-"`
+	metadataDeleteDBInstanceOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteDBInstanceOutput struct {
@@ -3626,7 +3626,7 @@ type DeleteDBParameterGroupInput struct {
 	// default DB parameter group Cannot be associated with any DB instances
 	DBParameterGroupName *string `type:"string" required:"true"`
 
-	metadataDeleteDBParameterGroupInput `json:"-", xml:"-"`
+	metadataDeleteDBParameterGroupInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteDBParameterGroupInput struct {
@@ -3634,7 +3634,7 @@ type metadataDeleteDBParameterGroupInput struct {
 }
 
 type DeleteDBParameterGroupOutput struct {
-	metadataDeleteDBParameterGroupOutput `json:"-", xml:"-"`
+	metadataDeleteDBParameterGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteDBParameterGroupOutput struct {
@@ -3651,7 +3651,7 @@ type DeleteDBSecurityGroupInput struct {
 	// May not contain spaces
 	DBSecurityGroupName *string `type:"string" required:"true"`
 
-	metadataDeleteDBSecurityGroupInput `json:"-", xml:"-"`
+	metadataDeleteDBSecurityGroupInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteDBSecurityGroupInput struct {
@@ -3659,7 +3659,7 @@ type metadataDeleteDBSecurityGroupInput struct {
 }
 
 type DeleteDBSecurityGroupOutput struct {
-	metadataDeleteDBSecurityGroupOutput `json:"-", xml:"-"`
+	metadataDeleteDBSecurityGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteDBSecurityGroupOutput struct {
@@ -3673,7 +3673,7 @@ type DeleteDBSnapshotInput struct {
 	// state.
 	DBSnapshotIdentifier *string `type:"string" required:"true"`
 
-	metadataDeleteDBSnapshotInput `json:"-", xml:"-"`
+	metadataDeleteDBSnapshotInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteDBSnapshotInput struct {
@@ -3687,7 +3687,7 @@ type DeleteDBSnapshotOutput struct {
 	// element in the DescribeDBSnapshots action.
 	DBSnapshot *DBSnapshot `type:"structure"`
 
-	metadataDeleteDBSnapshotOutput `json:"-", xml:"-"`
+	metadataDeleteDBSnapshotOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteDBSnapshotOutput struct {
@@ -3703,7 +3703,7 @@ type DeleteDBSubnetGroupInput struct {
 	// Cannot end with a hyphen or contain two consecutive hyphens
 	DBSubnetGroupName *string `type:"string" required:"true"`
 
-	metadataDeleteDBSubnetGroupInput `json:"-", xml:"-"`
+	metadataDeleteDBSubnetGroupInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteDBSubnetGroupInput struct {
@@ -3711,7 +3711,7 @@ type metadataDeleteDBSubnetGroupInput struct {
 }
 
 type DeleteDBSubnetGroupOutput struct {
-	metadataDeleteDBSubnetGroupOutput `json:"-", xml:"-"`
+	metadataDeleteDBSubnetGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteDBSubnetGroupOutput struct {
@@ -3722,7 +3722,7 @@ type DeleteEventSubscriptionInput struct {
 	// The name of the RDS event notification subscription you want to delete.
 	SubscriptionName *string `type:"string" required:"true"`
 
-	metadataDeleteEventSubscriptionInput `json:"-", xml:"-"`
+	metadataDeleteEventSubscriptionInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteEventSubscriptionInput struct {
@@ -3734,7 +3734,7 @@ type DeleteEventSubscriptionOutput struct {
 	// action.
 	EventSubscription *EventSubscription `type:"structure"`
 
-	metadataDeleteEventSubscriptionOutput `json:"-", xml:"-"`
+	metadataDeleteEventSubscriptionOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteEventSubscriptionOutput struct {
@@ -3747,7 +3747,7 @@ type DeleteOptionGroupInput struct {
 	// You cannot delete default option groups.
 	OptionGroupName *string `type:"string" required:"true"`
 
-	metadataDeleteOptionGroupInput `json:"-", xml:"-"`
+	metadataDeleteOptionGroupInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteOptionGroupInput struct {
@@ -3755,7 +3755,7 @@ type metadataDeleteOptionGroupInput struct {
 }
 
 type DeleteOptionGroupOutput struct {
-	metadataDeleteOptionGroupOutput `json:"-", xml:"-"`
+	metadataDeleteOptionGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteOptionGroupOutput struct {
@@ -3805,7 +3805,7 @@ type DescribeDBEngineVersionsInput struct {
 	// Constraints: minimum 20, maximum 100
 	MaxRecords *int64 `type:"integer"`
 
-	metadataDescribeDBEngineVersionsInput `json:"-", xml:"-"`
+	metadataDescribeDBEngineVersionsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeDBEngineVersionsInput struct {
@@ -3823,7 +3823,7 @@ type DescribeDBEngineVersionsOutput struct {
 	// the value specified by MaxRecords.
 	Marker *string `type:"string"`
 
-	metadataDescribeDBEngineVersionsOutput `json:"-", xml:"-"`
+	metadataDescribeDBEngineVersionsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeDBEngineVersionsOutput struct {
@@ -3858,7 +3858,7 @@ type DescribeDBInstancesInput struct {
 	// Constraints: minimum 20, maximum 100
 	MaxRecords *int64 `type:"integer"`
 
-	metadataDescribeDBInstancesInput `json:"-", xml:"-"`
+	metadataDescribeDBInstancesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeDBInstancesInput struct {
@@ -3876,7 +3876,7 @@ type DescribeDBInstancesOutput struct {
 	// the value specified by MaxRecords .
 	Marker *string `type:"string"`
 
-	metadataDescribeDBInstancesOutput `json:"-", xml:"-"`
+	metadataDescribeDBInstancesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeDBInstancesOutput struct {
@@ -3894,7 +3894,7 @@ type DescribeDBLogFilesDetails struct {
 	// The size, in bytes, of the log file for the specified DB instance.
 	Size *int64 `type:"long"`
 
-	metadataDescribeDBLogFilesDetails `json:"-", xml:"-"`
+	metadataDescribeDBLogFilesDetails `json:"-" xml:"-"`
 }
 
 type metadataDescribeDBLogFilesDetails struct {
@@ -3935,7 +3935,7 @@ type DescribeDBLogFilesInput struct {
 	// is included in the response so that the remaining results can be retrieved.
 	MaxRecords *int64 `type:"integer"`
 
-	metadataDescribeDBLogFilesInput `json:"-", xml:"-"`
+	metadataDescribeDBLogFilesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeDBLogFilesInput struct {
@@ -3950,7 +3950,7 @@ type DescribeDBLogFilesOutput struct {
 	// A pagination token that can be used in a subsequent DescribeDBLogFiles request.
 	Marker *string `type:"string"`
 
-	metadataDescribeDBLogFilesOutput `json:"-", xml:"-"`
+	metadataDescribeDBLogFilesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeDBLogFilesOutput struct {
@@ -3983,7 +3983,7 @@ type DescribeDBParameterGroupsInput struct {
 	// Constraints: minimum 20, maximum 100
 	MaxRecords *int64 `type:"integer"`
 
-	metadataDescribeDBParameterGroupsInput `json:"-", xml:"-"`
+	metadataDescribeDBParameterGroupsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeDBParameterGroupsInput struct {
@@ -4001,7 +4001,7 @@ type DescribeDBParameterGroupsOutput struct {
 	// the value specified by MaxRecords.
 	Marker *string `type:"string"`
 
-	metadataDescribeDBParameterGroupsOutput `json:"-", xml:"-"`
+	metadataDescribeDBParameterGroupsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeDBParameterGroupsOutput struct {
@@ -4041,7 +4041,7 @@ type DescribeDBParametersInput struct {
 	// Valid Values: user | system | engine-default
 	Source *string `type:"string"`
 
-	metadataDescribeDBParametersInput `json:"-", xml:"-"`
+	metadataDescribeDBParametersInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeDBParametersInput struct {
@@ -4059,7 +4059,7 @@ type DescribeDBParametersOutput struct {
 	// A list of Parameter values.
 	Parameters []*Parameter `locationNameList:"Parameter" type:"list"`
 
-	metadataDescribeDBParametersOutput `json:"-", xml:"-"`
+	metadataDescribeDBParametersOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeDBParametersOutput struct {
@@ -4087,7 +4087,7 @@ type DescribeDBSecurityGroupsInput struct {
 	// Constraints: minimum 20, maximum 100
 	MaxRecords *int64 `type:"integer"`
 
-	metadataDescribeDBSecurityGroupsInput `json:"-", xml:"-"`
+	metadataDescribeDBSecurityGroupsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeDBSecurityGroupsInput struct {
@@ -4105,7 +4105,7 @@ type DescribeDBSecurityGroupsOutput struct {
 	// the value specified by MaxRecords.
 	Marker *string `type:"string"`
 
-	metadataDescribeDBSecurityGroupsOutput `json:"-", xml:"-"`
+	metadataDescribeDBSecurityGroupsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeDBSecurityGroupsOutput struct {
@@ -4156,7 +4156,7 @@ type DescribeDBSnapshotsInput struct {
 	// types.
 	SnapshotType *string `type:"string"`
 
-	metadataDescribeDBSnapshotsInput `json:"-", xml:"-"`
+	metadataDescribeDBSnapshotsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeDBSnapshotsInput struct {
@@ -4174,7 +4174,7 @@ type DescribeDBSnapshotsOutput struct {
 	// the value specified by MaxRecords.
 	Marker *string `type:"string"`
 
-	metadataDescribeDBSnapshotsOutput `json:"-", xml:"-"`
+	metadataDescribeDBSnapshotsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeDBSnapshotsOutput struct {
@@ -4202,7 +4202,7 @@ type DescribeDBSubnetGroupsInput struct {
 	// Constraints: minimum 20, maximum 100
 	MaxRecords *int64 `type:"integer"`
 
-	metadataDescribeDBSubnetGroupsInput `json:"-", xml:"-"`
+	metadataDescribeDBSubnetGroupsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeDBSubnetGroupsInput struct {
@@ -4220,7 +4220,7 @@ type DescribeDBSubnetGroupsOutput struct {
 	// the value specified by MaxRecords.
 	Marker *string `type:"string"`
 
-	metadataDescribeDBSubnetGroupsOutput `json:"-", xml:"-"`
+	metadataDescribeDBSubnetGroupsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeDBSubnetGroupsOutput struct {
@@ -4248,7 +4248,7 @@ type DescribeEngineDefaultParametersInput struct {
 	// Constraints: minimum 20, maximum 100
 	MaxRecords *int64 `type:"integer"`
 
-	metadataDescribeEngineDefaultParametersInput `json:"-", xml:"-"`
+	metadataDescribeEngineDefaultParametersInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeEngineDefaultParametersInput struct {
@@ -4260,7 +4260,7 @@ type DescribeEngineDefaultParametersOutput struct {
 	// action.
 	EngineDefaults *EngineDefaults `type:"structure"`
 
-	metadataDescribeEngineDefaultParametersOutput `json:"-", xml:"-"`
+	metadataDescribeEngineDefaultParametersOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeEngineDefaultParametersOutput struct {
@@ -4276,7 +4276,7 @@ type DescribeEventCategoriesInput struct {
 	// Valid values: db-instance | db-parameter-group | db-security-group | db-snapshot
 	SourceType *string `type:"string"`
 
-	metadataDescribeEventCategoriesInput `json:"-", xml:"-"`
+	metadataDescribeEventCategoriesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeEventCategoriesInput struct {
@@ -4288,7 +4288,7 @@ type DescribeEventCategoriesOutput struct {
 	// A list of EventCategoriesMap data types.
 	EventCategoriesMapList []*EventCategoriesMap `locationNameList:"EventCategoriesMap" type:"list"`
 
-	metadataDescribeEventCategoriesOutput `json:"-", xml:"-"`
+	metadataDescribeEventCategoriesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeEventCategoriesOutput struct {
@@ -4316,7 +4316,7 @@ type DescribeEventSubscriptionsInput struct {
 	// The name of the RDS event notification subscription you want to describe.
 	SubscriptionName *string `type:"string"`
 
-	metadataDescribeEventSubscriptionsInput `json:"-", xml:"-"`
+	metadataDescribeEventSubscriptionsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeEventSubscriptionsInput struct {
@@ -4333,7 +4333,7 @@ type DescribeEventSubscriptionsOutput struct {
 	// beyond the marker, up to the value specified by MaxRecords.
 	Marker *string `type:"string"`
 
-	metadataDescribeEventSubscriptionsOutput `json:"-", xml:"-"`
+	metadataDescribeEventSubscriptionsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeEventSubscriptionsOutput struct {
@@ -4398,7 +4398,7 @@ type DescribeEventsInput struct {
 	// Example: 2009-07-08T18:00Z
 	StartTime *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataDescribeEventsInput `json:"-", xml:"-"`
+	metadataDescribeEventsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeEventsInput struct {
@@ -4415,7 +4415,7 @@ type DescribeEventsOutput struct {
 	// up to the value specified by MaxRecords .
 	Marker *string `type:"string"`
 
-	metadataDescribeEventsOutput `json:"-", xml:"-"`
+	metadataDescribeEventsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeEventsOutput struct {
@@ -4448,7 +4448,7 @@ type DescribeOptionGroupOptionsInput struct {
 	// Constraints: minimum 20, maximum 100
 	MaxRecords *int64 `type:"integer"`
 
-	metadataDescribeOptionGroupOptionsInput `json:"-", xml:"-"`
+	metadataDescribeOptionGroupOptionsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeOptionGroupOptionsInput struct {
@@ -4464,7 +4464,7 @@ type DescribeOptionGroupOptionsOutput struct {
 	// List of available option group options.
 	OptionGroupOptions []*OptionGroupOption `locationNameList:"OptionGroupOption" type:"list"`
 
-	metadataDescribeOptionGroupOptionsOutput `json:"-", xml:"-"`
+	metadataDescribeOptionGroupOptionsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeOptionGroupOptionsOutput struct {
@@ -4502,7 +4502,7 @@ type DescribeOptionGroupsInput struct {
 	// EngineName or MajorEngineVersion.
 	OptionGroupName *string `type:"string"`
 
-	metadataDescribeOptionGroupsInput `json:"-", xml:"-"`
+	metadataDescribeOptionGroupsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeOptionGroupsInput struct {
@@ -4519,7 +4519,7 @@ type DescribeOptionGroupsOutput struct {
 	// List of option groups.
 	OptionGroupsList []*OptionGroup `locationNameList:"OptionGroup" type:"list"`
 
-	metadataDescribeOptionGroupsOutput `json:"-", xml:"-"`
+	metadataDescribeOptionGroupsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeOptionGroupsOutput struct {
@@ -4563,7 +4563,7 @@ type DescribeOrderableDBInstanceOptionsInput struct {
 	// or non-VPC offerings.
 	VPC *bool `locationName:"Vpc" type:"boolean"`
 
-	metadataDescribeOrderableDBInstanceOptionsInput `json:"-", xml:"-"`
+	metadataDescribeOrderableDBInstanceOptionsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeOrderableDBInstanceOptionsInput struct {
@@ -4582,7 +4582,7 @@ type DescribeOrderableDBInstanceOptionsOutput struct {
 	// options for the DB instance.
 	OrderableDBInstanceOptions []*OrderableDBInstanceOption `locationNameList:"OrderableDBInstanceOption" type:"list"`
 
-	metadataDescribeOrderableDBInstanceOptionsOutput `json:"-", xml:"-"`
+	metadataDescribeOrderableDBInstanceOptionsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeOrderableDBInstanceOptionsOutput struct {
@@ -4614,7 +4614,7 @@ type DescribePendingMaintenanceActionsInput struct {
 	// The ARN of the resource to return pending maintenance actions for.
 	ResourceIdentifier *string `type:"string"`
 
-	metadataDescribePendingMaintenanceActionsInput `json:"-", xml:"-"`
+	metadataDescribePendingMaintenanceActionsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribePendingMaintenanceActionsInput struct {
@@ -4631,7 +4631,7 @@ type DescribePendingMaintenanceActionsOutput struct {
 	// Provides a list of the pending maintenance actions for the resource.
 	PendingMaintenanceActions []*ResourcePendingMaintenanceActions `locationNameList:"ResourcePendingMaintenanceActions" type:"list"`
 
-	metadataDescribePendingMaintenanceActionsOutput `json:"-", xml:"-"`
+	metadataDescribePendingMaintenanceActionsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribePendingMaintenanceActionsOutput struct {
@@ -4688,7 +4688,7 @@ type DescribeReservedDBInstancesInput struct {
 	// purchased reservations matching the specified offering identifier.
 	ReservedDBInstancesOfferingID *string `locationName:"ReservedDBInstancesOfferingId" type:"string"`
 
-	metadataDescribeReservedDBInstancesInput `json:"-", xml:"-"`
+	metadataDescribeReservedDBInstancesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeReservedDBInstancesInput struct {
@@ -4743,7 +4743,7 @@ type DescribeReservedDBInstancesOfferingsInput struct {
 	// Example: 438012d3-4052-4cc7-b2e3-8d3372e0e706
 	ReservedDBInstancesOfferingID *string `locationName:"ReservedDBInstancesOfferingId" type:"string"`
 
-	metadataDescribeReservedDBInstancesOfferingsInput `json:"-", xml:"-"`
+	metadataDescribeReservedDBInstancesOfferingsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeReservedDBInstancesOfferingsInput struct {
@@ -4761,7 +4761,7 @@ type DescribeReservedDBInstancesOfferingsOutput struct {
 	// A list of reserved DB instance offerings.
 	ReservedDBInstancesOfferings []*ReservedDBInstancesOffering `locationNameList:"ReservedDBInstancesOffering" type:"list"`
 
-	metadataDescribeReservedDBInstancesOfferingsOutput `json:"-", xml:"-"`
+	metadataDescribeReservedDBInstancesOfferingsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeReservedDBInstancesOfferingsOutput struct {
@@ -4779,7 +4779,7 @@ type DescribeReservedDBInstancesOutput struct {
 	// A list of reserved DB instances.
 	ReservedDBInstances []*ReservedDBInstance `locationNameList:"ReservedDBInstance" type:"list"`
 
-	metadataDescribeReservedDBInstancesOutput `json:"-", xml:"-"`
+	metadataDescribeReservedDBInstancesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeReservedDBInstancesOutput struct {
@@ -4824,7 +4824,7 @@ type DownloadDBLogFilePortionInput struct {
 	// continuing until the AdditionalDataPending response element returns false.
 	NumberOfLines *int64 `type:"integer"`
 
-	metadataDownloadDBLogFilePortionInput `json:"-", xml:"-"`
+	metadataDownloadDBLogFilePortionInput `json:"-" xml:"-"`
 }
 
 type metadataDownloadDBLogFilePortionInput struct {
@@ -4843,7 +4843,7 @@ type DownloadDBLogFilePortionOutput struct {
 	// request.
 	Marker *string `type:"string"`
 
-	metadataDownloadDBLogFilePortionOutput `json:"-", xml:"-"`
+	metadataDownloadDBLogFilePortionOutput `json:"-" xml:"-"`
 }
 
 type metadataDownloadDBLogFilePortionOutput struct {
@@ -4868,7 +4868,7 @@ type EC2SecurityGroup struct {
 	// "authorized", "revoking", and "revoked".
 	Status *string `type:"string"`
 
-	metadataEC2SecurityGroup `json:"-", xml:"-"`
+	metadataEC2SecurityGroup `json:"-" xml:"-"`
 }
 
 type metadataEC2SecurityGroup struct {
@@ -4885,7 +4885,7 @@ type Endpoint struct {
 	// Specifies the port that the database engine is listening on.
 	Port *int64 `type:"integer"`
 
-	metadataEndpoint `json:"-", xml:"-"`
+	metadataEndpoint `json:"-" xml:"-"`
 }
 
 type metadataEndpoint struct {
@@ -4907,7 +4907,7 @@ type EngineDefaults struct {
 	// Contains a list of engine default parameters.
 	Parameters []*Parameter `locationNameList:"Parameter" type:"list"`
 
-	metadataEngineDefaults `json:"-", xml:"-"`
+	metadataEngineDefaults `json:"-" xml:"-"`
 }
 
 type metadataEngineDefaults struct {
@@ -4931,7 +4931,7 @@ type Event struct {
 	// Specifies the source type for this event.
 	SourceType *string `type:"string"`
 
-	metadataEvent `json:"-", xml:"-"`
+	metadataEvent `json:"-" xml:"-"`
 }
 
 type metadataEvent struct {
@@ -4947,7 +4947,7 @@ type EventCategoriesMap struct {
 	// The source type that the returned categories belong to
 	SourceType *string `type:"string"`
 
-	metadataEventCategoriesMap `json:"-", xml:"-"`
+	metadataEventCategoriesMap `json:"-" xml:"-"`
 }
 
 type metadataEventCategoriesMap struct {
@@ -4994,7 +4994,7 @@ type EventSubscription struct {
 	// The time the RDS event notification subscription was created.
 	SubscriptionCreationTime *string `type:"string"`
 
-	metadataEventSubscription `json:"-", xml:"-"`
+	metadataEventSubscription `json:"-" xml:"-"`
 }
 
 type metadataEventSubscription struct {
@@ -5008,7 +5008,7 @@ type Filter struct {
 	// This parameter is not currently supported.
 	Values []*string `locationNameList:"Value" type:"list" required:"true"`
 
-	metadataFilter `json:"-", xml:"-"`
+	metadataFilter `json:"-" xml:"-"`
 }
 
 type metadataFilter struct {
@@ -5025,7 +5025,7 @@ type IPRange struct {
 	// "revoking", and "revoked".
 	Status *string `type:"string"`
 
-	metadataIPRange `json:"-", xml:"-"`
+	metadataIPRange `json:"-" xml:"-"`
 }
 
 type metadataIPRange struct {
@@ -5041,7 +5041,7 @@ type ListTagsForResourceInput struct {
 	// Amazon Resource Name (ARN) (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.html#USER_Tagging.ARN).
 	ResourceName *string `type:"string" required:"true"`
 
-	metadataListTagsForResourceInput `json:"-", xml:"-"`
+	metadataListTagsForResourceInput `json:"-" xml:"-"`
 }
 
 type metadataListTagsForResourceInput struct {
@@ -5052,7 +5052,7 @@ type ListTagsForResourceOutput struct {
 	// List of tags returned by the ListTagsForResource operation.
 	TagList []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataListTagsForResourceOutput `json:"-", xml:"-"`
+	metadataListTagsForResourceOutput `json:"-" xml:"-"`
 }
 
 type metadataListTagsForResourceOutput struct {
@@ -5370,7 +5370,7 @@ type ModifyDBInstanceInput struct {
 	// Cannot end with a hyphen or contain two consecutive hyphens
 	VPCSecurityGroupIDs []*string `locationName:"VpcSecurityGroupIds" locationNameList:"VpcSecurityGroupId" type:"list"`
 
-	metadataModifyDBInstanceInput `json:"-", xml:"-"`
+	metadataModifyDBInstanceInput `json:"-" xml:"-"`
 }
 
 type metadataModifyDBInstanceInput struct {
@@ -5384,7 +5384,7 @@ type ModifyDBInstanceOutput struct {
 	// as a response element in the DescribeDBInstances action.
 	DBInstance *DBInstance `type:"structure"`
 
-	metadataModifyDBInstanceOutput `json:"-", xml:"-"`
+	metadataModifyDBInstanceOutput `json:"-" xml:"-"`
 }
 
 type metadataModifyDBInstanceOutput struct {
@@ -5413,7 +5413,7 @@ type ModifyDBParameterGroupInput struct {
 	// are applied when you reboot the DB instance without failover.
 	Parameters []*Parameter `locationNameList:"Parameter" type:"list" required:"true"`
 
-	metadataModifyDBParameterGroupInput `json:"-", xml:"-"`
+	metadataModifyDBParameterGroupInput `json:"-" xml:"-"`
 }
 
 type metadataModifyDBParameterGroupInput struct {
@@ -5435,7 +5435,7 @@ type ModifyDBSubnetGroupInput struct {
 	// The EC2 subnet IDs for the DB subnet group.
 	SubnetIDs []*string `locationName:"SubnetIds" locationNameList:"SubnetIdentifier" type:"list" required:"true"`
 
-	metadataModifyDBSubnetGroupInput `json:"-", xml:"-"`
+	metadataModifyDBSubnetGroupInput `json:"-" xml:"-"`
 }
 
 type metadataModifyDBSubnetGroupInput struct {
@@ -5450,7 +5450,7 @@ type ModifyDBSubnetGroupOutput struct {
 	// action.
 	DBSubnetGroup *DBSubnetGroup `type:"structure"`
 
-	metadataModifyDBSubnetGroupOutput `json:"-", xml:"-"`
+	metadataModifyDBSubnetGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataModifyDBSubnetGroupOutput struct {
@@ -5484,7 +5484,7 @@ type ModifyEventSubscriptionInput struct {
 	// The name of the RDS event notification subscription.
 	SubscriptionName *string `type:"string" required:"true"`
 
-	metadataModifyEventSubscriptionInput `json:"-", xml:"-"`
+	metadataModifyEventSubscriptionInput `json:"-" xml:"-"`
 }
 
 type metadataModifyEventSubscriptionInput struct {
@@ -5496,7 +5496,7 @@ type ModifyEventSubscriptionOutput struct {
 	// action.
 	EventSubscription *EventSubscription `type:"structure"`
 
-	metadataModifyEventSubscriptionOutput `json:"-", xml:"-"`
+	metadataModifyEventSubscriptionOutput `json:"-" xml:"-"`
 }
 
 type metadataModifyEventSubscriptionOutput struct {
@@ -5522,7 +5522,7 @@ type ModifyOptionGroupInput struct {
 	// Options in this list are removed from the option group.
 	OptionsToRemove []*string `type:"list"`
 
-	metadataModifyOptionGroupInput `json:"-", xml:"-"`
+	metadataModifyOptionGroupInput `json:"-" xml:"-"`
 }
 
 type metadataModifyOptionGroupInput struct {
@@ -5532,7 +5532,7 @@ type metadataModifyOptionGroupInput struct {
 type ModifyOptionGroupOutput struct {
 	OptionGroup *OptionGroup `type:"structure"`
 
-	metadataModifyOptionGroupOutput `json:"-", xml:"-"`
+	metadataModifyOptionGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataModifyOptionGroupOutput struct {
@@ -5567,7 +5567,7 @@ type Option struct {
 	// access to the port.
 	VPCSecurityGroupMemberships []*VPCSecurityGroupMembership `locationName:"VpcSecurityGroupMemberships" locationNameList:"VpcSecurityGroupMembership" type:"list"`
 
-	metadataOption `json:"-", xml:"-"`
+	metadataOption `json:"-" xml:"-"`
 }
 
 type metadataOption struct {
@@ -5591,7 +5591,7 @@ type OptionConfiguration struct {
 	// A list of VpcSecurityGroupMemebrship name strings used for this option.
 	VPCSecurityGroupMemberships []*string `locationName:"VpcSecurityGroupMemberships" locationNameList:"VpcSecurityGroupId" type:"list"`
 
-	metadataOptionConfiguration `json:"-", xml:"-"`
+	metadataOptionConfiguration `json:"-" xml:"-"`
 }
 
 type metadataOptionConfiguration struct {
@@ -5626,7 +5626,7 @@ type OptionGroup struct {
 	// that are in the VPC indicated by this field.
 	VPCID *string `locationName:"VpcId" type:"string"`
 
-	metadataOptionGroup `json:"-", xml:"-"`
+	metadataOptionGroup `json:"-" xml:"-"`
 }
 
 type metadataOptionGroup struct {
@@ -5642,7 +5642,7 @@ type OptionGroupMembership struct {
 	// pending-maintenance, applying).
 	Status *string `type:"string"`
 
-	metadataOptionGroupMembership `json:"-", xml:"-"`
+	metadataOptionGroupMembership `json:"-" xml:"-"`
 }
 
 type metadataOptionGroupMembership struct {
@@ -5690,7 +5690,7 @@ type OptionGroupOption struct {
 	// Specifies whether the option requires a port.
 	PortRequired *bool `type:"boolean"`
 
-	metadataOptionGroupOption `json:"-", xml:"-"`
+	metadataOptionGroupOption `json:"-" xml:"-"`
 }
 
 type metadataOptionGroupOption struct {
@@ -5720,7 +5720,7 @@ type OptionGroupOptionSetting struct {
 	// The name of the option group option.
 	SettingName *string `type:"string"`
 
-	metadataOptionGroupOptionSetting `json:"-", xml:"-"`
+	metadataOptionGroupOptionSetting `json:"-" xml:"-"`
 }
 
 type metadataOptionGroupOptionSetting struct {
@@ -5760,7 +5760,7 @@ type OptionSetting struct {
 	// The current value of the option setting.
 	Value *string `type:"string"`
 
-	metadataOptionSetting `json:"-", xml:"-"`
+	metadataOptionSetting `json:"-" xml:"-"`
 }
 
 type metadataOptionSetting struct {
@@ -5805,7 +5805,7 @@ type OrderableDBInstanceOption struct {
 	// Indicates whether this is a VPC orderable DB instance.
 	VPC *bool `locationName:"Vpc" type:"boolean"`
 
-	metadataOrderableDBInstanceOption `json:"-", xml:"-"`
+	metadataOrderableDBInstanceOption `json:"-" xml:"-"`
 }
 
 type metadataOrderableDBInstanceOption struct {
@@ -5850,7 +5850,7 @@ type Parameter struct {
 	// Indicates the source of the parameter value.
 	Source *string `type:"string"`
 
-	metadataParameter `json:"-", xml:"-"`
+	metadataParameter `json:"-" xml:"-"`
 }
 
 type metadataParameter struct {
@@ -5884,7 +5884,7 @@ type PendingMaintenanceAction struct {
 	// Indicates the type of opt-in request that has been received for the resource.
 	OptInStatus *string `type:"string"`
 
-	metadataPendingMaintenanceAction `json:"-", xml:"-"`
+	metadataPendingMaintenanceAction `json:"-" xml:"-"`
 }
 
 type metadataPendingMaintenanceAction struct {
@@ -5928,7 +5928,7 @@ type PendingModifiedValues struct {
 	// Specifies the storage type to be associated with the DB instance.
 	StorageType *string `type:"string"`
 
-	metadataPendingModifiedValues `json:"-", xml:"-"`
+	metadataPendingModifiedValues `json:"-" xml:"-"`
 }
 
 type metadataPendingModifiedValues struct {
@@ -5969,7 +5969,7 @@ type PromoteReadReplicaInput struct {
 	// window. Must be at least 30 minutes.
 	PreferredBackupWindow *string `type:"string"`
 
-	metadataPromoteReadReplicaInput `json:"-", xml:"-"`
+	metadataPromoteReadReplicaInput `json:"-" xml:"-"`
 }
 
 type metadataPromoteReadReplicaInput struct {
@@ -5983,7 +5983,7 @@ type PromoteReadReplicaOutput struct {
 	// as a response element in the DescribeDBInstances action.
 	DBInstance *DBInstance `type:"structure"`
 
-	metadataPromoteReadReplicaOutput `json:"-", xml:"-"`
+	metadataPromoteReadReplicaOutput `json:"-" xml:"-"`
 }
 
 type metadataPromoteReadReplicaOutput struct {
@@ -6009,7 +6009,7 @@ type PurchaseReservedDBInstancesOfferingInput struct {
 	// A list of tags.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataPurchaseReservedDBInstancesOfferingInput `json:"-", xml:"-"`
+	metadataPurchaseReservedDBInstancesOfferingInput `json:"-" xml:"-"`
 }
 
 type metadataPurchaseReservedDBInstancesOfferingInput struct {
@@ -6021,7 +6021,7 @@ type PurchaseReservedDBInstancesOfferingOutput struct {
 	// and PurchaseReservedDBInstancesOffering actions.
 	ReservedDBInstance *ReservedDBInstance `type:"structure"`
 
-	metadataPurchaseReservedDBInstancesOfferingOutput `json:"-", xml:"-"`
+	metadataPurchaseReservedDBInstancesOfferingOutput `json:"-" xml:"-"`
 }
 
 type metadataPurchaseReservedDBInstancesOfferingOutput struct {
@@ -6043,7 +6043,7 @@ type RebootDBInstanceInput struct {
 	// MultiAZ.
 	ForceFailover *bool `type:"boolean"`
 
-	metadataRebootDBInstanceInput `json:"-", xml:"-"`
+	metadataRebootDBInstanceInput `json:"-" xml:"-"`
 }
 
 type metadataRebootDBInstanceInput struct {
@@ -6057,7 +6057,7 @@ type RebootDBInstanceOutput struct {
 	// as a response element in the DescribeDBInstances action.
 	DBInstance *DBInstance `type:"structure"`
 
-	metadataRebootDBInstanceOutput `json:"-", xml:"-"`
+	metadataRebootDBInstanceOutput `json:"-" xml:"-"`
 }
 
 type metadataRebootDBInstanceOutput struct {
@@ -6073,7 +6073,7 @@ type RecurringCharge struct {
 	// The frequency of the recurring charge.
 	RecurringChargeFrequency *string `type:"string"`
 
-	metadataRecurringCharge `json:"-", xml:"-"`
+	metadataRecurringCharge `json:"-" xml:"-"`
 }
 
 type metadataRecurringCharge struct {
@@ -6089,7 +6089,7 @@ type RemoveSourceIdentifierFromSubscriptionInput struct {
 	// source identifier from.
 	SubscriptionName *string `type:"string" required:"true"`
 
-	metadataRemoveSourceIdentifierFromSubscriptionInput `json:"-", xml:"-"`
+	metadataRemoveSourceIdentifierFromSubscriptionInput `json:"-" xml:"-"`
 }
 
 type metadataRemoveSourceIdentifierFromSubscriptionInput struct {
@@ -6101,7 +6101,7 @@ type RemoveSourceIdentifierFromSubscriptionOutput struct {
 	// action.
 	EventSubscription *EventSubscription `type:"structure"`
 
-	metadataRemoveSourceIdentifierFromSubscriptionOutput `json:"-", xml:"-"`
+	metadataRemoveSourceIdentifierFromSubscriptionOutput `json:"-" xml:"-"`
 }
 
 type metadataRemoveSourceIdentifierFromSubscriptionOutput struct {
@@ -6117,7 +6117,7 @@ type RemoveTagsFromResourceInput struct {
 	// The tag key (name) of the tag to be removed.
 	TagKeys []*string `type:"list" required:"true"`
 
-	metadataRemoveTagsFromResourceInput `json:"-", xml:"-"`
+	metadataRemoveTagsFromResourceInput `json:"-" xml:"-"`
 }
 
 type metadataRemoveTagsFromResourceInput struct {
@@ -6125,7 +6125,7 @@ type metadataRemoveTagsFromResourceInput struct {
 }
 
 type RemoveTagsFromResourceOutput struct {
-	metadataRemoveTagsFromResourceOutput `json:"-", xml:"-"`
+	metadataRemoveTagsFromResourceOutput `json:"-" xml:"-"`
 }
 
 type metadataRemoveTagsFromResourceOutput struct {
@@ -6177,7 +6177,7 @@ type ReservedDBInstance struct {
 	// The hourly price charged for this reserved DB instance.
 	UsagePrice *float64 `type:"double"`
 
-	metadataReservedDBInstance `json:"-", xml:"-"`
+	metadataReservedDBInstance `json:"-" xml:"-"`
 }
 
 type metadataReservedDBInstance struct {
@@ -6217,7 +6217,7 @@ type ReservedDBInstancesOffering struct {
 	// The hourly price charged for this offering.
 	UsagePrice *float64 `type:"double"`
 
-	metadataReservedDBInstancesOffering `json:"-", xml:"-"`
+	metadataReservedDBInstancesOffering `json:"-" xml:"-"`
 }
 
 type metadataReservedDBInstancesOffering struct {
@@ -6257,7 +6257,7 @@ type ResetDBParameterGroupInput struct {
 	// Default: true
 	ResetAllParameters *bool `type:"boolean"`
 
-	metadataResetDBParameterGroupInput `json:"-", xml:"-"`
+	metadataResetDBParameterGroupInput `json:"-" xml:"-"`
 }
 
 type metadataResetDBParameterGroupInput struct {
@@ -6272,7 +6272,7 @@ type ResourcePendingMaintenanceActions struct {
 	// The ARN of this resource that has pending maintenance actions.
 	ResourceIdentifier *string `type:"string"`
 
-	metadataResourcePendingMaintenanceActions `json:"-", xml:"-"`
+	metadataResourcePendingMaintenanceActions `json:"-" xml:"-"`
 }
 
 type metadataResourcePendingMaintenanceActions struct {
@@ -6413,7 +6413,7 @@ type RestoreDBInstanceFromDBSnapshotInput struct {
 	// A list of tags.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataRestoreDBInstanceFromDBSnapshotInput `json:"-", xml:"-"`
+	metadataRestoreDBInstanceFromDBSnapshotInput `json:"-" xml:"-"`
 }
 
 type metadataRestoreDBInstanceFromDBSnapshotInput struct {
@@ -6427,7 +6427,7 @@ type RestoreDBInstanceFromDBSnapshotOutput struct {
 	// as a response element in the DescribeDBInstances action.
 	DBInstance *DBInstance `type:"structure"`
 
-	metadataRestoreDBInstanceFromDBSnapshotOutput `json:"-", xml:"-"`
+	metadataRestoreDBInstanceFromDBSnapshotOutput `json:"-" xml:"-"`
 }
 
 type metadataRestoreDBInstanceFromDBSnapshotOutput struct {
@@ -6583,7 +6583,7 @@ type RestoreDBInstanceToPointInTimeInput struct {
 	// Constraints: Cannot be specified if RestoreTime parameter is provided.
 	UseLatestRestorableTime *bool `type:"boolean"`
 
-	metadataRestoreDBInstanceToPointInTimeInput `json:"-", xml:"-"`
+	metadataRestoreDBInstanceToPointInTimeInput `json:"-" xml:"-"`
 }
 
 type metadataRestoreDBInstanceToPointInTimeInput struct {
@@ -6597,7 +6597,7 @@ type RestoreDBInstanceToPointInTimeOutput struct {
 	// as a response element in the DescribeDBInstances action.
 	DBInstance *DBInstance `type:"structure"`
 
-	metadataRestoreDBInstanceToPointInTimeOutput `json:"-", xml:"-"`
+	metadataRestoreDBInstanceToPointInTimeOutput `json:"-" xml:"-"`
 }
 
 type metadataRestoreDBInstanceToPointInTimeOutput struct {
@@ -6630,7 +6630,7 @@ type RevokeDBSecurityGroupIngressInput struct {
 	// must be provided.
 	EC2SecurityGroupOwnerID *string `locationName:"EC2SecurityGroupOwnerId" type:"string"`
 
-	metadataRevokeDBSecurityGroupIngressInput `json:"-", xml:"-"`
+	metadataRevokeDBSecurityGroupIngressInput `json:"-" xml:"-"`
 }
 
 type metadataRevokeDBSecurityGroupIngressInput struct {
@@ -6645,7 +6645,7 @@ type RevokeDBSecurityGroupIngressOutput struct {
 	// in the DescribeDBSecurityGroups action.
 	DBSecurityGroup *DBSecurityGroup `type:"structure"`
 
-	metadataRevokeDBSecurityGroupIngressOutput `json:"-", xml:"-"`
+	metadataRevokeDBSecurityGroupIngressOutput `json:"-" xml:"-"`
 }
 
 type metadataRevokeDBSecurityGroupIngressOutput struct {
@@ -6666,7 +6666,7 @@ type Subnet struct {
 	// Specifies the status of the subnet.
 	SubnetStatus *string `type:"string"`
 
-	metadataSubnet `json:"-", xml:"-"`
+	metadataSubnet `json:"-" xml:"-"`
 }
 
 type metadataSubnet struct {
@@ -6687,7 +6687,7 @@ type Tag struct {
 	// white-space, '_', '.', '/', '=', '+', '-' (Java regex: "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-]*)$").
 	Value *string `type:"string"`
 
-	metadataTag `json:"-", xml:"-"`
+	metadataTag `json:"-" xml:"-"`
 }
 
 type metadataTag struct {
@@ -6703,7 +6703,7 @@ type VPCSecurityGroupMembership struct {
 	// The name of the VPC security group.
 	VPCSecurityGroupID *string `locationName:"VpcSecurityGroupId" type:"string"`
 
-	metadataVPCSecurityGroupMembership `json:"-", xml:"-"`
+	metadataVPCSecurityGroupMembership `json:"-" xml:"-"`
 }
 
 type metadataVPCSecurityGroupMembership struct {

--- a/service/redshift/api.go
+++ b/service/redshift/api.go
@@ -2227,7 +2227,7 @@ type AccountWithRestoreAccess struct {
 	// The identifier of an AWS customer account authorized to restore a snapshot.
 	AccountID *string `locationName:"AccountId" type:"string"`
 
-	metadataAccountWithRestoreAccess `json:"-", xml:"-"`
+	metadataAccountWithRestoreAccess `json:"-" xml:"-"`
 }
 
 type metadataAccountWithRestoreAccess struct {
@@ -2252,7 +2252,7 @@ type AuthorizeClusterSecurityGroupIngressInput struct {
 	//  Example: 111122223333
 	EC2SecurityGroupOwnerID *string `locationName:"EC2SecurityGroupOwnerId" type:"string"`
 
-	metadataAuthorizeClusterSecurityGroupIngressInput `json:"-", xml:"-"`
+	metadataAuthorizeClusterSecurityGroupIngressInput `json:"-" xml:"-"`
 }
 
 type metadataAuthorizeClusterSecurityGroupIngressInput struct {
@@ -2263,7 +2263,7 @@ type AuthorizeClusterSecurityGroupIngressOutput struct {
 	// Describes a security group.
 	ClusterSecurityGroup *ClusterSecurityGroup `type:"structure"`
 
-	metadataAuthorizeClusterSecurityGroupIngressOutput `json:"-", xml:"-"`
+	metadataAuthorizeClusterSecurityGroupIngressOutput `json:"-" xml:"-"`
 }
 
 type metadataAuthorizeClusterSecurityGroupIngressOutput struct {
@@ -2283,7 +2283,7 @@ type AuthorizeSnapshotAccessInput struct {
 	// The identifier of the snapshot the account is authorized to restore.
 	SnapshotIdentifier *string `type:"string" required:"true"`
 
-	metadataAuthorizeSnapshotAccessInput `json:"-", xml:"-"`
+	metadataAuthorizeSnapshotAccessInput `json:"-" xml:"-"`
 }
 
 type metadataAuthorizeSnapshotAccessInput struct {
@@ -2294,7 +2294,7 @@ type AuthorizeSnapshotAccessOutput struct {
 	// Describes a snapshot.
 	Snapshot *Snapshot `type:"structure"`
 
-	metadataAuthorizeSnapshotAccessOutput `json:"-", xml:"-"`
+	metadataAuthorizeSnapshotAccessOutput `json:"-" xml:"-"`
 }
 
 type metadataAuthorizeSnapshotAccessOutput struct {
@@ -2306,7 +2306,7 @@ type AvailabilityZone struct {
 	// The name of the availability zone.
 	Name *string `type:"string"`
 
-	metadataAvailabilityZone `json:"-", xml:"-"`
+	metadataAvailabilityZone `json:"-" xml:"-"`
 }
 
 type metadataAvailabilityZone struct {
@@ -2429,7 +2429,7 @@ type Cluster struct {
 	// VPC.
 	VPCSecurityGroups []*VPCSecurityGroupMembership `locationName:"VpcSecurityGroups" locationNameList:"VpcSecurityGroup" type:"list"`
 
-	metadataCluster `json:"-", xml:"-"`
+	metadataCluster `json:"-" xml:"-"`
 }
 
 type metadataCluster struct {
@@ -2447,7 +2447,7 @@ type ClusterNode struct {
 	// The public IP address of a node within a cluster.
 	PublicIPAddress *string `type:"string"`
 
-	metadataClusterNode `json:"-", xml:"-"`
+	metadataClusterNode `json:"-" xml:"-"`
 }
 
 type metadataClusterNode struct {
@@ -2469,7 +2469,7 @@ type ClusterParameterGroup struct {
 	// The list of tags for the cluster parameter group.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataClusterParameterGroup `json:"-", xml:"-"`
+	metadataClusterParameterGroup `json:"-" xml:"-"`
 }
 
 type metadataClusterParameterGroup struct {
@@ -2488,7 +2488,7 @@ type ClusterParameterGroupNameMessage struct {
 	// of an associated cluster.
 	ParameterGroupStatus *string `type:"string"`
 
-	metadataClusterParameterGroupNameMessage `json:"-", xml:"-"`
+	metadataClusterParameterGroupNameMessage `json:"-" xml:"-"`
 }
 
 type metadataClusterParameterGroupNameMessage struct {
@@ -2503,7 +2503,7 @@ type ClusterParameterGroupStatus struct {
 	// The name of the cluster parameter group.
 	ParameterGroupName *string `type:"string"`
 
-	metadataClusterParameterGroupStatus `json:"-", xml:"-"`
+	metadataClusterParameterGroupStatus `json:"-" xml:"-"`
 }
 
 type metadataClusterParameterGroupStatus struct {
@@ -2529,7 +2529,7 @@ type ClusterSecurityGroup struct {
 	// The list of tags for the cluster security group.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataClusterSecurityGroup `json:"-", xml:"-"`
+	metadataClusterSecurityGroup `json:"-" xml:"-"`
 }
 
 type metadataClusterSecurityGroup struct {
@@ -2544,7 +2544,7 @@ type ClusterSecurityGroupMembership struct {
 	// The status of the cluster security group.
 	Status *string `type:"string"`
 
-	metadataClusterSecurityGroupMembership `json:"-", xml:"-"`
+	metadataClusterSecurityGroupMembership `json:"-" xml:"-"`
 }
 
 type metadataClusterSecurityGroupMembership struct {
@@ -2562,7 +2562,7 @@ type ClusterSnapshotCopyStatus struct {
 	// region after they are copied from a source region.
 	RetentionPeriod *int64 `type:"long"`
 
-	metadataClusterSnapshotCopyStatus `json:"-", xml:"-"`
+	metadataClusterSnapshotCopyStatus `json:"-" xml:"-"`
 }
 
 type metadataClusterSnapshotCopyStatus struct {
@@ -2590,7 +2590,7 @@ type ClusterSubnetGroup struct {
 	// The VPC ID of the cluster subnet group.
 	VPCID *string `locationName:"VpcId" type:"string"`
 
-	metadataClusterSubnetGroup `json:"-", xml:"-"`
+	metadataClusterSubnetGroup `json:"-" xml:"-"`
 }
 
 type metadataClusterSubnetGroup struct {
@@ -2609,7 +2609,7 @@ type ClusterVersion struct {
 	// The description of the cluster version.
 	Description *string `type:"string"`
 
-	metadataClusterVersion `json:"-", xml:"-"`
+	metadataClusterVersion `json:"-" xml:"-"`
 }
 
 type metadataClusterVersion struct {
@@ -2643,7 +2643,7 @@ type CopyClusterSnapshotInput struct {
 	// that is making the request.
 	TargetSnapshotIdentifier *string `type:"string" required:"true"`
 
-	metadataCopyClusterSnapshotInput `json:"-", xml:"-"`
+	metadataCopyClusterSnapshotInput `json:"-" xml:"-"`
 }
 
 type metadataCopyClusterSnapshotInput struct {
@@ -2654,7 +2654,7 @@ type CopyClusterSnapshotOutput struct {
 	// Describes a snapshot.
 	Snapshot *Snapshot `type:"structure"`
 
-	metadataCopyClusterSnapshotOutput `json:"-", xml:"-"`
+	metadataCopyClusterSnapshotOutput `json:"-" xml:"-"`
 }
 
 type metadataCopyClusterSnapshotOutput struct {
@@ -2874,7 +2874,7 @@ type CreateClusterInput struct {
 	// Default: The default VPC security group is associated with the cluster.
 	VPCSecurityGroupIDs []*string `locationName:"VpcSecurityGroupIds" locationNameList:"VpcSecurityGroupId" type:"list"`
 
-	metadataCreateClusterInput `json:"-", xml:"-"`
+	metadataCreateClusterInput `json:"-" xml:"-"`
 }
 
 type metadataCreateClusterInput struct {
@@ -2885,7 +2885,7 @@ type CreateClusterOutput struct {
 	// Describes a cluster.
 	Cluster *Cluster `type:"structure"`
 
-	metadataCreateClusterOutput `json:"-", xml:"-"`
+	metadataCreateClusterOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateClusterOutput struct {
@@ -2920,7 +2920,7 @@ type CreateClusterParameterGroupInput struct {
 	// A list of tag instances.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataCreateClusterParameterGroupInput `json:"-", xml:"-"`
+	metadataCreateClusterParameterGroupInput `json:"-" xml:"-"`
 }
 
 type metadataCreateClusterParameterGroupInput struct {
@@ -2931,7 +2931,7 @@ type CreateClusterParameterGroupOutput struct {
 	// Describes a parameter group.
 	ClusterParameterGroup *ClusterParameterGroup `type:"structure"`
 
-	metadataCreateClusterParameterGroupOutput `json:"-", xml:"-"`
+	metadataCreateClusterParameterGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateClusterParameterGroupOutput struct {
@@ -2956,7 +2956,7 @@ type CreateClusterSecurityGroupInput struct {
 	// A list of tag instances.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataCreateClusterSecurityGroupInput `json:"-", xml:"-"`
+	metadataCreateClusterSecurityGroupInput `json:"-" xml:"-"`
 }
 
 type metadataCreateClusterSecurityGroupInput struct {
@@ -2967,7 +2967,7 @@ type CreateClusterSecurityGroupOutput struct {
 	// Describes a security group.
 	ClusterSecurityGroup *ClusterSecurityGroup `type:"structure"`
 
-	metadataCreateClusterSecurityGroupOutput `json:"-", xml:"-"`
+	metadataCreateClusterSecurityGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateClusterSecurityGroupOutput struct {
@@ -2991,7 +2991,7 @@ type CreateClusterSnapshotInput struct {
 	// A list of tag instances.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataCreateClusterSnapshotInput `json:"-", xml:"-"`
+	metadataCreateClusterSnapshotInput `json:"-" xml:"-"`
 }
 
 type metadataCreateClusterSnapshotInput struct {
@@ -3002,7 +3002,7 @@ type CreateClusterSnapshotOutput struct {
 	// Describes a snapshot.
 	Snapshot *Snapshot `type:"structure"`
 
-	metadataCreateClusterSnapshotOutput `json:"-", xml:"-"`
+	metadataCreateClusterSnapshotOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateClusterSnapshotOutput struct {
@@ -3030,7 +3030,7 @@ type CreateClusterSubnetGroupInput struct {
 	// A list of tag instances.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataCreateClusterSubnetGroupInput `json:"-", xml:"-"`
+	metadataCreateClusterSubnetGroupInput `json:"-" xml:"-"`
 }
 
 type metadataCreateClusterSubnetGroupInput struct {
@@ -3041,7 +3041,7 @@ type CreateClusterSubnetGroupOutput struct {
 	// Describes a subnet group.
 	ClusterSubnetGroup *ClusterSubnetGroup `type:"structure"`
 
-	metadataCreateClusterSubnetGroupOutput `json:"-", xml:"-"`
+	metadataCreateClusterSubnetGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateClusterSubnetGroupOutput struct {
@@ -3103,7 +3103,7 @@ type CreateEventSubscriptionInput struct {
 	// A list of tag instances.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataCreateEventSubscriptionInput `json:"-", xml:"-"`
+	metadataCreateEventSubscriptionInput `json:"-" xml:"-"`
 }
 
 type metadataCreateEventSubscriptionInput struct {
@@ -3113,7 +3113,7 @@ type metadataCreateEventSubscriptionInput struct {
 type CreateEventSubscriptionOutput struct {
 	EventSubscription *EventSubscription `type:"structure"`
 
-	metadataCreateEventSubscriptionOutput `json:"-", xml:"-"`
+	metadataCreateEventSubscriptionOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateEventSubscriptionOutput struct {
@@ -3128,7 +3128,7 @@ type CreateHSMClientCertificateInput struct {
 	// A list of tag instances.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataCreateHSMClientCertificateInput `json:"-", xml:"-"`
+	metadataCreateHSMClientCertificateInput `json:"-" xml:"-"`
 }
 
 type metadataCreateHSMClientCertificateInput struct {
@@ -3141,7 +3141,7 @@ type CreateHSMClientCertificateOutput struct {
 	// cluster to encrypt data files.
 	HSMClientCertificate *HSMClientCertificate `locationName:"HsmClientCertificate" type:"structure"`
 
-	metadataCreateHSMClientCertificateOutput `json:"-", xml:"-"`
+	metadataCreateHSMClientCertificateOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateHSMClientCertificateOutput struct {
@@ -3172,7 +3172,7 @@ type CreateHSMConfigurationInput struct {
 	// A list of tag instances.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataCreateHSMConfigurationInput `json:"-", xml:"-"`
+	metadataCreateHSMConfigurationInput `json:"-" xml:"-"`
 }
 
 type metadataCreateHSMConfigurationInput struct {
@@ -3185,7 +3185,7 @@ type CreateHSMConfigurationOutput struct {
 	// HSM where they can store database encryption keys.
 	HSMConfiguration *HSMConfiguration `locationName:"HsmConfiguration" type:"structure"`
 
-	metadataCreateHSMConfigurationOutput `json:"-", xml:"-"`
+	metadataCreateHSMConfigurationOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateHSMConfigurationOutput struct {
@@ -3206,7 +3206,7 @@ type CreateTagsInput struct {
 	// "tag-key"="version":"tag-value"="1.0".
 	Tags []*Tag `locationNameList:"Tag" type:"list" required:"true"`
 
-	metadataCreateTagsInput `json:"-", xml:"-"`
+	metadataCreateTagsInput `json:"-" xml:"-"`
 }
 
 type metadataCreateTagsInput struct {
@@ -3214,7 +3214,7 @@ type metadataCreateTagsInput struct {
 }
 
 type CreateTagsOutput struct {
-	metadataCreateTagsOutput `json:"-", xml:"-"`
+	metadataCreateTagsOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateTagsOutput struct {
@@ -3237,7 +3237,7 @@ type DefaultClusterParameters struct {
 	// The list of cluster default parameters.
 	Parameters []*Parameter `locationNameList:"Parameter" type:"list"`
 
-	metadataDefaultClusterParameters `json:"-", xml:"-"`
+	metadataDefaultClusterParameters `json:"-" xml:"-"`
 }
 
 type metadataDefaultClusterParameters struct {
@@ -3272,7 +3272,7 @@ type DeleteClusterInput struct {
 	// is false. Default: false
 	SkipFinalClusterSnapshot *bool `type:"boolean"`
 
-	metadataDeleteClusterInput `json:"-", xml:"-"`
+	metadataDeleteClusterInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteClusterInput struct {
@@ -3283,7 +3283,7 @@ type DeleteClusterOutput struct {
 	// Describes a cluster.
 	Cluster *Cluster `type:"structure"`
 
-	metadataDeleteClusterOutput `json:"-", xml:"-"`
+	metadataDeleteClusterOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteClusterOutput struct {
@@ -3299,7 +3299,7 @@ type DeleteClusterParameterGroupInput struct {
 	// a default cluster parameter group.
 	ParameterGroupName *string `type:"string" required:"true"`
 
-	metadataDeleteClusterParameterGroupInput `json:"-", xml:"-"`
+	metadataDeleteClusterParameterGroupInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteClusterParameterGroupInput struct {
@@ -3307,7 +3307,7 @@ type metadataDeleteClusterParameterGroupInput struct {
 }
 
 type DeleteClusterParameterGroupOutput struct {
-	metadataDeleteClusterParameterGroupOutput `json:"-", xml:"-"`
+	metadataDeleteClusterParameterGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteClusterParameterGroupOutput struct {
@@ -3318,7 +3318,7 @@ type DeleteClusterSecurityGroupInput struct {
 	// The name of the cluster security group to be deleted.
 	ClusterSecurityGroupName *string `type:"string" required:"true"`
 
-	metadataDeleteClusterSecurityGroupInput `json:"-", xml:"-"`
+	metadataDeleteClusterSecurityGroupInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteClusterSecurityGroupInput struct {
@@ -3326,7 +3326,7 @@ type metadataDeleteClusterSecurityGroupInput struct {
 }
 
 type DeleteClusterSecurityGroupOutput struct {
-	metadataDeleteClusterSecurityGroupOutput `json:"-", xml:"-"`
+	metadataDeleteClusterSecurityGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteClusterSecurityGroupOutput struct {
@@ -3347,7 +3347,7 @@ type DeleteClusterSnapshotInput struct {
 	// state.
 	SnapshotIdentifier *string `type:"string" required:"true"`
 
-	metadataDeleteClusterSnapshotInput `json:"-", xml:"-"`
+	metadataDeleteClusterSnapshotInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteClusterSnapshotInput struct {
@@ -3358,7 +3358,7 @@ type DeleteClusterSnapshotOutput struct {
 	// Describes a snapshot.
 	Snapshot *Snapshot `type:"structure"`
 
-	metadataDeleteClusterSnapshotOutput `json:"-", xml:"-"`
+	metadataDeleteClusterSnapshotOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteClusterSnapshotOutput struct {
@@ -3369,7 +3369,7 @@ type DeleteClusterSubnetGroupInput struct {
 	// The name of the cluster subnet group name to be deleted.
 	ClusterSubnetGroupName *string `type:"string" required:"true"`
 
-	metadataDeleteClusterSubnetGroupInput `json:"-", xml:"-"`
+	metadataDeleteClusterSubnetGroupInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteClusterSubnetGroupInput struct {
@@ -3377,7 +3377,7 @@ type metadataDeleteClusterSubnetGroupInput struct {
 }
 
 type DeleteClusterSubnetGroupOutput struct {
-	metadataDeleteClusterSubnetGroupOutput `json:"-", xml:"-"`
+	metadataDeleteClusterSubnetGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteClusterSubnetGroupOutput struct {
@@ -3388,7 +3388,7 @@ type DeleteEventSubscriptionInput struct {
 	// The name of the Amazon Redshift event notification subscription to be deleted.
 	SubscriptionName *string `type:"string" required:"true"`
 
-	metadataDeleteEventSubscriptionInput `json:"-", xml:"-"`
+	metadataDeleteEventSubscriptionInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteEventSubscriptionInput struct {
@@ -3396,7 +3396,7 @@ type metadataDeleteEventSubscriptionInput struct {
 }
 
 type DeleteEventSubscriptionOutput struct {
-	metadataDeleteEventSubscriptionOutput `json:"-", xml:"-"`
+	metadataDeleteEventSubscriptionOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteEventSubscriptionOutput struct {
@@ -3407,7 +3407,7 @@ type DeleteHSMClientCertificateInput struct {
 	// The identifier of the HSM client certificate to be deleted.
 	HSMClientCertificateIdentifier *string `locationName:"HsmClientCertificateIdentifier" type:"string" required:"true"`
 
-	metadataDeleteHSMClientCertificateInput `json:"-", xml:"-"`
+	metadataDeleteHSMClientCertificateInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteHSMClientCertificateInput struct {
@@ -3415,7 +3415,7 @@ type metadataDeleteHSMClientCertificateInput struct {
 }
 
 type DeleteHSMClientCertificateOutput struct {
-	metadataDeleteHSMClientCertificateOutput `json:"-", xml:"-"`
+	metadataDeleteHSMClientCertificateOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteHSMClientCertificateOutput struct {
@@ -3426,7 +3426,7 @@ type DeleteHSMConfigurationInput struct {
 	// The identifier of the Amazon Redshift HSM configuration to be deleted.
 	HSMConfigurationIdentifier *string `locationName:"HsmConfigurationIdentifier" type:"string" required:"true"`
 
-	metadataDeleteHSMConfigurationInput `json:"-", xml:"-"`
+	metadataDeleteHSMConfigurationInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteHSMConfigurationInput struct {
@@ -3434,7 +3434,7 @@ type metadataDeleteHSMConfigurationInput struct {
 }
 
 type DeleteHSMConfigurationOutput struct {
-	metadataDeleteHSMConfigurationOutput `json:"-", xml:"-"`
+	metadataDeleteHSMConfigurationOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteHSMConfigurationOutput struct {
@@ -3450,7 +3450,7 @@ type DeleteTagsInput struct {
 	// The tag key that you want to delete.
 	TagKeys []*string `locationNameList:"TagKey" type:"list" required:"true"`
 
-	metadataDeleteTagsInput `json:"-", xml:"-"`
+	metadataDeleteTagsInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteTagsInput struct {
@@ -3458,7 +3458,7 @@ type metadataDeleteTagsInput struct {
 }
 
 type DeleteTagsOutput struct {
-	metadataDeleteTagsOutput `json:"-", xml:"-"`
+	metadataDeleteTagsOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteTagsOutput struct {
@@ -3504,7 +3504,7 @@ type DescribeClusterParameterGroupsInput struct {
 	// both of these tag values associated with them.
 	TagValues []*string `locationNameList:"TagValue" type:"list"`
 
-	metadataDescribeClusterParameterGroupsInput `json:"-", xml:"-"`
+	metadataDescribeClusterParameterGroupsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeClusterParameterGroupsInput struct {
@@ -3524,7 +3524,7 @@ type DescribeClusterParameterGroupsOutput struct {
 	// parameter group.
 	ParameterGroups []*ClusterParameterGroup `locationNameList:"ClusterParameterGroup" type:"list"`
 
-	metadataDescribeClusterParameterGroupsOutput `json:"-", xml:"-"`
+	metadataDescribeClusterParameterGroupsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeClusterParameterGroupsOutput struct {
@@ -3562,7 +3562,7 @@ type DescribeClusterParametersInput struct {
 	// Valid Values: user | engine-default
 	Source *string `type:"string"`
 
-	metadataDescribeClusterParametersInput `json:"-", xml:"-"`
+	metadataDescribeClusterParametersInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeClusterParametersInput struct {
@@ -3582,7 +3582,7 @@ type DescribeClusterParametersOutput struct {
 	// cluster parameter group.
 	Parameters []*Parameter `locationNameList:"Parameter" type:"list"`
 
-	metadataDescribeClusterParametersOutput `json:"-", xml:"-"`
+	metadataDescribeClusterParametersOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeClusterParametersOutput struct {
@@ -3635,7 +3635,7 @@ type DescribeClusterSecurityGroupsInput struct {
 	// both of these tag values associated with them.
 	TagValues []*string `locationNameList:"TagValue" type:"list"`
 
-	metadataDescribeClusterSecurityGroupsInput `json:"-", xml:"-"`
+	metadataDescribeClusterSecurityGroupsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeClusterSecurityGroupsInput struct {
@@ -3654,7 +3654,7 @@ type DescribeClusterSecurityGroupsOutput struct {
 	// records have been retrieved for the request.
 	Marker *string `type:"string"`
 
-	metadataDescribeClusterSecurityGroupsOutput `json:"-", xml:"-"`
+	metadataDescribeClusterSecurityGroupsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeClusterSecurityGroupsOutput struct {
@@ -3728,7 +3728,7 @@ type DescribeClusterSnapshotsInput struct {
 	// these tag values associated with them.
 	TagValues []*string `locationNameList:"TagValue" type:"list"`
 
-	metadataDescribeClusterSnapshotsInput `json:"-", xml:"-"`
+	metadataDescribeClusterSnapshotsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeClusterSnapshotsInput struct {
@@ -3747,7 +3747,7 @@ type DescribeClusterSnapshotsOutput struct {
 	// A list of Snapshot instances.
 	Snapshots []*Snapshot `locationNameList:"Snapshot" type:"list"`
 
-	metadataDescribeClusterSnapshotsOutput `json:"-", xml:"-"`
+	metadataDescribeClusterSnapshotsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeClusterSnapshotsOutput struct {
@@ -3792,7 +3792,7 @@ type DescribeClusterSubnetGroupsInput struct {
 	// of these tag values associated with them.
 	TagValues []*string `locationNameList:"TagValue" type:"list"`
 
-	metadataDescribeClusterSubnetGroupsInput `json:"-", xml:"-"`
+	metadataDescribeClusterSubnetGroupsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeClusterSubnetGroupsInput struct {
@@ -3811,7 +3811,7 @@ type DescribeClusterSubnetGroupsOutput struct {
 	// records have been retrieved for the request.
 	Marker *string `type:"string"`
 
-	metadataDescribeClusterSubnetGroupsOutput `json:"-", xml:"-"`
+	metadataDescribeClusterSubnetGroupsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeClusterSubnetGroupsOutput struct {
@@ -3849,7 +3849,7 @@ type DescribeClusterVersionsInput struct {
 	// Constraints: minimum 20, maximum 100.
 	MaxRecords *int64 `type:"integer"`
 
-	metadataDescribeClusterVersionsInput `json:"-", xml:"-"`
+	metadataDescribeClusterVersionsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeClusterVersionsInput struct {
@@ -3868,7 +3868,7 @@ type DescribeClusterVersionsOutput struct {
 	// records have been retrieved for the request.
 	Marker *string `type:"string"`
 
-	metadataDescribeClusterVersionsOutput `json:"-", xml:"-"`
+	metadataDescribeClusterVersionsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeClusterVersionsOutput struct {
@@ -3918,7 +3918,7 @@ type DescribeClustersInput struct {
 	// values associated with them.
 	TagValues []*string `locationNameList:"TagValue" type:"list"`
 
-	metadataDescribeClustersInput `json:"-", xml:"-"`
+	metadataDescribeClustersInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeClustersInput struct {
@@ -3937,7 +3937,7 @@ type DescribeClustersOutput struct {
 	// records have been retrieved for the request.
 	Marker *string `type:"string"`
 
-	metadataDescribeClustersOutput `json:"-", xml:"-"`
+	metadataDescribeClustersOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeClustersOutput struct {
@@ -3966,7 +3966,7 @@ type DescribeDefaultClusterParametersInput struct {
 	// The name of the cluster parameter group family.
 	ParameterGroupFamily *string `type:"string" required:"true"`
 
-	metadataDescribeDefaultClusterParametersInput `json:"-", xml:"-"`
+	metadataDescribeDefaultClusterParametersInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeDefaultClusterParametersInput struct {
@@ -3977,7 +3977,7 @@ type DescribeDefaultClusterParametersOutput struct {
 	// Describes the default cluster parameters for a parameter group family.
 	DefaultClusterParameters *DefaultClusterParameters `type:"structure"`
 
-	metadataDescribeDefaultClusterParametersOutput `json:"-", xml:"-"`
+	metadataDescribeDefaultClusterParametersOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeDefaultClusterParametersOutput struct {
@@ -3991,7 +3991,7 @@ type DescribeEventCategoriesInput struct {
 	//  Valid values: cluster, snapshot, parameter group, and security group.
 	SourceType *string `type:"string"`
 
-	metadataDescribeEventCategoriesInput `json:"-", xml:"-"`
+	metadataDescribeEventCategoriesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeEventCategoriesInput struct {
@@ -4002,7 +4002,7 @@ type DescribeEventCategoriesOutput struct {
 	// A list of event categories descriptions.
 	EventCategoriesMapList []*EventCategoriesMap `locationNameList:"EventCategoriesMap" type:"list"`
 
-	metadataDescribeEventCategoriesOutput `json:"-", xml:"-"`
+	metadataDescribeEventCategoriesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeEventCategoriesOutput struct {
@@ -4031,7 +4031,7 @@ type DescribeEventSubscriptionsInput struct {
 	// The name of the Amazon Redshift event notification subscription to be described.
 	SubscriptionName *string `type:"string"`
 
-	metadataDescribeEventSubscriptionsInput `json:"-", xml:"-"`
+	metadataDescribeEventSubscriptionsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeEventSubscriptionsInput struct {
@@ -4049,7 +4049,7 @@ type DescribeEventSubscriptionsOutput struct {
 	// records have been retrieved for the request.
 	Marker *string `type:"string"`
 
-	metadataDescribeEventSubscriptionsOutput `json:"-", xml:"-"`
+	metadataDescribeEventSubscriptionsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeEventSubscriptionsOutput struct {
@@ -4122,7 +4122,7 @@ type DescribeEventsInput struct {
 	// Example: 2009-07-08T18:00Z
 	StartTime *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataDescribeEventsInput `json:"-", xml:"-"`
+	metadataDescribeEventsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeEventsInput struct {
@@ -4141,7 +4141,7 @@ type DescribeEventsOutput struct {
 	// records have been retrieved for the request.
 	Marker *string `type:"string"`
 
-	metadataDescribeEventsOutput `json:"-", xml:"-"`
+	metadataDescribeEventsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeEventsOutput struct {
@@ -4188,7 +4188,7 @@ type DescribeHSMClientCertificatesInput struct {
 	// that have either or both of these tag values associated with them.
 	TagValues []*string `locationNameList:"TagValue" type:"list"`
 
-	metadataDescribeHSMClientCertificatesInput `json:"-", xml:"-"`
+	metadataDescribeHSMClientCertificatesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeHSMClientCertificatesInput struct {
@@ -4208,7 +4208,7 @@ type DescribeHSMClientCertificatesOutput struct {
 	// records have been retrieved for the request.
 	Marker *string `type:"string"`
 
-	metadataDescribeHSMClientCertificatesOutput `json:"-", xml:"-"`
+	metadataDescribeHSMClientCertificatesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeHSMClientCertificatesOutput struct {
@@ -4255,7 +4255,7 @@ type DescribeHSMConfigurationsInput struct {
 	// or both of these tag values associated with them.
 	TagValues []*string `locationNameList:"TagValue" type:"list"`
 
-	metadataDescribeHSMConfigurationsInput `json:"-", xml:"-"`
+	metadataDescribeHSMConfigurationsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeHSMConfigurationsInput struct {
@@ -4273,7 +4273,7 @@ type DescribeHSMConfigurationsOutput struct {
 	// records have been retrieved for the request.
 	Marker *string `type:"string"`
 
-	metadataDescribeHSMConfigurationsOutput `json:"-", xml:"-"`
+	metadataDescribeHSMConfigurationsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeHSMConfigurationsOutput struct {
@@ -4286,7 +4286,7 @@ type DescribeLoggingStatusInput struct {
 	// Example: examplecluster
 	ClusterIdentifier *string `type:"string" required:"true"`
 
-	metadataDescribeLoggingStatusInput `json:"-", xml:"-"`
+	metadataDescribeLoggingStatusInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeLoggingStatusInput struct {
@@ -4324,7 +4324,7 @@ type DescribeOrderableClusterOptionsInput struct {
 	// offerings matching the specified node type.
 	NodeType *string `type:"string"`
 
-	metadataDescribeOrderableClusterOptionsInput `json:"-", xml:"-"`
+	metadataDescribeOrderableClusterOptionsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeOrderableClusterOptionsInput struct {
@@ -4344,7 +4344,7 @@ type DescribeOrderableClusterOptionsOutput struct {
 	// options for the Cluster.
 	OrderableClusterOptions []*OrderableClusterOption `locationNameList:"OrderableClusterOption" type:"list"`
 
-	metadataDescribeOrderableClusterOptionsOutput `json:"-", xml:"-"`
+	metadataDescribeOrderableClusterOptionsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeOrderableClusterOptionsOutput struct {
@@ -4374,7 +4374,7 @@ type DescribeReservedNodeOfferingsInput struct {
 	// The unique identifier for the offering.
 	ReservedNodeOfferingID *string `locationName:"ReservedNodeOfferingId" type:"string"`
 
-	metadataDescribeReservedNodeOfferingsInput `json:"-", xml:"-"`
+	metadataDescribeReservedNodeOfferingsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeReservedNodeOfferingsInput struct {
@@ -4393,7 +4393,7 @@ type DescribeReservedNodeOfferingsOutput struct {
 	// A list of reserved node offerings.
 	ReservedNodeOfferings []*ReservedNodeOffering `locationNameList:"ReservedNodeOffering" type:"list"`
 
-	metadataDescribeReservedNodeOfferingsOutput `json:"-", xml:"-"`
+	metadataDescribeReservedNodeOfferingsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeReservedNodeOfferingsOutput struct {
@@ -4421,7 +4421,7 @@ type DescribeReservedNodesInput struct {
 	// Identifier for the node reservation.
 	ReservedNodeID *string `locationName:"ReservedNodeId" type:"string"`
 
-	metadataDescribeReservedNodesInput `json:"-", xml:"-"`
+	metadataDescribeReservedNodesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeReservedNodesInput struct {
@@ -4440,7 +4440,7 @@ type DescribeReservedNodesOutput struct {
 	// The list of reserved nodes.
 	ReservedNodes []*ReservedNode `locationNameList:"ReservedNode" type:"list"`
 
-	metadataDescribeReservedNodesOutput `json:"-", xml:"-"`
+	metadataDescribeReservedNodesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeReservedNodesOutput struct {
@@ -4455,7 +4455,7 @@ type DescribeResizeInput struct {
 	// are returned.
 	ClusterIdentifier *string `type:"string" required:"true"`
 
-	metadataDescribeResizeInput `json:"-", xml:"-"`
+	metadataDescribeResizeInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeResizeInput struct {
@@ -4523,7 +4523,7 @@ type DescribeResizeOutput struct {
 	// resize operation began.
 	TotalResizeDataInMegaBytes *int64 `type:"long"`
 
-	metadataDescribeResizeOutput `json:"-", xml:"-"`
+	metadataDescribeResizeOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeResizeOutput struct {
@@ -4574,7 +4574,7 @@ type DescribeTagsInput struct {
 	// associated with them.
 	TagValues []*string `locationNameList:"TagValue" type:"list"`
 
-	metadataDescribeTagsInput `json:"-", xml:"-"`
+	metadataDescribeTagsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeTagsInput struct {
@@ -4593,7 +4593,7 @@ type DescribeTagsOutput struct {
 	// A list of tags with their associated resources.
 	TaggedResources []*TaggedResource `locationNameList:"TaggedResource" type:"list"`
 
-	metadataDescribeTagsOutput `json:"-", xml:"-"`
+	metadataDescribeTagsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeTagsOutput struct {
@@ -4606,7 +4606,7 @@ type DisableLoggingInput struct {
 	// Example: examplecluster
 	ClusterIdentifier *string `type:"string" required:"true"`
 
-	metadataDisableLoggingInput `json:"-", xml:"-"`
+	metadataDisableLoggingInput `json:"-" xml:"-"`
 }
 
 type metadataDisableLoggingInput struct {
@@ -4621,7 +4621,7 @@ type DisableSnapshotCopyInput struct {
 	// snapshot copy enabled.
 	ClusterIdentifier *string `type:"string" required:"true"`
 
-	metadataDisableSnapshotCopyInput `json:"-", xml:"-"`
+	metadataDisableSnapshotCopyInput `json:"-" xml:"-"`
 }
 
 type metadataDisableSnapshotCopyInput struct {
@@ -4632,7 +4632,7 @@ type DisableSnapshotCopyOutput struct {
 	// Describes a cluster.
 	Cluster *Cluster `type:"structure"`
 
-	metadataDisableSnapshotCopyOutput `json:"-", xml:"-"`
+	metadataDisableSnapshotCopyOutput `json:"-" xml:"-"`
 }
 
 type metadataDisableSnapshotCopyOutput struct {
@@ -4654,7 +4654,7 @@ type EC2SecurityGroup struct {
 	// The list of tags for the EC2 security group.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataEC2SecurityGroup `json:"-", xml:"-"`
+	metadataEC2SecurityGroup `json:"-" xml:"-"`
 }
 
 type metadataEC2SecurityGroup struct {
@@ -4669,7 +4669,7 @@ type ElasticIPStatus struct {
 	// Describes the status of the elastic IP (EIP) address.
 	Status *string `type:"string"`
 
-	metadataElasticIPStatus `json:"-", xml:"-"`
+	metadataElasticIPStatus `json:"-" xml:"-"`
 }
 
 type metadataElasticIPStatus struct {
@@ -4699,7 +4699,7 @@ type EnableLoggingInput struct {
 	// codes for invalid characters are:  x00 to x20 x22 x27 x5c x7f or larger
 	S3KeyPrefix *string `type:"string"`
 
-	metadataEnableLoggingInput `json:"-", xml:"-"`
+	metadataEnableLoggingInput `json:"-" xml:"-"`
 }
 
 type metadataEnableLoggingInput struct {
@@ -4728,7 +4728,7 @@ type EnableSnapshotCopyInput struct {
 	//  Constraints: Must be at least 1 and no more than 35.
 	RetentionPeriod *int64 `type:"integer"`
 
-	metadataEnableSnapshotCopyInput `json:"-", xml:"-"`
+	metadataEnableSnapshotCopyInput `json:"-" xml:"-"`
 }
 
 type metadataEnableSnapshotCopyInput struct {
@@ -4739,7 +4739,7 @@ type EnableSnapshotCopyOutput struct {
 	// Describes a cluster.
 	Cluster *Cluster `type:"structure"`
 
-	metadataEnableSnapshotCopyOutput `json:"-", xml:"-"`
+	metadataEnableSnapshotCopyOutput `json:"-" xml:"-"`
 }
 
 type metadataEnableSnapshotCopyOutput struct {
@@ -4754,7 +4754,7 @@ type Endpoint struct {
 	// The port that the database engine is listening on.
 	Port *int64 `type:"integer"`
 
-	metadataEndpoint `json:"-", xml:"-"`
+	metadataEndpoint `json:"-" xml:"-"`
 }
 
 type metadataEndpoint struct {
@@ -4786,7 +4786,7 @@ type Event struct {
 	// The source type for this event.
 	SourceType *string `type:"string"`
 
-	metadataEvent `json:"-", xml:"-"`
+	metadataEvent `json:"-" xml:"-"`
 }
 
 type metadataEvent struct {
@@ -4801,7 +4801,7 @@ type EventCategoriesMap struct {
 	// the returned categories belong to.
 	SourceType *string `type:"string"`
 
-	metadataEventCategoriesMap `json:"-", xml:"-"`
+	metadataEventCategoriesMap `json:"-" xml:"-"`
 }
 
 type metadataEventCategoriesMap struct {
@@ -4823,7 +4823,7 @@ type EventInfoMap struct {
 	// Values: ERROR, INFO
 	Severity *string `type:"string"`
 
-	metadataEventInfoMap `json:"-", xml:"-"`
+	metadataEventInfoMap `json:"-" xml:"-"`
 }
 
 type metadataEventInfoMap struct {
@@ -4882,7 +4882,7 @@ type EventSubscription struct {
 	// The list of tags for the event subscription.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataEventSubscription `json:"-", xml:"-"`
+	metadataEventSubscription `json:"-" xml:"-"`
 }
 
 type metadataEventSubscription struct {
@@ -4903,7 +4903,7 @@ type HSMClientCertificate struct {
 	// The list of tags for the HSM client certificate.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataHSMClientCertificate `json:"-", xml:"-"`
+	metadataHSMClientCertificate `json:"-" xml:"-"`
 }
 
 type metadataHSMClientCertificate struct {
@@ -4930,7 +4930,7 @@ type HSMConfiguration struct {
 	// The list of tags for the HSM configuration.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataHSMConfiguration `json:"-", xml:"-"`
+	metadataHSMConfiguration `json:"-" xml:"-"`
 }
 
 type metadataHSMConfiguration struct {
@@ -4952,7 +4952,7 @@ type HSMStatus struct {
 	// Values: active, applying
 	Status *string `type:"string"`
 
-	metadataHSMStatus `json:"-", xml:"-"`
+	metadataHSMStatus `json:"-" xml:"-"`
 }
 
 type metadataHSMStatus struct {
@@ -4970,7 +4970,7 @@ type IPRange struct {
 	// The list of tags for the IP range.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataIPRange `json:"-", xml:"-"`
+	metadataIPRange `json:"-" xml:"-"`
 }
 
 type metadataIPRange struct {
@@ -4997,7 +4997,7 @@ type LoggingStatus struct {
 	// The prefix applied to the log file names.
 	S3KeyPrefix *string `type:"string"`
 
-	metadataLoggingStatus `json:"-", xml:"-"`
+	metadataLoggingStatus `json:"-" xml:"-"`
 }
 
 type metadataLoggingStatus struct {
@@ -5159,7 +5159,7 @@ type ModifyClusterInput struct {
 	// the cluster.
 	VPCSecurityGroupIDs []*string `locationName:"VpcSecurityGroupIds" locationNameList:"VpcSecurityGroupId" type:"list"`
 
-	metadataModifyClusterInput `json:"-", xml:"-"`
+	metadataModifyClusterInput `json:"-" xml:"-"`
 }
 
 type metadataModifyClusterInput struct {
@@ -5170,7 +5170,7 @@ type ModifyClusterOutput struct {
 	// Describes a cluster.
 	Cluster *Cluster `type:"structure"`
 
-	metadataModifyClusterOutput `json:"-", xml:"-"`
+	metadataModifyClusterOutput `json:"-" xml:"-"`
 }
 
 type metadataModifyClusterOutput struct {
@@ -5191,7 +5191,7 @@ type ModifyClusterParameterGroupInput struct {
 	// name-value pairs in the wlm_json_configuration parameter.
 	Parameters []*Parameter `locationNameList:"Parameter" type:"list" required:"true"`
 
-	metadataModifyClusterParameterGroupInput `json:"-", xml:"-"`
+	metadataModifyClusterParameterGroupInput `json:"-" xml:"-"`
 }
 
 type metadataModifyClusterParameterGroupInput struct {
@@ -5209,7 +5209,7 @@ type ModifyClusterSubnetGroupInput struct {
 	// single request.
 	SubnetIDs []*string `locationName:"SubnetIds" locationNameList:"SubnetIdentifier" type:"list" required:"true"`
 
-	metadataModifyClusterSubnetGroupInput `json:"-", xml:"-"`
+	metadataModifyClusterSubnetGroupInput `json:"-" xml:"-"`
 }
 
 type metadataModifyClusterSubnetGroupInput struct {
@@ -5220,7 +5220,7 @@ type ModifyClusterSubnetGroupOutput struct {
 	// Describes a subnet group.
 	ClusterSubnetGroup *ClusterSubnetGroup `type:"structure"`
 
-	metadataModifyClusterSubnetGroupOutput `json:"-", xml:"-"`
+	metadataModifyClusterSubnetGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataModifyClusterSubnetGroupOutput struct {
@@ -5272,7 +5272,7 @@ type ModifyEventSubscriptionInput struct {
 	// The name of the modified Amazon Redshift event notification subscription.
 	SubscriptionName *string `type:"string" required:"true"`
 
-	metadataModifyEventSubscriptionInput `json:"-", xml:"-"`
+	metadataModifyEventSubscriptionInput `json:"-" xml:"-"`
 }
 
 type metadataModifyEventSubscriptionInput struct {
@@ -5282,7 +5282,7 @@ type metadataModifyEventSubscriptionInput struct {
 type ModifyEventSubscriptionOutput struct {
 	EventSubscription *EventSubscription `type:"structure"`
 
-	metadataModifyEventSubscriptionOutput `json:"-", xml:"-"`
+	metadataModifyEventSubscriptionOutput `json:"-" xml:"-"`
 }
 
 type metadataModifyEventSubscriptionOutput struct {
@@ -5308,7 +5308,7 @@ type ModifySnapshotCopyRetentionPeriodInput struct {
 	//  Constraints: Must be at least 1 and no more than 35.
 	RetentionPeriod *int64 `type:"integer" required:"true"`
 
-	metadataModifySnapshotCopyRetentionPeriodInput `json:"-", xml:"-"`
+	metadataModifySnapshotCopyRetentionPeriodInput `json:"-" xml:"-"`
 }
 
 type metadataModifySnapshotCopyRetentionPeriodInput struct {
@@ -5319,7 +5319,7 @@ type ModifySnapshotCopyRetentionPeriodOutput struct {
 	// Describes a cluster.
 	Cluster *Cluster `type:"structure"`
 
-	metadataModifySnapshotCopyRetentionPeriodOutput `json:"-", xml:"-"`
+	metadataModifySnapshotCopyRetentionPeriodOutput `json:"-" xml:"-"`
 }
 
 type metadataModifySnapshotCopyRetentionPeriodOutput struct {
@@ -5340,7 +5340,7 @@ type OrderableClusterOption struct {
 	// The node type for the orderable cluster.
 	NodeType *string `type:"string"`
 
-	metadataOrderableClusterOption `json:"-", xml:"-"`
+	metadataOrderableClusterOption `json:"-" xml:"-"`
 }
 
 type metadataOrderableClusterOption struct {
@@ -5374,7 +5374,7 @@ type Parameter struct {
 	// The source of the parameter value, such as "engine-default" or "user".
 	Source *string `type:"string"`
 
-	metadataParameter `json:"-", xml:"-"`
+	metadataParameter `json:"-" xml:"-"`
 }
 
 type metadataParameter struct {
@@ -5405,7 +5405,7 @@ type PendingModifiedValues struct {
 	// The pending or in-progress change of the number of nodes in the cluster.
 	NumberOfNodes *int64 `type:"integer"`
 
-	metadataPendingModifiedValues `json:"-", xml:"-"`
+	metadataPendingModifiedValues `json:"-" xml:"-"`
 }
 
 type metadataPendingModifiedValues struct {
@@ -5421,7 +5421,7 @@ type PurchaseReservedNodeOfferingInput struct {
 	// The unique identifier of the reserved node offering you want to purchase.
 	ReservedNodeOfferingID *string `locationName:"ReservedNodeOfferingId" type:"string" required:"true"`
 
-	metadataPurchaseReservedNodeOfferingInput `json:"-", xml:"-"`
+	metadataPurchaseReservedNodeOfferingInput `json:"-" xml:"-"`
 }
 
 type metadataPurchaseReservedNodeOfferingInput struct {
@@ -5432,7 +5432,7 @@ type PurchaseReservedNodeOfferingOutput struct {
 	// Describes a reserved node.
 	ReservedNode *ReservedNode `type:"structure"`
 
-	metadataPurchaseReservedNodeOfferingOutput `json:"-", xml:"-"`
+	metadataPurchaseReservedNodeOfferingOutput `json:"-" xml:"-"`
 }
 
 type metadataPurchaseReservedNodeOfferingOutput struct {
@@ -5443,7 +5443,7 @@ type RebootClusterInput struct {
 	// The cluster identifier.
 	ClusterIdentifier *string `type:"string" required:"true"`
 
-	metadataRebootClusterInput `json:"-", xml:"-"`
+	metadataRebootClusterInput `json:"-" xml:"-"`
 }
 
 type metadataRebootClusterInput struct {
@@ -5454,7 +5454,7 @@ type RebootClusterOutput struct {
 	// Describes a cluster.
 	Cluster *Cluster `type:"structure"`
 
-	metadataRebootClusterOutput `json:"-", xml:"-"`
+	metadataRebootClusterOutput `json:"-" xml:"-"`
 }
 
 type metadataRebootClusterOutput struct {
@@ -5470,7 +5470,7 @@ type RecurringCharge struct {
 	// The frequency at which the recurring charge amount is applied.
 	RecurringChargeFrequency *string `type:"string"`
 
-	metadataRecurringCharge `json:"-", xml:"-"`
+	metadataRecurringCharge `json:"-" xml:"-"`
 }
 
 type metadataRecurringCharge struct {
@@ -5524,7 +5524,7 @@ type ReservedNode struct {
 	// The hourly rate Amazon Redshift charge you for this reserved node.
 	UsagePrice *float64 `type:"double"`
 
-	metadataReservedNode `json:"-", xml:"-"`
+	metadataReservedNode `json:"-" xml:"-"`
 }
 
 type metadataReservedNode struct {
@@ -5562,7 +5562,7 @@ type ReservedNodeOffering struct {
 	// is running.
 	UsagePrice *float64 `type:"double"`
 
-	metadataReservedNodeOffering `json:"-", xml:"-"`
+	metadataReservedNodeOffering `json:"-" xml:"-"`
 }
 
 type metadataReservedNodeOffering struct {
@@ -5585,7 +5585,7 @@ type ResetClusterParameterGroupInput struct {
 	// Default: true
 	ResetAllParameters *bool `type:"boolean"`
 
-	metadataResetClusterParameterGroupInput `json:"-", xml:"-"`
+	metadataResetClusterParameterGroupInput `json:"-" xml:"-"`
 }
 
 type metadataResetClusterParameterGroupInput struct {
@@ -5715,7 +5715,7 @@ type RestoreFromClusterSnapshotInput struct {
 	//  VPC security groups only apply to clusters in VPCs.
 	VPCSecurityGroupIDs []*string `locationName:"VpcSecurityGroupIds" locationNameList:"VpcSecurityGroupId" type:"list"`
 
-	metadataRestoreFromClusterSnapshotInput `json:"-", xml:"-"`
+	metadataRestoreFromClusterSnapshotInput `json:"-" xml:"-"`
 }
 
 type metadataRestoreFromClusterSnapshotInput struct {
@@ -5726,7 +5726,7 @@ type RestoreFromClusterSnapshotOutput struct {
 	// Describes a cluster.
 	Cluster *Cluster `type:"structure"`
 
-	metadataRestoreFromClusterSnapshotOutput `json:"-", xml:"-"`
+	metadataRestoreFromClusterSnapshotOutput `json:"-" xml:"-"`
 }
 
 type metadataRestoreFromClusterSnapshotOutput struct {
@@ -5758,7 +5758,7 @@ type RestoreStatus struct {
 	// or failed.
 	Status *string `type:"string"`
 
-	metadataRestoreStatus `json:"-", xml:"-"`
+	metadataRestoreStatus `json:"-" xml:"-"`
 }
 
 type metadataRestoreStatus struct {
@@ -5788,7 +5788,7 @@ type RevokeClusterSecurityGroupIngressInput struct {
 	// Example: 111122223333
 	EC2SecurityGroupOwnerID *string `locationName:"EC2SecurityGroupOwnerId" type:"string"`
 
-	metadataRevokeClusterSecurityGroupIngressInput `json:"-", xml:"-"`
+	metadataRevokeClusterSecurityGroupIngressInput `json:"-" xml:"-"`
 }
 
 type metadataRevokeClusterSecurityGroupIngressInput struct {
@@ -5799,7 +5799,7 @@ type RevokeClusterSecurityGroupIngressOutput struct {
 	// Describes a security group.
 	ClusterSecurityGroup *ClusterSecurityGroup `type:"structure"`
 
-	metadataRevokeClusterSecurityGroupIngressOutput `json:"-", xml:"-"`
+	metadataRevokeClusterSecurityGroupIngressOutput `json:"-" xml:"-"`
 }
 
 type metadataRevokeClusterSecurityGroupIngressOutput struct {
@@ -5819,7 +5819,7 @@ type RevokeSnapshotAccessInput struct {
 	// The identifier of the snapshot that the account can no longer access.
 	SnapshotIdentifier *string `type:"string" required:"true"`
 
-	metadataRevokeSnapshotAccessInput `json:"-", xml:"-"`
+	metadataRevokeSnapshotAccessInput `json:"-" xml:"-"`
 }
 
 type metadataRevokeSnapshotAccessInput struct {
@@ -5830,7 +5830,7 @@ type RevokeSnapshotAccessOutput struct {
 	// Describes a snapshot.
 	Snapshot *Snapshot `type:"structure"`
 
-	metadataRevokeSnapshotAccessOutput `json:"-", xml:"-"`
+	metadataRevokeSnapshotAccessOutput `json:"-" xml:"-"`
 }
 
 type metadataRevokeSnapshotAccessOutput struct {
@@ -5844,7 +5844,7 @@ type RotateEncryptionKeyInput struct {
 	//  Constraints: Must be the name of valid cluster that has encryption enabled.
 	ClusterIdentifier *string `type:"string" required:"true"`
 
-	metadataRotateEncryptionKeyInput `json:"-", xml:"-"`
+	metadataRotateEncryptionKeyInput `json:"-" xml:"-"`
 }
 
 type metadataRotateEncryptionKeyInput struct {
@@ -5855,7 +5855,7 @@ type RotateEncryptionKeyOutput struct {
 	// Describes a cluster.
 	Cluster *Cluster `type:"structure"`
 
-	metadataRotateEncryptionKeyOutput `json:"-", xml:"-"`
+	metadataRotateEncryptionKeyOutput `json:"-" xml:"-"`
 }
 
 type metadataRotateEncryptionKeyOutput struct {
@@ -5961,7 +5961,7 @@ type Snapshot struct {
 	// VPC. Otherwise, this field is not in the output.
 	VPCID *string `locationName:"VpcId" type:"string"`
 
-	metadataSnapshot `json:"-", xml:"-"`
+	metadataSnapshot `json:"-" xml:"-"`
 }
 
 type metadataSnapshot struct {
@@ -5979,7 +5979,7 @@ type Subnet struct {
 	// The status of the subnet.
 	SubnetStatus *string `type:"string"`
 
-	metadataSubnet `json:"-", xml:"-"`
+	metadataSubnet `json:"-" xml:"-"`
 }
 
 type metadataSubnet struct {
@@ -5994,7 +5994,7 @@ type Tag struct {
 	// The value for the resource tag.
 	Value *string `type:"string"`
 
-	metadataTag `json:"-", xml:"-"`
+	metadataTag `json:"-" xml:"-"`
 }
 
 type metadataTag struct {
@@ -6019,7 +6019,7 @@ type TaggedResource struct {
 	// The tag for the resource.
 	Tag *Tag `type:"structure"`
 
-	metadataTaggedResource `json:"-", xml:"-"`
+	metadataTaggedResource `json:"-" xml:"-"`
 }
 
 type metadataTaggedResource struct {
@@ -6032,7 +6032,7 @@ type VPCSecurityGroupMembership struct {
 
 	VPCSecurityGroupID *string `locationName:"VpcSecurityGroupId" type:"string"`
 
-	metadataVPCSecurityGroupMembership `json:"-", xml:"-"`
+	metadataVPCSecurityGroupMembership `json:"-" xml:"-"`
 }
 
 type metadataVPCSecurityGroupMembership struct {

--- a/service/route53/api.go
+++ b/service/route53/api.go
@@ -1261,7 +1261,7 @@ type AliasTarget struct {
 	// .
 	HostedZoneID *string `locationName:"HostedZoneId" type:"string" required:"true"`
 
-	metadataAliasTarget `json:"-", xml:"-"`
+	metadataAliasTarget `json:"-" xml:"-"`
 }
 
 type metadataAliasTarget struct {
@@ -1283,7 +1283,7 @@ type AssociateVPCWithHostedZoneInput struct {
 	// The VPC that you want your hosted zone to be associated with.
 	VPC *VPC `type:"structure" required:"true"`
 
-	metadataAssociateVPCWithHostedZoneInput `json:"-", xml:"-"`
+	metadataAssociateVPCWithHostedZoneInput `json:"-" xml:"-"`
 }
 
 type metadataAssociateVPCWithHostedZoneInput struct {
@@ -1296,7 +1296,7 @@ type AssociateVPCWithHostedZoneOutput struct {
 	// your AssociateVPCWithHostedZoneRequest.
 	ChangeInfo *ChangeInfo `type:"structure" required:"true"`
 
-	metadataAssociateVPCWithHostedZoneOutput `json:"-", xml:"-"`
+	metadataAssociateVPCWithHostedZoneOutput `json:"-" xml:"-"`
 }
 
 type metadataAssociateVPCWithHostedZoneOutput struct {
@@ -1314,7 +1314,7 @@ type Change struct {
 	// Information about the resource record set to create or delete.
 	ResourceRecordSet *ResourceRecordSet `type:"structure" required:"true"`
 
-	metadataChange `json:"-", xml:"-"`
+	metadataChange `json:"-" xml:"-"`
 }
 
 type metadataChange struct {
@@ -1331,7 +1331,7 @@ type ChangeBatch struct {
 	// Optional: Any comments you want to include about a change batch request.
 	Comment *string `type:"string"`
 
-	metadataChangeBatch `json:"-", xml:"-"`
+	metadataChangeBatch `json:"-" xml:"-"`
 }
 
 type metadataChangeBatch struct {
@@ -1367,7 +1367,7 @@ type ChangeInfo struct {
 	// Time (UTC), which is synonymous with Greenwich Mean Time in this context.
 	SubmittedAt *time.Time `type:"timestamp" timestampFormat:"iso8601" required:"true"`
 
-	metadataChangeInfo `json:"-", xml:"-"`
+	metadataChangeInfo `json:"-" xml:"-"`
 }
 
 type metadataChangeInfo struct {
@@ -1383,7 +1383,7 @@ type ChangeResourceRecordSetsInput struct {
 	// want to change.
 	HostedZoneID *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
-	metadataChangeResourceRecordSetsInput `json:"-", xml:"-"`
+	metadataChangeResourceRecordSetsInput `json:"-" xml:"-"`
 }
 
 type metadataChangeResourceRecordSetsInput struct {
@@ -1399,7 +1399,7 @@ type ChangeResourceRecordSetsOutput struct {
 	// to get detailed information about the change.
 	ChangeInfo *ChangeInfo `type:"structure" required:"true"`
 
-	metadataChangeResourceRecordSetsOutput `json:"-", xml:"-"`
+	metadataChangeResourceRecordSetsOutput `json:"-" xml:"-"`
 }
 
 type metadataChangeResourceRecordSetsOutput struct {
@@ -1426,7 +1426,7 @@ type ChangeTagsForResourceInput struct {
 	// - The resource type for hosted zones is hostedzone.
 	ResourceType *string `location:"uri" locationName:"ResourceType" type:"string" required:"true"`
 
-	metadataChangeTagsForResourceInput `json:"-", xml:"-"`
+	metadataChangeTagsForResourceInput `json:"-" xml:"-"`
 }
 
 type metadataChangeTagsForResourceInput struct {
@@ -1435,7 +1435,7 @@ type metadataChangeTagsForResourceInput struct {
 
 // Empty response for the request.
 type ChangeTagsForResourceOutput struct {
-	metadataChangeTagsForResourceOutput `json:"-", xml:"-"`
+	metadataChangeTagsForResourceOutput `json:"-" xml:"-"`
 }
 
 type metadataChangeTagsForResourceOutput struct {
@@ -1458,7 +1458,7 @@ type CreateHealthCheckInput struct {
 	// A complex type that contains health check configuration.
 	HealthCheckConfig *HealthCheckConfig `type:"structure" required:"true"`
 
-	metadataCreateHealthCheckInput `json:"-", xml:"-"`
+	metadataCreateHealthCheckInput `json:"-" xml:"-"`
 }
 
 type metadataCreateHealthCheckInput struct {
@@ -1473,7 +1473,7 @@ type CreateHealthCheckOutput struct {
 	// The unique URL representing the new health check.
 	Location *string `location:"header" locationName:"Location" type:"string" required:"true"`
 
-	metadataCreateHealthCheckOutput `json:"-", xml:"-"`
+	metadataCreateHealthCheckOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateHealthCheckOutput struct {
@@ -1515,7 +1515,7 @@ type CreateHostedZoneInput struct {
 	// than the given VPC.
 	VPC *VPC `type:"structure"`
 
-	metadataCreateHostedZoneInput `json:"-", xml:"-"`
+	metadataCreateHostedZoneInput `json:"-" xml:"-"`
 }
 
 type metadataCreateHostedZoneInput struct {
@@ -1540,7 +1540,7 @@ type CreateHostedZoneOutput struct {
 
 	VPC *VPC `type:"structure"`
 
-	metadataCreateHostedZoneOutput `json:"-", xml:"-"`
+	metadataCreateHostedZoneOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateHostedZoneOutput struct {
@@ -1562,7 +1562,7 @@ type CreateReusableDelegationSetInput struct {
 	// It is an optional parameter.
 	HostedZoneID *string `locationName:"HostedZoneId" type:"string"`
 
-	metadataCreateReusableDelegationSetInput `json:"-", xml:"-"`
+	metadataCreateReusableDelegationSetInput `json:"-" xml:"-"`
 }
 
 type metadataCreateReusableDelegationSetInput struct {
@@ -1576,7 +1576,7 @@ type CreateReusableDelegationSetOutput struct {
 	// The unique URL representing the new reusbale delegation set.
 	Location *string `location:"header" locationName:"Location" type:"string" required:"true"`
 
-	metadataCreateReusableDelegationSetOutput `json:"-", xml:"-"`
+	metadataCreateReusableDelegationSetOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateReusableDelegationSetOutput struct {
@@ -1594,7 +1594,7 @@ type DelegationSet struct {
 	// to your domain for each NameServer that is assigned to your hosted zone.
 	NameServers []*string `locationNameList:"NameServer" type:"list" required:"true"`
 
-	metadataDelegationSet `json:"-", xml:"-"`
+	metadataDelegationSet `json:"-" xml:"-"`
 }
 
 type metadataDelegationSet struct {
@@ -1606,7 +1606,7 @@ type DeleteHealthCheckInput struct {
 	// The ID of the health check to delete.
 	HealthCheckID *string `location:"uri" locationName:"HealthCheckId" type:"string" required:"true"`
 
-	metadataDeleteHealthCheckInput `json:"-", xml:"-"`
+	metadataDeleteHealthCheckInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteHealthCheckInput struct {
@@ -1615,7 +1615,7 @@ type metadataDeleteHealthCheckInput struct {
 
 // Empty response for the request.
 type DeleteHealthCheckOutput struct {
-	metadataDeleteHealthCheckOutput `json:"-", xml:"-"`
+	metadataDeleteHealthCheckOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteHealthCheckOutput struct {
@@ -1628,7 +1628,7 @@ type DeleteHostedZoneInput struct {
 	// The ID of the hosted zone you want to delete.
 	ID *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
-	metadataDeleteHostedZoneInput `json:"-", xml:"-"`
+	metadataDeleteHostedZoneInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteHostedZoneInput struct {
@@ -1641,7 +1641,7 @@ type DeleteHostedZoneOutput struct {
 	// your delete request.
 	ChangeInfo *ChangeInfo `type:"structure" required:"true"`
 
-	metadataDeleteHostedZoneOutput `json:"-", xml:"-"`
+	metadataDeleteHostedZoneOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteHostedZoneOutput struct {
@@ -1653,7 +1653,7 @@ type DeleteReusableDelegationSetInput struct {
 	// The ID of the reusable delegation set you want to delete.
 	ID *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
-	metadataDeleteReusableDelegationSetInput `json:"-", xml:"-"`
+	metadataDeleteReusableDelegationSetInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteReusableDelegationSetInput struct {
@@ -1662,7 +1662,7 @@ type metadataDeleteReusableDelegationSetInput struct {
 
 // Empty response for the request.
 type DeleteReusableDelegationSetOutput struct {
-	metadataDeleteReusableDelegationSetOutput `json:"-", xml:"-"`
+	metadataDeleteReusableDelegationSetOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteReusableDelegationSetOutput struct {
@@ -1683,7 +1683,7 @@ type DisassociateVPCFromHostedZoneInput struct {
 	// The VPC that you want your hosted zone to be disassociated from.
 	VPC *VPC `type:"structure" required:"true"`
 
-	metadataDisassociateVPCFromHostedZoneInput `json:"-", xml:"-"`
+	metadataDisassociateVPCFromHostedZoneInput `json:"-" xml:"-"`
 }
 
 type metadataDisassociateVPCFromHostedZoneInput struct {
@@ -1696,7 +1696,7 @@ type DisassociateVPCFromHostedZoneOutput struct {
 	// your DisassociateVPCFromHostedZoneRequest.
 	ChangeInfo *ChangeInfo `type:"structure" required:"true"`
 
-	metadataDisassociateVPCFromHostedZoneOutput `json:"-", xml:"-"`
+	metadataDisassociateVPCFromHostedZoneOutput `json:"-" xml:"-"`
 }
 
 type metadataDisassociateVPCFromHostedZoneOutput struct {
@@ -1728,7 +1728,7 @@ type GeoLocation struct {
 	// error.
 	SubdivisionCode *string `type:"string"`
 
-	metadataGeoLocation `json:"-", xml:"-"`
+	metadataGeoLocation `json:"-" xml:"-"`
 }
 
 type metadataGeoLocation struct {
@@ -1764,7 +1764,7 @@ type GeoLocationDetails struct {
 	// is also present.
 	SubdivisionName *string `type:"string"`
 
-	metadataGeoLocationDetails `json:"-", xml:"-"`
+	metadataGeoLocationDetails `json:"-" xml:"-"`
 }
 
 type metadataGeoLocationDetails struct {
@@ -1778,7 +1778,7 @@ type GetChangeInput struct {
 	// the request.
 	ID *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
-	metadataGetChangeInput `json:"-", xml:"-"`
+	metadataGetChangeInput `json:"-" xml:"-"`
 }
 
 type metadataGetChangeInput struct {
@@ -1792,7 +1792,7 @@ type GetChangeOutput struct {
 	// time of the request.
 	ChangeInfo *ChangeInfo `type:"structure" required:"true"`
 
-	metadataGetChangeOutput `json:"-", xml:"-"`
+	metadataGetChangeOutput `json:"-" xml:"-"`
 }
 
 type metadataGetChangeOutput struct {
@@ -1801,7 +1801,7 @@ type metadataGetChangeOutput struct {
 
 // Empty request.
 type GetCheckerIPRangesInput struct {
-	metadataGetCheckerIPRangesInput `json:"-", xml:"-"`
+	metadataGetCheckerIPRangesInput `json:"-" xml:"-"`
 }
 
 type metadataGetCheckerIPRangesInput struct {
@@ -1814,7 +1814,7 @@ type GetCheckerIPRangesOutput struct {
 	// Amazon Route 53 health checkers.
 	CheckerIPRanges []*string `locationName:"CheckerIpRanges" type:"list" required:"true"`
 
-	metadataGetCheckerIPRangesOutput `json:"-", xml:"-"`
+	metadataGetCheckerIPRangesOutput `json:"-" xml:"-"`
 }
 
 type metadataGetCheckerIPRangesOutput struct {
@@ -1846,7 +1846,7 @@ type GetGeoLocationInput struct {
 	// error.
 	SubdivisionCode *string `location:"querystring" locationName:"subdivisioncode" type:"string"`
 
-	metadataGetGeoLocationInput `json:"-", xml:"-"`
+	metadataGetGeoLocationInput `json:"-" xml:"-"`
 }
 
 type metadataGetGeoLocationInput struct {
@@ -1858,7 +1858,7 @@ type GetGeoLocationOutput struct {
 	// A complex type that contains the information about the specified geo location.
 	GeoLocationDetails *GeoLocationDetails `type:"structure" required:"true"`
 
-	metadataGetGeoLocationOutput `json:"-", xml:"-"`
+	metadataGetGeoLocationOutput `json:"-" xml:"-"`
 }
 
 type metadataGetGeoLocationOutput struct {
@@ -1868,7 +1868,7 @@ type metadataGetGeoLocationOutput struct {
 // To retrieve a count of all your health checks, send a GET request to the
 // 2013-04-01/healthcheckcount resource.
 type GetHealthCheckCountInput struct {
-	metadataGetHealthCheckCountInput `json:"-", xml:"-"`
+	metadataGetHealthCheckCountInput `json:"-" xml:"-"`
 }
 
 type metadataGetHealthCheckCountInput struct {
@@ -1881,7 +1881,7 @@ type GetHealthCheckCountOutput struct {
 	// The number of health checks associated with the current AWS account.
 	HealthCheckCount *int64 `type:"long" required:"true"`
 
-	metadataGetHealthCheckCountOutput `json:"-", xml:"-"`
+	metadataGetHealthCheckCountOutput `json:"-" xml:"-"`
 }
 
 type metadataGetHealthCheckCountOutput struct {
@@ -1894,7 +1894,7 @@ type GetHealthCheckInput struct {
 	// The ID of the health check to retrieve.
 	HealthCheckID *string `location:"uri" locationName:"HealthCheckId" type:"string" required:"true"`
 
-	metadataGetHealthCheckInput `json:"-", xml:"-"`
+	metadataGetHealthCheckInput `json:"-" xml:"-"`
 }
 
 type metadataGetHealthCheckInput struct {
@@ -1908,7 +1908,7 @@ type GetHealthCheckLastFailureReasonInput struct {
 	// the most recent failure.
 	HealthCheckID *string `location:"uri" locationName:"HealthCheckId" type:"string" required:"true"`
 
-	metadataGetHealthCheckLastFailureReasonInput `json:"-", xml:"-"`
+	metadataGetHealthCheckLastFailureReasonInput `json:"-" xml:"-"`
 }
 
 type metadataGetHealthCheckLastFailureReasonInput struct {
@@ -1922,7 +1922,7 @@ type GetHealthCheckLastFailureReasonOutput struct {
 	// health checker.
 	HealthCheckObservations []*HealthCheckObservation `locationNameList:"HealthCheckObservation" type:"list" required:"true"`
 
-	metadataGetHealthCheckLastFailureReasonOutput `json:"-", xml:"-"`
+	metadataGetHealthCheckLastFailureReasonOutput `json:"-" xml:"-"`
 }
 
 type metadataGetHealthCheckLastFailureReasonOutput struct {
@@ -1934,7 +1934,7 @@ type GetHealthCheckOutput struct {
 	// A complex type that contains the information about the specified health check.
 	HealthCheck *HealthCheck `type:"structure" required:"true"`
 
-	metadataGetHealthCheckOutput `json:"-", xml:"-"`
+	metadataGetHealthCheckOutput `json:"-" xml:"-"`
 }
 
 type metadataGetHealthCheckOutput struct {
@@ -1948,7 +1948,7 @@ type GetHealthCheckStatusInput struct {
 	// status.
 	HealthCheckID *string `location:"uri" locationName:"HealthCheckId" type:"string" required:"true"`
 
-	metadataGetHealthCheckStatusInput `json:"-", xml:"-"`
+	metadataGetHealthCheckStatusInput `json:"-" xml:"-"`
 }
 
 type metadataGetHealthCheckStatusInput struct {
@@ -1962,7 +1962,7 @@ type GetHealthCheckStatusOutput struct {
 	// health checker.
 	HealthCheckObservations []*HealthCheckObservation `locationNameList:"HealthCheckObservation" type:"list" required:"true"`
 
-	metadataGetHealthCheckStatusOutput `json:"-", xml:"-"`
+	metadataGetHealthCheckStatusOutput `json:"-" xml:"-"`
 }
 
 type metadataGetHealthCheckStatusOutput struct {
@@ -1972,7 +1972,7 @@ type metadataGetHealthCheckStatusOutput struct {
 // To retrieve a count of all your hosted zones, send a GET request to the 2013-04-01/hostedzonecount
 // resource.
 type GetHostedZoneCountInput struct {
-	metadataGetHostedZoneCountInput `json:"-", xml:"-"`
+	metadataGetHostedZoneCountInput `json:"-" xml:"-"`
 }
 
 type metadataGetHostedZoneCountInput struct {
@@ -1985,7 +1985,7 @@ type GetHostedZoneCountOutput struct {
 	// The number of hosted zones associated with the current AWS account.
 	HostedZoneCount *int64 `type:"long" required:"true"`
 
-	metadataGetHostedZoneCountOutput `json:"-", xml:"-"`
+	metadataGetHostedZoneCountOutput `json:"-" xml:"-"`
 }
 
 type metadataGetHostedZoneCountOutput struct {
@@ -1998,7 +1998,7 @@ type GetHostedZoneInput struct {
 	// in the delegation set.
 	ID *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
-	metadataGetHostedZoneInput `json:"-", xml:"-"`
+	metadataGetHostedZoneInput `json:"-" xml:"-"`
 }
 
 type metadataGetHostedZoneInput struct {
@@ -2018,7 +2018,7 @@ type GetHostedZoneOutput struct {
 	// hosted zone.
 	VPCs []*VPC `locationNameList:"VPC" type:"list"`
 
-	metadataGetHostedZoneOutput `json:"-", xml:"-"`
+	metadataGetHostedZoneOutput `json:"-" xml:"-"`
 }
 
 type metadataGetHostedZoneOutput struct {
@@ -2031,7 +2031,7 @@ type GetReusableDelegationSetInput struct {
 	// the name server.
 	ID *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
-	metadataGetReusableDelegationSetInput `json:"-", xml:"-"`
+	metadataGetReusableDelegationSetInput `json:"-" xml:"-"`
 }
 
 type metadataGetReusableDelegationSetInput struct {
@@ -2045,7 +2045,7 @@ type GetReusableDelegationSetOutput struct {
 	// specified delegation set ID.
 	DelegationSet *DelegationSet `type:"structure" required:"true"`
 
-	metadataGetReusableDelegationSetOutput `json:"-", xml:"-"`
+	metadataGetReusableDelegationSetOutput `json:"-" xml:"-"`
 }
 
 type metadataGetReusableDelegationSetOutput struct {
@@ -2068,7 +2068,7 @@ type HealthCheck struct {
 	// The ID of the specified health check.
 	ID *string `locationName:"Id" type:"string" required:"true"`
 
-	metadataHealthCheck `json:"-", xml:"-"`
+	metadataHealthCheck `json:"-" xml:"-"`
 }
 
 type metadataHealthCheck struct {
@@ -2117,7 +2117,7 @@ type HealthCheckConfig struct {
 	// HTTP, HTTPS, HTTP_STR_MATCH, and HTTPS_STR_MATCH.
 	Type *string `type:"string" required:"true"`
 
-	metadataHealthCheckConfig `json:"-", xml:"-"`
+	metadataHealthCheckConfig `json:"-" xml:"-"`
 }
 
 type metadataHealthCheckConfig struct {
@@ -2134,7 +2134,7 @@ type HealthCheckObservation struct {
 	// the current observation.
 	StatusReport *StatusReport `type:"structure"`
 
-	metadataHealthCheckObservation `json:"-", xml:"-"`
+	metadataHealthCheckObservation `json:"-" xml:"-"`
 }
 
 type metadataHealthCheckObservation struct {
@@ -2165,7 +2165,7 @@ type HostedZone struct {
 	// Total number of resource record sets in the hosted zone.
 	ResourceRecordSetCount *int64 `type:"long"`
 
-	metadataHostedZone `json:"-", xml:"-"`
+	metadataHostedZone `json:"-" xml:"-"`
 }
 
 type metadataHostedZone struct {
@@ -2185,7 +2185,7 @@ type HostedZoneConfig struct {
 	// returned in the response; do not specify it in the request.
 	PrivateZone *bool `type:"boolean"`
 
-	metadataHostedZoneConfig `json:"-", xml:"-"`
+	metadataHostedZoneConfig `json:"-" xml:"-"`
 }
 
 type metadataHostedZoneConfig struct {
@@ -2221,7 +2221,7 @@ type ListGeoLocationsInput struct {
 	// error.
 	StartSubdivisionCode *string `location:"querystring" locationName:"startsubdivisioncode" type:"string"`
 
-	metadataListGeoLocationsInput `json:"-", xml:"-"`
+	metadataListGeoLocationsInput `json:"-" xml:"-"`
 }
 
 type metadataListGeoLocationsInput struct {
@@ -2263,7 +2263,7 @@ type ListGeoLocationsOutput struct {
 	// is true and the next geo location has a subdivision.
 	NextSubdivisionCode *string `type:"string"`
 
-	metadataListGeoLocationsOutput `json:"-", xml:"-"`
+	metadataListGeoLocationsOutput `json:"-" xml:"-"`
 }
 
 type metadataListGeoLocationsOutput struct {
@@ -2288,7 +2288,7 @@ type ListHealthChecksInput struct {
 	// Specify the maximum number of health checks to return per page of results.
 	MaxItems *string `location:"querystring" locationName:"maxitems" type:"string"`
 
-	metadataListHealthChecksInput `json:"-", xml:"-"`
+	metadataListHealthChecksInput `json:"-" xml:"-"`
 }
 
 type metadataListHealthChecksInput struct {
@@ -2325,7 +2325,7 @@ type ListHealthChecksOutput struct {
 	// the NextMarker element in the Marker element to get the next page of results.
 	NextMarker *string `type:"string"`
 
-	metadataListHealthChecksOutput `json:"-", xml:"-"`
+	metadataListHealthChecksOutput `json:"-" xml:"-"`
 }
 
 type metadataListHealthChecksOutput struct {
@@ -2361,7 +2361,7 @@ type ListHostedZonesByNameInput struct {
 	// Specify the maximum number of hosted zones to return per page of results.
 	MaxItems *string `location:"querystring" locationName:"maxitems" type:"string"`
 
-	metadataListHostedZonesByNameInput `json:"-", xml:"-"`
+	metadataListHostedZonesByNameInput `json:"-" xml:"-"`
 }
 
 type metadataListHostedZonesByNameInput struct {
@@ -2409,7 +2409,7 @@ type ListHostedZonesByNameOutput struct {
 	// in the ListHostedZonesByNameRequest$HostedZoneId element.
 	NextHostedZoneID *string `locationName:"NextHostedZoneId" type:"string"`
 
-	metadataListHostedZonesByNameOutput `json:"-", xml:"-"`
+	metadataListHostedZonesByNameOutput `json:"-" xml:"-"`
 }
 
 type metadataListHostedZonesByNameOutput struct {
@@ -2439,7 +2439,7 @@ type ListHostedZonesInput struct {
 	// Specify the maximum number of hosted zones to return per page of results.
 	MaxItems *string `location:"querystring" locationName:"maxitems" type:"string"`
 
-	metadataListHostedZonesInput `json:"-", xml:"-"`
+	metadataListHostedZonesInput `json:"-" xml:"-"`
 }
 
 type metadataListHostedZonesInput struct {
@@ -2476,7 +2476,7 @@ type ListHostedZonesOutput struct {
 	// the NextMarker element in the Marker element to get the next page of results.
 	NextMarker *string `type:"string"`
 
-	metadataListHostedZonesOutput `json:"-", xml:"-"`
+	metadataListHostedZonesOutput `json:"-" xml:"-"`
 }
 
 type metadataListHostedZonesOutput struct {
@@ -2516,7 +2516,7 @@ type ListResourceRecordSetsInput struct {
 	// error.
 	StartRecordType *string `location:"querystring" locationName:"type" type:"string"`
 
-	metadataListResourceRecordSetsInput `json:"-", xml:"-"`
+	metadataListResourceRecordSetsInput `json:"-" xml:"-"`
 }
 
 type metadataListResourceRecordSetsInput struct {
@@ -2557,7 +2557,7 @@ type ListResourceRecordSetsOutput struct {
 	// are returned by the request.
 	ResourceRecordSets []*ResourceRecordSet `locationNameList:"ResourceRecordSet" type:"list" required:"true"`
 
-	metadataListResourceRecordSetsOutput `json:"-", xml:"-"`
+	metadataListResourceRecordSetsOutput `json:"-" xml:"-"`
 }
 
 type metadataListResourceRecordSetsOutput struct {
@@ -2584,7 +2584,7 @@ type ListReusableDelegationSetsInput struct {
 	// of results.
 	MaxItems *string `location:"querystring" locationName:"maxitems" type:"string"`
 
-	metadataListReusableDelegationSetsInput `json:"-", xml:"-"`
+	metadataListReusableDelegationSetsInput `json:"-" xml:"-"`
 }
 
 type metadataListReusableDelegationSetsInput struct {
@@ -2623,7 +2623,7 @@ type ListReusableDelegationSetsOutput struct {
 	// of results.
 	NextMarker *string `type:"string"`
 
-	metadataListReusableDelegationSetsOutput `json:"-", xml:"-"`
+	metadataListReusableDelegationSetsOutput `json:"-" xml:"-"`
 }
 
 type metadataListReusableDelegationSetsOutput struct {
@@ -2643,7 +2643,7 @@ type ListTagsForResourceInput struct {
 	// - The resource type for hosted zones is hostedzone.
 	ResourceType *string `location:"uri" locationName:"ResourceType" type:"string" required:"true"`
 
-	metadataListTagsForResourceInput `json:"-", xml:"-"`
+	metadataListTagsForResourceInput `json:"-" xml:"-"`
 }
 
 type metadataListTagsForResourceInput struct {
@@ -2655,7 +2655,7 @@ type ListTagsForResourceOutput struct {
 	// A ResourceTagSet containing tags associated with the specified resource.
 	ResourceTagSet *ResourceTagSet `type:"structure" required:"true"`
 
-	metadataListTagsForResourceOutput `json:"-", xml:"-"`
+	metadataListTagsForResourceOutput `json:"-" xml:"-"`
 }
 
 type metadataListTagsForResourceOutput struct {
@@ -2676,7 +2676,7 @@ type ListTagsForResourcesInput struct {
 	// - The resource type for hosted zones is hostedzone.
 	ResourceType *string `location:"uri" locationName:"ResourceType" type:"string" required:"true"`
 
-	metadataListTagsForResourcesInput `json:"-", xml:"-"`
+	metadataListTagsForResourcesInput `json:"-" xml:"-"`
 }
 
 type metadataListTagsForResourcesInput struct {
@@ -2688,7 +2688,7 @@ type ListTagsForResourcesOutput struct {
 	// A list of ResourceTagSets containing tags associated with the specified resources.
 	ResourceTagSets []*ResourceTagSet `locationNameList:"ResourceTagSet" type:"list" required:"true"`
 
-	metadataListTagsForResourcesOutput `json:"-", xml:"-"`
+	metadataListTagsForResourcesOutput `json:"-" xml:"-"`
 }
 
 type metadataListTagsForResourcesOutput struct {
@@ -2701,7 +2701,7 @@ type ResourceRecord struct {
 	// The value of the Value element for the current resource record set.
 	Value *string `type:"string" required:"true"`
 
-	metadataResourceRecord `json:"-", xml:"-"`
+	metadataResourceRecord `json:"-" xml:"-"`
 }
 
 type metadataResourceRecord struct {
@@ -2772,7 +2772,7 @@ type ResourceRecordSet struct {
 	// location.
 	Weight *int64 `type:"long"`
 
-	metadataResourceRecordSet `json:"-", xml:"-"`
+	metadataResourceRecordSet `json:"-" xml:"-"`
 }
 
 type metadataResourceRecordSet struct {
@@ -2794,7 +2794,7 @@ type ResourceTagSet struct {
 	// The tags associated with the specified resource.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataResourceTagSet `json:"-", xml:"-"`
+	metadataResourceTagSet `json:"-" xml:"-"`
 }
 
 type metadataResourceTagSet struct {
@@ -2813,7 +2813,7 @@ type StatusReport struct {
 	// The observed health check status.
 	Status *string `type:"string"`
 
-	metadataStatusReport `json:"-", xml:"-"`
+	metadataStatusReport `json:"-" xml:"-"`
 }
 
 type metadataStatusReport struct {
@@ -2828,7 +2828,7 @@ type Tag struct {
 	// The value for a Tag.
 	Value *string `type:"string"`
 
-	metadataTag `json:"-", xml:"-"`
+	metadataTag `json:"-" xml:"-"`
 }
 
 type metadataTag struct {
@@ -2890,7 +2890,7 @@ type UpdateHealthCheckInput struct {
 	// Specify this value only if you want to change it.
 	SearchString *string `type:"string"`
 
-	metadataUpdateHealthCheckInput `json:"-", xml:"-"`
+	metadataUpdateHealthCheckInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateHealthCheckInput struct {
@@ -2901,7 +2901,7 @@ type UpdateHealthCheckOutput struct {
 	// A complex type that contains identifying information about the health check.
 	HealthCheck *HealthCheck `type:"structure" required:"true"`
 
-	metadataUpdateHealthCheckOutput `json:"-", xml:"-"`
+	metadataUpdateHealthCheckOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateHealthCheckOutput struct {
@@ -2917,7 +2917,7 @@ type UpdateHostedZoneCommentInput struct {
 	// The ID of the hosted zone you want to update.
 	ID *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
-	metadataUpdateHostedZoneCommentInput `json:"-", xml:"-"`
+	metadataUpdateHostedZoneCommentInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateHostedZoneCommentInput struct {
@@ -2930,7 +2930,7 @@ type UpdateHostedZoneCommentOutput struct {
 	// A complex type that contain information about the specified hosted zone.
 	HostedZone *HostedZone `type:"structure" required:"true"`
 
-	metadataUpdateHostedZoneCommentOutput `json:"-", xml:"-"`
+	metadataUpdateHostedZoneCommentOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateHostedZoneCommentOutput struct {
@@ -2943,7 +2943,7 @@ type VPC struct {
 
 	VPCRegion *string `type:"string"`
 
-	metadataVPC `json:"-", xml:"-"`
+	metadataVPC `json:"-" xml:"-"`
 }
 
 type metadataVPC struct {

--- a/service/route53domains/api.go
+++ b/service/route53domains/api.go
@@ -730,7 +730,7 @@ type CheckDomainAvailabilityInput struct {
 	// Reserved for future use.
 	IDNLangCode *string `locationName:"IdnLangCode" type:"string"`
 
-	metadataCheckDomainAvailabilityInput `json:"-", xml:"-"`
+	metadataCheckDomainAvailabilityInput `json:"-" xml:"-"`
 }
 
 type metadataCheckDomainAvailabilityInput struct {
@@ -755,7 +755,7 @@ type CheckDomainAvailabilityOutput struct {
 	// name has been reserved for another person or organization.
 	Availability *string `type:"string" required:"true"`
 
-	metadataCheckDomainAvailabilityOutput `json:"-", xml:"-"`
+	metadataCheckDomainAvailabilityOutput `json:"-" xml:"-"`
 }
 
 type metadataCheckDomainAvailabilityOutput struct {
@@ -954,7 +954,7 @@ type ContactDetail struct {
 	// Required: No
 	ZipCode *string `type:"string"`
 
-	metadataContactDetail `json:"-", xml:"-"`
+	metadataContactDetail `json:"-" xml:"-"`
 }
 
 type metadataContactDetail struct {
@@ -991,7 +991,7 @@ type DeleteTagsForDomainInput struct {
 	// '>
 	TagsToDelete []*string `type:"list" required:"true"`
 
-	metadataDeleteTagsForDomainInput `json:"-", xml:"-"`
+	metadataDeleteTagsForDomainInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteTagsForDomainInput struct {
@@ -999,7 +999,7 @@ type metadataDeleteTagsForDomainInput struct {
 }
 
 type DeleteTagsForDomainOutput struct {
-	metadataDeleteTagsForDomainOutput `json:"-", xml:"-"`
+	metadataDeleteTagsForDomainOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteTagsForDomainOutput struct {
@@ -1009,7 +1009,7 @@ type metadataDeleteTagsForDomainOutput struct {
 type DisableDomainAutoRenewInput struct {
 	DomainName *string `type:"string" required:"true"`
 
-	metadataDisableDomainAutoRenewInput `json:"-", xml:"-"`
+	metadataDisableDomainAutoRenewInput `json:"-" xml:"-"`
 }
 
 type metadataDisableDomainAutoRenewInput struct {
@@ -1017,7 +1017,7 @@ type metadataDisableDomainAutoRenewInput struct {
 }
 
 type DisableDomainAutoRenewOutput struct {
-	metadataDisableDomainAutoRenewOutput `json:"-", xml:"-"`
+	metadataDisableDomainAutoRenewOutput `json:"-" xml:"-"`
 }
 
 type metadataDisableDomainAutoRenewOutput struct {
@@ -1039,7 +1039,7 @@ type DisableDomainTransferLockInput struct {
 	// Required: Yes
 	DomainName *string `type:"string" required:"true"`
 
-	metadataDisableDomainTransferLockInput `json:"-", xml:"-"`
+	metadataDisableDomainTransferLockInput `json:"-" xml:"-"`
 }
 
 type metadataDisableDomainTransferLockInput struct {
@@ -1058,7 +1058,7 @@ type DisableDomainTransferLockOutput struct {
 	// Constraints: Maximum 255 characters.
 	OperationID *string `locationName:"OperationId" type:"string" required:"true"`
 
-	metadataDisableDomainTransferLockOutput `json:"-", xml:"-"`
+	metadataDisableDomainTransferLockOutput `json:"-" xml:"-"`
 }
 
 type metadataDisableDomainTransferLockOutput struct {
@@ -1091,7 +1091,7 @@ type DomainSummary struct {
 	// Valid values: True | False
 	TransferLock *bool `type:"boolean"`
 
-	metadataDomainSummary `json:"-", xml:"-"`
+	metadataDomainSummary `json:"-" xml:"-"`
 }
 
 type metadataDomainSummary struct {
@@ -1101,7 +1101,7 @@ type metadataDomainSummary struct {
 type EnableDomainAutoRenewInput struct {
 	DomainName *string `type:"string" required:"true"`
 
-	metadataEnableDomainAutoRenewInput `json:"-", xml:"-"`
+	metadataEnableDomainAutoRenewInput `json:"-" xml:"-"`
 }
 
 type metadataEnableDomainAutoRenewInput struct {
@@ -1109,7 +1109,7 @@ type metadataEnableDomainAutoRenewInput struct {
 }
 
 type EnableDomainAutoRenewOutput struct {
-	metadataEnableDomainAutoRenewOutput `json:"-", xml:"-"`
+	metadataEnableDomainAutoRenewOutput `json:"-" xml:"-"`
 }
 
 type metadataEnableDomainAutoRenewOutput struct {
@@ -1131,7 +1131,7 @@ type EnableDomainTransferLockInput struct {
 	// Required: Yes
 	DomainName *string `type:"string" required:"true"`
 
-	metadataEnableDomainTransferLockInput `json:"-", xml:"-"`
+	metadataEnableDomainTransferLockInput `json:"-" xml:"-"`
 }
 
 type metadataEnableDomainTransferLockInput struct {
@@ -1150,7 +1150,7 @@ type EnableDomainTransferLockOutput struct {
 	// Constraints: Maximum 255 characters.
 	OperationID *string `locationName:"OperationId" type:"string" required:"true"`
 
-	metadataEnableDomainTransferLockOutput `json:"-", xml:"-"`
+	metadataEnableDomainTransferLockOutput `json:"-" xml:"-"`
 }
 
 type metadataEnableDomainTransferLockOutput struct {
@@ -1190,7 +1190,7 @@ type ExtraParam struct {
 	// Required: Yes
 	Value *string `type:"string" required:"true"`
 
-	metadataExtraParam `json:"-", xml:"-"`
+	metadataExtraParam `json:"-" xml:"-"`
 }
 
 type metadataExtraParam struct {
@@ -1212,7 +1212,7 @@ type GetDomainDetailInput struct {
 	// Required: Yes
 	DomainName *string `type:"string" required:"true"`
 
-	metadataGetDomainDetailInput `json:"-", xml:"-"`
+	metadataGetDomainDetailInput `json:"-" xml:"-"`
 }
 
 type metadataGetDomainDetailInput struct {
@@ -1358,7 +1358,7 @@ type GetDomainDetailOutput struct {
 	// Type: String
 	WhoIsServer *string `type:"string"`
 
-	metadataGetDomainDetailOutput `json:"-", xml:"-"`
+	metadataGetDomainDetailOutput `json:"-" xml:"-"`
 }
 
 type metadataGetDomainDetailOutput struct {
@@ -1377,7 +1377,7 @@ type GetOperationDetailInput struct {
 	// Required: Yes
 	OperationID *string `locationName:"OperationId" type:"string" required:"true"`
 
-	metadataGetOperationDetailInput `json:"-", xml:"-"`
+	metadataGetOperationDetailInput `json:"-" xml:"-"`
 }
 
 type metadataGetOperationDetailInput struct {
@@ -1414,7 +1414,7 @@ type GetOperationDetailOutput struct {
 	// Type: String
 	Type *string `type:"string"`
 
-	metadataGetOperationDetailOutput `json:"-", xml:"-"`
+	metadataGetOperationDetailOutput `json:"-" xml:"-"`
 }
 
 type metadataGetOperationDetailOutput struct {
@@ -1450,7 +1450,7 @@ type ListDomainsInput struct {
 	// Required: No
 	MaxItems *int64 `type:"integer"`
 
-	metadataListDomainsInput `json:"-", xml:"-"`
+	metadataListDomainsInput `json:"-" xml:"-"`
 }
 
 type metadataListDomainsInput struct {
@@ -1475,7 +1475,7 @@ type ListDomainsOutput struct {
 	// Parent: Operations
 	NextPageMarker *string `type:"string"`
 
-	metadataListDomainsOutput `json:"-", xml:"-"`
+	metadataListDomainsOutput `json:"-" xml:"-"`
 }
 
 type metadataListDomainsOutput struct {
@@ -1509,7 +1509,7 @@ type ListOperationsInput struct {
 	// Required: No
 	MaxItems *int64 `type:"integer"`
 
-	metadataListOperationsInput `json:"-", xml:"-"`
+	metadataListOperationsInput `json:"-" xml:"-"`
 }
 
 type metadataListOperationsInput struct {
@@ -1534,7 +1534,7 @@ type ListOperationsOutput struct {
 	// Children: OperationId, Status, SubmittedDate, Type
 	Operations []*OperationSummary `type:"list" required:"true"`
 
-	metadataListOperationsOutput `json:"-", xml:"-"`
+	metadataListOperationsOutput `json:"-" xml:"-"`
 }
 
 type metadataListOperationsOutput struct {
@@ -1546,7 +1546,7 @@ type ListTagsForDomainInput struct {
 	// The domain for which you want to get a list of tags.
 	DomainName *string `type:"string" required:"true"`
 
-	metadataListTagsForDomainInput `json:"-", xml:"-"`
+	metadataListTagsForDomainInput `json:"-" xml:"-"`
 }
 
 type metadataListTagsForDomainInput struct {
@@ -1574,7 +1574,7 @@ type ListTagsForDomainOutput struct {
 	// Type: String
 	TagList []*Tag `type:"list" required:"true"`
 
-	metadataListTagsForDomainOutput `json:"-", xml:"-"`
+	metadataListTagsForDomainOutput `json:"-" xml:"-"`
 }
 
 type metadataListTagsForDomainOutput struct {
@@ -1604,7 +1604,7 @@ type Nameserver struct {
 	// Parent: Nameservers
 	Name *string `type:"string" required:"true"`
 
-	metadataNameserver `json:"-", xml:"-"`
+	metadataNameserver `json:"-" xml:"-"`
 }
 
 type metadataNameserver struct {
@@ -1634,7 +1634,7 @@ type OperationSummary struct {
 	// | UPDATE_NAMESERVER | CHANGE_PRIVACY_PROTECTION | DOMAIN_LOCK
 	Type *string `type:"string" required:"true"`
 
-	metadataOperationSummary `json:"-", xml:"-"`
+	metadataOperationSummary `json:"-" xml:"-"`
 }
 
 type metadataOperationSummary struct {
@@ -1758,7 +1758,7 @@ type RegisterDomainInput struct {
 	// Required: Yes
 	TechContact *ContactDetail `type:"structure" required:"true"`
 
-	metadataRegisterDomainInput `json:"-", xml:"-"`
+	metadataRegisterDomainInput `json:"-" xml:"-"`
 }
 
 type metadataRegisterDomainInput struct {
@@ -1777,7 +1777,7 @@ type RegisterDomainOutput struct {
 	// Constraints: Maximum 255 characters.
 	OperationID *string `locationName:"OperationId" type:"string" required:"true"`
 
-	metadataRegisterDomainOutput `json:"-", xml:"-"`
+	metadataRegisterDomainOutput `json:"-" xml:"-"`
 }
 
 type metadataRegisterDomainOutput struct {
@@ -1799,7 +1799,7 @@ type RetrieveDomainAuthCodeInput struct {
 	// Required: Yes
 	DomainName *string `type:"string" required:"true"`
 
-	metadataRetrieveDomainAuthCodeInput `json:"-", xml:"-"`
+	metadataRetrieveDomainAuthCodeInput `json:"-" xml:"-"`
 }
 
 type metadataRetrieveDomainAuthCodeInput struct {
@@ -1813,7 +1813,7 @@ type RetrieveDomainAuthCodeOutput struct {
 	// Type: String
 	AuthCode *string `type:"string" required:"true"`
 
-	metadataRetrieveDomainAuthCodeOutput `json:"-", xml:"-"`
+	metadataRetrieveDomainAuthCodeOutput `json:"-" xml:"-"`
 }
 
 type metadataRetrieveDomainAuthCodeOutput struct {
@@ -1848,7 +1848,7 @@ type Tag struct {
 	// Required: Yes
 	Value *string `type:"string"`
 
-	metadataTag `json:"-", xml:"-"`
+	metadataTag `json:"-" xml:"-"`
 }
 
 type metadataTag struct {
@@ -1989,7 +1989,7 @@ type TransferDomainInput struct {
 	// Required: Yes
 	TechContact *ContactDetail `type:"structure" required:"true"`
 
-	metadataTransferDomainInput `json:"-", xml:"-"`
+	metadataTransferDomainInput `json:"-" xml:"-"`
 }
 
 type metadataTransferDomainInput struct {
@@ -2008,7 +2008,7 @@ type TransferDomainOutput struct {
 	// Constraints: Maximum 255 characters.
 	OperationID *string `locationName:"OperationId" type:"string" required:"true"`
 
-	metadataTransferDomainOutput `json:"-", xml:"-"`
+	metadataTransferDomainOutput `json:"-" xml:"-"`
 }
 
 type metadataTransferDomainOutput struct {
@@ -2063,7 +2063,7 @@ type UpdateDomainContactInput struct {
 	// Required: Yes
 	TechContact *ContactDetail `type:"structure"`
 
-	metadataUpdateDomainContactInput `json:"-", xml:"-"`
+	metadataUpdateDomainContactInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateDomainContactInput struct {
@@ -2082,7 +2082,7 @@ type UpdateDomainContactOutput struct {
 	// Constraints: Maximum 255 characters.
 	OperationID *string `locationName:"OperationId" type:"string" required:"true"`
 
-	metadataUpdateDomainContactOutput `json:"-", xml:"-"`
+	metadataUpdateDomainContactOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateDomainContactOutput struct {
@@ -2146,7 +2146,7 @@ type UpdateDomainContactPrivacyInput struct {
 	// Required: No
 	TechPrivacy *bool `type:"boolean"`
 
-	metadataUpdateDomainContactPrivacyInput `json:"-", xml:"-"`
+	metadataUpdateDomainContactPrivacyInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateDomainContactPrivacyInput struct {
@@ -2165,7 +2165,7 @@ type UpdateDomainContactPrivacyOutput struct {
 	// Constraints: Maximum 255 characters.
 	OperationID *string `locationName:"OperationId" type:"string" required:"true"`
 
-	metadataUpdateDomainContactPrivacyOutput `json:"-", xml:"-"`
+	metadataUpdateDomainContactPrivacyOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateDomainContactPrivacyOutput struct {
@@ -2199,7 +2199,7 @@ type UpdateDomainNameserversInput struct {
 	// Required: Yes
 	Nameservers []*Nameserver `type:"list" required:"true"`
 
-	metadataUpdateDomainNameserversInput `json:"-", xml:"-"`
+	metadataUpdateDomainNameserversInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateDomainNameserversInput struct {
@@ -2218,7 +2218,7 @@ type UpdateDomainNameserversOutput struct {
 	// Constraints: Maximum 255 characters.
 	OperationID *string `locationName:"OperationId" type:"string" required:"true"`
 
-	metadataUpdateDomainNameserversOutput `json:"-", xml:"-"`
+	metadataUpdateDomainNameserversOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateDomainNameserversOutput struct {
@@ -2284,7 +2284,7 @@ type UpdateTagsForDomainInput struct {
 	// Required: Yes
 	TagsToUpdate []*Tag `type:"list"`
 
-	metadataUpdateTagsForDomainInput `json:"-", xml:"-"`
+	metadataUpdateTagsForDomainInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateTagsForDomainInput struct {
@@ -2292,7 +2292,7 @@ type metadataUpdateTagsForDomainInput struct {
 }
 
 type UpdateTagsForDomainOutput struct {
-	metadataUpdateTagsForDomainOutput `json:"-", xml:"-"`
+	metadataUpdateTagsForDomainOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateTagsForDomainOutput struct {

--- a/service/s3/api.go
+++ b/service/s3/api.go
@@ -1777,7 +1777,7 @@ type AbortMultipartUploadInput struct {
 
 	UploadID *string `location:"querystring" locationName:"uploadId" type:"string" required:"true"`
 
-	metadataAbortMultipartUploadInput `json:"-", xml:"-"`
+	metadataAbortMultipartUploadInput `json:"-" xml:"-"`
 }
 
 type metadataAbortMultipartUploadInput struct {
@@ -1789,7 +1789,7 @@ type AbortMultipartUploadOutput struct {
 	// request.
 	RequestCharged *string `location:"header" locationName:"x-amz-request-charged" type:"string"`
 
-	metadataAbortMultipartUploadOutput `json:"-", xml:"-"`
+	metadataAbortMultipartUploadOutput `json:"-" xml:"-"`
 }
 
 type metadataAbortMultipartUploadOutput struct {
@@ -1802,7 +1802,7 @@ type AccessControlPolicy struct {
 
 	Owner *Owner `type:"structure"`
 
-	metadataAccessControlPolicy `json:"-", xml:"-"`
+	metadataAccessControlPolicy `json:"-" xml:"-"`
 }
 
 type metadataAccessControlPolicy struct {
@@ -1816,7 +1816,7 @@ type Bucket struct {
 	// The name of the bucket.
 	Name *string `type:"string"`
 
-	metadataBucket `json:"-", xml:"-"`
+	metadataBucket `json:"-" xml:"-"`
 }
 
 type metadataBucket struct {
@@ -1826,7 +1826,7 @@ type metadataBucket struct {
 type BucketLoggingStatus struct {
 	LoggingEnabled *LoggingEnabled `type:"structure"`
 
-	metadataBucketLoggingStatus `json:"-", xml:"-"`
+	metadataBucketLoggingStatus `json:"-" xml:"-"`
 }
 
 type metadataBucketLoggingStatus struct {
@@ -1836,7 +1836,7 @@ type metadataBucketLoggingStatus struct {
 type CORSConfiguration struct {
 	CORSRules []*CORSRule `locationName:"CORSRule" type:"list" flattened:"true"`
 
-	metadataCORSConfiguration `json:"-", xml:"-"`
+	metadataCORSConfiguration `json:"-" xml:"-"`
 }
 
 type metadataCORSConfiguration struct {
@@ -1863,7 +1863,7 @@ type CORSRule struct {
 	// for the specified resource.
 	MaxAgeSeconds *int64 `type:"integer"`
 
-	metadataCORSRule `json:"-", xml:"-"`
+	metadataCORSRule `json:"-" xml:"-"`
 }
 
 type metadataCORSRule struct {
@@ -1881,7 +1881,7 @@ type CloudFunctionConfiguration struct {
 
 	InvocationRole *string `type:"string"`
 
-	metadataCloudFunctionConfiguration `json:"-", xml:"-"`
+	metadataCloudFunctionConfiguration `json:"-" xml:"-"`
 }
 
 type metadataCloudFunctionConfiguration struct {
@@ -1891,7 +1891,7 @@ type metadataCloudFunctionConfiguration struct {
 type CommonPrefix struct {
 	Prefix *string `type:"string"`
 
-	metadataCommonPrefix `json:"-", xml:"-"`
+	metadataCommonPrefix `json:"-" xml:"-"`
 }
 
 type metadataCommonPrefix struct {
@@ -1913,7 +1913,7 @@ type CompleteMultipartUploadInput struct {
 
 	UploadID *string `location:"querystring" locationName:"uploadId" type:"string" required:"true"`
 
-	metadataCompleteMultipartUploadInput `json:"-", xml:"-"`
+	metadataCompleteMultipartUploadInput `json:"-" xml:"-"`
 }
 
 type metadataCompleteMultipartUploadInput struct {
@@ -1949,7 +1949,7 @@ type CompleteMultipartUploadOutput struct {
 	// Version of the object.
 	VersionID *string `location:"header" locationName:"x-amz-version-id" type:"string"`
 
-	metadataCompleteMultipartUploadOutput `json:"-", xml:"-"`
+	metadataCompleteMultipartUploadOutput `json:"-" xml:"-"`
 }
 
 type metadataCompleteMultipartUploadOutput struct {
@@ -1959,7 +1959,7 @@ type metadataCompleteMultipartUploadOutput struct {
 type CompletedMultipartUpload struct {
 	Parts []*CompletedPart `locationName:"Part" type:"list" flattened:"true"`
 
-	metadataCompletedMultipartUpload `json:"-", xml:"-"`
+	metadataCompletedMultipartUpload `json:"-" xml:"-"`
 }
 
 type metadataCompletedMultipartUpload struct {
@@ -1973,7 +1973,7 @@ type CompletedPart struct {
 	// Part number that identifies the part.
 	PartNumber *int64 `type:"integer"`
 
-	metadataCompletedPart `json:"-", xml:"-"`
+	metadataCompletedPart `json:"-" xml:"-"`
 }
 
 type metadataCompletedPart struct {
@@ -1997,7 +1997,7 @@ type Condition struct {
 	// the redirect to be applied.
 	KeyPrefixEquals *string `type:"string"`
 
-	metadataCondition `json:"-", xml:"-"`
+	metadataCondition `json:"-" xml:"-"`
 }
 
 type metadataCondition struct {
@@ -2121,7 +2121,7 @@ type CopyObjectInput struct {
 	// the value of this header in the object metadata.
 	WebsiteRedirectLocation *string `location:"header" locationName:"x-amz-website-redirect-location" type:"string"`
 
-	metadataCopyObjectInput `json:"-", xml:"-"`
+	metadataCopyObjectInput `json:"-" xml:"-"`
 }
 
 type metadataCopyObjectInput struct {
@@ -2158,7 +2158,7 @@ type CopyObjectOutput struct {
 	// (e.g., AES256, aws:kms).
 	ServerSideEncryption *string `location:"header" locationName:"x-amz-server-side-encryption" type:"string"`
 
-	metadataCopyObjectOutput `json:"-", xml:"-"`
+	metadataCopyObjectOutput `json:"-" xml:"-"`
 }
 
 type metadataCopyObjectOutput struct {
@@ -2170,7 +2170,7 @@ type CopyObjectResult struct {
 
 	LastModified *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataCopyObjectResult `json:"-", xml:"-"`
+	metadataCopyObjectResult `json:"-" xml:"-"`
 }
 
 type metadataCopyObjectResult struct {
@@ -2184,7 +2184,7 @@ type CopyPartResult struct {
 	// Date and time at which the object was uploaded.
 	LastModified *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataCopyPartResult `json:"-", xml:"-"`
+	metadataCopyPartResult `json:"-" xml:"-"`
 }
 
 type metadataCopyPartResult struct {
@@ -2195,7 +2195,7 @@ type CreateBucketConfiguration struct {
 	// Specifies the region where the bucket will be created.
 	LocationConstraint *string `type:"string"`
 
-	metadataCreateBucketConfiguration `json:"-", xml:"-"`
+	metadataCreateBucketConfiguration `json:"-" xml:"-"`
 }
 
 type metadataCreateBucketConfiguration struct {
@@ -2226,7 +2226,7 @@ type CreateBucketInput struct {
 	// Allows grantee to write the ACL for the applicable bucket.
 	GrantWriteACP *string `location:"header" locationName:"x-amz-grant-write-acp" type:"string"`
 
-	metadataCreateBucketInput `json:"-", xml:"-"`
+	metadataCreateBucketInput `json:"-" xml:"-"`
 }
 
 type metadataCreateBucketInput struct {
@@ -2236,7 +2236,7 @@ type metadataCreateBucketInput struct {
 type CreateBucketOutput struct {
 	Location *string `location:"header" locationName:"Location" type:"string"`
 
-	metadataCreateBucketOutput `json:"-", xml:"-"`
+	metadataCreateBucketOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateBucketOutput struct {
@@ -2326,7 +2326,7 @@ type CreateMultipartUploadInput struct {
 	// the value of this header in the object metadata.
 	WebsiteRedirectLocation *string `location:"header" locationName:"x-amz-website-redirect-location" type:"string"`
 
-	metadataCreateMultipartUploadInput `json:"-", xml:"-"`
+	metadataCreateMultipartUploadInput `json:"-" xml:"-"`
 }
 
 type metadataCreateMultipartUploadInput struct {
@@ -2365,7 +2365,7 @@ type CreateMultipartUploadOutput struct {
 	// ID for the initiated multipart upload.
 	UploadID *string `locationName:"UploadId" type:"string"`
 
-	metadataCreateMultipartUploadOutput `json:"-", xml:"-"`
+	metadataCreateMultipartUploadOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateMultipartUploadOutput struct {
@@ -2379,7 +2379,7 @@ type Delete struct {
 	// you must set its value to true.
 	Quiet *bool `type:"boolean"`
 
-	metadataDelete `json:"-", xml:"-"`
+	metadataDelete `json:"-" xml:"-"`
 }
 
 type metadataDelete struct {
@@ -2389,7 +2389,7 @@ type metadataDelete struct {
 type DeleteBucketCORSInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
-	metadataDeleteBucketCORSInput `json:"-", xml:"-"`
+	metadataDeleteBucketCORSInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteBucketCORSInput struct {
@@ -2397,7 +2397,7 @@ type metadataDeleteBucketCORSInput struct {
 }
 
 type DeleteBucketCORSOutput struct {
-	metadataDeleteBucketCORSOutput `json:"-", xml:"-"`
+	metadataDeleteBucketCORSOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteBucketCORSOutput struct {
@@ -2407,7 +2407,7 @@ type metadataDeleteBucketCORSOutput struct {
 type DeleteBucketInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
-	metadataDeleteBucketInput `json:"-", xml:"-"`
+	metadataDeleteBucketInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteBucketInput struct {
@@ -2417,7 +2417,7 @@ type metadataDeleteBucketInput struct {
 type DeleteBucketLifecycleInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
-	metadataDeleteBucketLifecycleInput `json:"-", xml:"-"`
+	metadataDeleteBucketLifecycleInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteBucketLifecycleInput struct {
@@ -2425,7 +2425,7 @@ type metadataDeleteBucketLifecycleInput struct {
 }
 
 type DeleteBucketLifecycleOutput struct {
-	metadataDeleteBucketLifecycleOutput `json:"-", xml:"-"`
+	metadataDeleteBucketLifecycleOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteBucketLifecycleOutput struct {
@@ -2433,7 +2433,7 @@ type metadataDeleteBucketLifecycleOutput struct {
 }
 
 type DeleteBucketOutput struct {
-	metadataDeleteBucketOutput `json:"-", xml:"-"`
+	metadataDeleteBucketOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteBucketOutput struct {
@@ -2443,7 +2443,7 @@ type metadataDeleteBucketOutput struct {
 type DeleteBucketPolicyInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
-	metadataDeleteBucketPolicyInput `json:"-", xml:"-"`
+	metadataDeleteBucketPolicyInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteBucketPolicyInput struct {
@@ -2451,7 +2451,7 @@ type metadataDeleteBucketPolicyInput struct {
 }
 
 type DeleteBucketPolicyOutput struct {
-	metadataDeleteBucketPolicyOutput `json:"-", xml:"-"`
+	metadataDeleteBucketPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteBucketPolicyOutput struct {
@@ -2461,7 +2461,7 @@ type metadataDeleteBucketPolicyOutput struct {
 type DeleteBucketReplicationInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
-	metadataDeleteBucketReplicationInput `json:"-", xml:"-"`
+	metadataDeleteBucketReplicationInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteBucketReplicationInput struct {
@@ -2469,7 +2469,7 @@ type metadataDeleteBucketReplicationInput struct {
 }
 
 type DeleteBucketReplicationOutput struct {
-	metadataDeleteBucketReplicationOutput `json:"-", xml:"-"`
+	metadataDeleteBucketReplicationOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteBucketReplicationOutput struct {
@@ -2479,7 +2479,7 @@ type metadataDeleteBucketReplicationOutput struct {
 type DeleteBucketTaggingInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
-	metadataDeleteBucketTaggingInput `json:"-", xml:"-"`
+	metadataDeleteBucketTaggingInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteBucketTaggingInput struct {
@@ -2487,7 +2487,7 @@ type metadataDeleteBucketTaggingInput struct {
 }
 
 type DeleteBucketTaggingOutput struct {
-	metadataDeleteBucketTaggingOutput `json:"-", xml:"-"`
+	metadataDeleteBucketTaggingOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteBucketTaggingOutput struct {
@@ -2497,7 +2497,7 @@ type metadataDeleteBucketTaggingOutput struct {
 type DeleteBucketWebsiteInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
-	metadataDeleteBucketWebsiteInput `json:"-", xml:"-"`
+	metadataDeleteBucketWebsiteInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteBucketWebsiteInput struct {
@@ -2505,7 +2505,7 @@ type metadataDeleteBucketWebsiteInput struct {
 }
 
 type DeleteBucketWebsiteOutput struct {
-	metadataDeleteBucketWebsiteOutput `json:"-", xml:"-"`
+	metadataDeleteBucketWebsiteOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteBucketWebsiteOutput struct {
@@ -2528,7 +2528,7 @@ type DeleteMarkerEntry struct {
 	// Version ID of an object.
 	VersionID *string `locationName:"VersionId" type:"string"`
 
-	metadataDeleteMarkerEntry `json:"-", xml:"-"`
+	metadataDeleteMarkerEntry `json:"-" xml:"-"`
 }
 
 type metadataDeleteMarkerEntry struct {
@@ -2553,7 +2553,7 @@ type DeleteObjectInput struct {
 	// VersionId used to reference a specific version of the object.
 	VersionID *string `location:"querystring" locationName:"versionId" type:"string"`
 
-	metadataDeleteObjectInput `json:"-", xml:"-"`
+	metadataDeleteObjectInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteObjectInput struct {
@@ -2573,7 +2573,7 @@ type DeleteObjectOutput struct {
 	// operation.
 	VersionID *string `location:"header" locationName:"x-amz-version-id" type:"string"`
 
-	metadataDeleteObjectOutput `json:"-", xml:"-"`
+	metadataDeleteObjectOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteObjectOutput struct {
@@ -2595,7 +2595,7 @@ type DeleteObjectsInput struct {
 	// at http://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html
 	RequestPayer *string `location:"header" locationName:"x-amz-request-payer" type:"string"`
 
-	metadataDeleteObjectsInput `json:"-", xml:"-"`
+	metadataDeleteObjectsInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteObjectsInput struct {
@@ -2611,7 +2611,7 @@ type DeleteObjectsOutput struct {
 	// request.
 	RequestCharged *string `location:"header" locationName:"x-amz-request-charged" type:"string"`
 
-	metadataDeleteObjectsOutput `json:"-", xml:"-"`
+	metadataDeleteObjectsOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteObjectsOutput struct {
@@ -2627,7 +2627,7 @@ type DeletedObject struct {
 
 	VersionID *string `locationName:"VersionId" type:"string"`
 
-	metadataDeletedObject `json:"-", xml:"-"`
+	metadataDeletedObject `json:"-" xml:"-"`
 }
 
 type metadataDeletedObject struct {
@@ -2639,7 +2639,7 @@ type Destination struct {
 	// replicas of the object identified by the rule.
 	Bucket *string `type:"string" required:"true"`
 
-	metadataDestination `json:"-", xml:"-"`
+	metadataDestination `json:"-" xml:"-"`
 }
 
 type metadataDestination struct {
@@ -2655,7 +2655,7 @@ type Error struct {
 
 	VersionID *string `locationName:"VersionId" type:"string"`
 
-	metadataError `json:"-", xml:"-"`
+	metadataError `json:"-" xml:"-"`
 }
 
 type metadataError struct {
@@ -2666,7 +2666,7 @@ type ErrorDocument struct {
 	// The object key name to use when a 4XX class error occurs.
 	Key *string `type:"string" required:"true"`
 
-	metadataErrorDocument `json:"-", xml:"-"`
+	metadataErrorDocument `json:"-" xml:"-"`
 }
 
 type metadataErrorDocument struct {
@@ -2676,7 +2676,7 @@ type metadataErrorDocument struct {
 type GetBucketACLInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
-	metadataGetBucketACLInput `json:"-", xml:"-"`
+	metadataGetBucketACLInput `json:"-" xml:"-"`
 }
 
 type metadataGetBucketACLInput struct {
@@ -2689,7 +2689,7 @@ type GetBucketACLOutput struct {
 
 	Owner *Owner `type:"structure"`
 
-	metadataGetBucketACLOutput `json:"-", xml:"-"`
+	metadataGetBucketACLOutput `json:"-" xml:"-"`
 }
 
 type metadataGetBucketACLOutput struct {
@@ -2699,7 +2699,7 @@ type metadataGetBucketACLOutput struct {
 type GetBucketCORSInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
-	metadataGetBucketCORSInput `json:"-", xml:"-"`
+	metadataGetBucketCORSInput `json:"-" xml:"-"`
 }
 
 type metadataGetBucketCORSInput struct {
@@ -2709,7 +2709,7 @@ type metadataGetBucketCORSInput struct {
 type GetBucketCORSOutput struct {
 	CORSRules []*CORSRule `locationName:"CORSRule" type:"list" flattened:"true"`
 
-	metadataGetBucketCORSOutput `json:"-", xml:"-"`
+	metadataGetBucketCORSOutput `json:"-" xml:"-"`
 }
 
 type metadataGetBucketCORSOutput struct {
@@ -2719,7 +2719,7 @@ type metadataGetBucketCORSOutput struct {
 type GetBucketLifecycleInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
-	metadataGetBucketLifecycleInput `json:"-", xml:"-"`
+	metadataGetBucketLifecycleInput `json:"-" xml:"-"`
 }
 
 type metadataGetBucketLifecycleInput struct {
@@ -2729,7 +2729,7 @@ type metadataGetBucketLifecycleInput struct {
 type GetBucketLifecycleOutput struct {
 	Rules []*LifecycleRule `locationName:"Rule" type:"list" flattened:"true"`
 
-	metadataGetBucketLifecycleOutput `json:"-", xml:"-"`
+	metadataGetBucketLifecycleOutput `json:"-" xml:"-"`
 }
 
 type metadataGetBucketLifecycleOutput struct {
@@ -2739,7 +2739,7 @@ type metadataGetBucketLifecycleOutput struct {
 type GetBucketLocationInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
-	metadataGetBucketLocationInput `json:"-", xml:"-"`
+	metadataGetBucketLocationInput `json:"-" xml:"-"`
 }
 
 type metadataGetBucketLocationInput struct {
@@ -2749,7 +2749,7 @@ type metadataGetBucketLocationInput struct {
 type GetBucketLocationOutput struct {
 	LocationConstraint *string `type:"string"`
 
-	metadataGetBucketLocationOutput `json:"-", xml:"-"`
+	metadataGetBucketLocationOutput `json:"-" xml:"-"`
 }
 
 type metadataGetBucketLocationOutput struct {
@@ -2759,7 +2759,7 @@ type metadataGetBucketLocationOutput struct {
 type GetBucketLoggingInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
-	metadataGetBucketLoggingInput `json:"-", xml:"-"`
+	metadataGetBucketLoggingInput `json:"-" xml:"-"`
 }
 
 type metadataGetBucketLoggingInput struct {
@@ -2769,7 +2769,7 @@ type metadataGetBucketLoggingInput struct {
 type GetBucketLoggingOutput struct {
 	LoggingEnabled *LoggingEnabled `type:"structure"`
 
-	metadataGetBucketLoggingOutput `json:"-", xml:"-"`
+	metadataGetBucketLoggingOutput `json:"-" xml:"-"`
 }
 
 type metadataGetBucketLoggingOutput struct {
@@ -2779,7 +2779,7 @@ type metadataGetBucketLoggingOutput struct {
 type GetBucketNotificationInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
-	metadataGetBucketNotificationInput `json:"-", xml:"-"`
+	metadataGetBucketNotificationInput `json:"-" xml:"-"`
 }
 
 type metadataGetBucketNotificationInput struct {
@@ -2793,7 +2793,7 @@ type GetBucketNotificationOutput struct {
 
 	TopicConfiguration *TopicConfiguration `type:"structure"`
 
-	metadataGetBucketNotificationOutput `json:"-", xml:"-"`
+	metadataGetBucketNotificationOutput `json:"-" xml:"-"`
 }
 
 type metadataGetBucketNotificationOutput struct {
@@ -2803,7 +2803,7 @@ type metadataGetBucketNotificationOutput struct {
 type GetBucketPolicyInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
-	metadataGetBucketPolicyInput `json:"-", xml:"-"`
+	metadataGetBucketPolicyInput `json:"-" xml:"-"`
 }
 
 type metadataGetBucketPolicyInput struct {
@@ -2814,7 +2814,7 @@ type GetBucketPolicyOutput struct {
 	// The bucket policy as a JSON document.
 	Policy *string `type:"string"`
 
-	metadataGetBucketPolicyOutput `json:"-", xml:"-"`
+	metadataGetBucketPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataGetBucketPolicyOutput struct {
@@ -2824,7 +2824,7 @@ type metadataGetBucketPolicyOutput struct {
 type GetBucketReplicationInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
-	metadataGetBucketReplicationInput `json:"-", xml:"-"`
+	metadataGetBucketReplicationInput `json:"-" xml:"-"`
 }
 
 type metadataGetBucketReplicationInput struct {
@@ -2836,7 +2836,7 @@ type GetBucketReplicationOutput struct {
 	// replication configuration size can be up to 2 MB.
 	ReplicationConfiguration *ReplicationConfiguration `type:"structure"`
 
-	metadataGetBucketReplicationOutput `json:"-", xml:"-"`
+	metadataGetBucketReplicationOutput `json:"-" xml:"-"`
 }
 
 type metadataGetBucketReplicationOutput struct {
@@ -2846,7 +2846,7 @@ type metadataGetBucketReplicationOutput struct {
 type GetBucketRequestPaymentInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
-	metadataGetBucketRequestPaymentInput `json:"-", xml:"-"`
+	metadataGetBucketRequestPaymentInput `json:"-" xml:"-"`
 }
 
 type metadataGetBucketRequestPaymentInput struct {
@@ -2857,7 +2857,7 @@ type GetBucketRequestPaymentOutput struct {
 	// Specifies who pays for the download and request fees.
 	Payer *string `type:"string"`
 
-	metadataGetBucketRequestPaymentOutput `json:"-", xml:"-"`
+	metadataGetBucketRequestPaymentOutput `json:"-" xml:"-"`
 }
 
 type metadataGetBucketRequestPaymentOutput struct {
@@ -2867,7 +2867,7 @@ type metadataGetBucketRequestPaymentOutput struct {
 type GetBucketTaggingInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
-	metadataGetBucketTaggingInput `json:"-", xml:"-"`
+	metadataGetBucketTaggingInput `json:"-" xml:"-"`
 }
 
 type metadataGetBucketTaggingInput struct {
@@ -2877,7 +2877,7 @@ type metadataGetBucketTaggingInput struct {
 type GetBucketTaggingOutput struct {
 	TagSet []*Tag `locationNameList:"Tag" type:"list" required:"true"`
 
-	metadataGetBucketTaggingOutput `json:"-", xml:"-"`
+	metadataGetBucketTaggingOutput `json:"-" xml:"-"`
 }
 
 type metadataGetBucketTaggingOutput struct {
@@ -2887,7 +2887,7 @@ type metadataGetBucketTaggingOutput struct {
 type GetBucketVersioningInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
-	metadataGetBucketVersioningInput `json:"-", xml:"-"`
+	metadataGetBucketVersioningInput `json:"-" xml:"-"`
 }
 
 type metadataGetBucketVersioningInput struct {
@@ -2903,7 +2903,7 @@ type GetBucketVersioningOutput struct {
 	// The versioning state of the bucket.
 	Status *string `type:"string"`
 
-	metadataGetBucketVersioningOutput `json:"-", xml:"-"`
+	metadataGetBucketVersioningOutput `json:"-" xml:"-"`
 }
 
 type metadataGetBucketVersioningOutput struct {
@@ -2913,7 +2913,7 @@ type metadataGetBucketVersioningOutput struct {
 type GetBucketWebsiteInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
-	metadataGetBucketWebsiteInput `json:"-", xml:"-"`
+	metadataGetBucketWebsiteInput `json:"-" xml:"-"`
 }
 
 type metadataGetBucketWebsiteInput struct {
@@ -2929,7 +2929,7 @@ type GetBucketWebsiteOutput struct {
 
 	RoutingRules []*RoutingRule `locationNameList:"RoutingRule" type:"list"`
 
-	metadataGetBucketWebsiteOutput `json:"-", xml:"-"`
+	metadataGetBucketWebsiteOutput `json:"-" xml:"-"`
 }
 
 type metadataGetBucketWebsiteOutput struct {
@@ -2950,7 +2950,7 @@ type GetObjectACLInput struct {
 	// VersionId used to reference a specific version of the object.
 	VersionID *string `location:"querystring" locationName:"versionId" type:"string"`
 
-	metadataGetObjectACLInput `json:"-", xml:"-"`
+	metadataGetObjectACLInput `json:"-" xml:"-"`
 }
 
 type metadataGetObjectACLInput struct {
@@ -2967,7 +2967,7 @@ type GetObjectACLOutput struct {
 	// request.
 	RequestCharged *string `location:"header" locationName:"x-amz-request-charged" type:"string"`
 
-	metadataGetObjectACLOutput `json:"-", xml:"-"`
+	metadataGetObjectACLOutput `json:"-" xml:"-"`
 }
 
 type metadataGetObjectACLOutput struct {
@@ -3042,7 +3042,7 @@ type GetObjectInput struct {
 	// VersionId used to reference a specific version of the object.
 	VersionID *string `location:"querystring" locationName:"versionId" type:"string"`
 
-	metadataGetObjectInput `json:"-", xml:"-"`
+	metadataGetObjectInput `json:"-" xml:"-"`
 }
 
 type metadataGetObjectInput struct {
@@ -3140,7 +3140,7 @@ type GetObjectOutput struct {
 	// the value of this header in the object metadata.
 	WebsiteRedirectLocation *string `location:"header" locationName:"x-amz-website-redirect-location" type:"string"`
 
-	metadataGetObjectOutput `json:"-", xml:"-"`
+	metadataGetObjectOutput `json:"-" xml:"-"`
 }
 
 type metadataGetObjectOutput struct {
@@ -3158,7 +3158,7 @@ type GetObjectTorrentInput struct {
 	// at http://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html
 	RequestPayer *string `location:"header" locationName:"x-amz-request-payer" type:"string"`
 
-	metadataGetObjectTorrentInput `json:"-", xml:"-"`
+	metadataGetObjectTorrentInput `json:"-" xml:"-"`
 }
 
 type metadataGetObjectTorrentInput struct {
@@ -3172,7 +3172,7 @@ type GetObjectTorrentOutput struct {
 	// request.
 	RequestCharged *string `location:"header" locationName:"x-amz-request-charged" type:"string"`
 
-	metadataGetObjectTorrentOutput `json:"-", xml:"-"`
+	metadataGetObjectTorrentOutput `json:"-" xml:"-"`
 }
 
 type metadataGetObjectTorrentOutput struct {
@@ -3185,7 +3185,7 @@ type Grant struct {
 	// Specifies the permission given to the grantee.
 	Permission *string `type:"string"`
 
-	metadataGrant `json:"-", xml:"-"`
+	metadataGrant `json:"-" xml:"-"`
 }
 
 type metadataGrant struct {
@@ -3208,7 +3208,7 @@ type Grantee struct {
 	// URI of the grantee group.
 	URI *string `type:"string"`
 
-	metadataGrantee `json:"-", xml:"-"`
+	metadataGrantee `json:"-" xml:"-"`
 }
 
 type metadataGrantee struct {
@@ -3218,7 +3218,7 @@ type metadataGrantee struct {
 type HeadBucketInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
-	metadataHeadBucketInput `json:"-", xml:"-"`
+	metadataHeadBucketInput `json:"-" xml:"-"`
 }
 
 type metadataHeadBucketInput struct {
@@ -3226,7 +3226,7 @@ type metadataHeadBucketInput struct {
 }
 
 type HeadBucketOutput struct {
-	metadataHeadBucketOutput `json:"-", xml:"-"`
+	metadataHeadBucketOutput `json:"-" xml:"-"`
 }
 
 type metadataHeadBucketOutput struct {
@@ -3283,7 +3283,7 @@ type HeadObjectInput struct {
 	// VersionId used to reference a specific version of the object.
 	VersionID *string `location:"querystring" locationName:"versionId" type:"string"`
 
-	metadataHeadObjectInput `json:"-", xml:"-"`
+	metadataHeadObjectInput `json:"-" xml:"-"`
 }
 
 type metadataHeadObjectInput struct {
@@ -3378,7 +3378,7 @@ type HeadObjectOutput struct {
 	// the value of this header in the object metadata.
 	WebsiteRedirectLocation *string `location:"header" locationName:"x-amz-website-redirect-location" type:"string"`
 
-	metadataHeadObjectOutput `json:"-", xml:"-"`
+	metadataHeadObjectOutput `json:"-" xml:"-"`
 }
 
 type metadataHeadObjectOutput struct {
@@ -3392,7 +3392,7 @@ type IndexDocument struct {
 	// The suffix must not be empty and must not include a slash character.
 	Suffix *string `type:"string" required:"true"`
 
-	metadataIndexDocument `json:"-", xml:"-"`
+	metadataIndexDocument `json:"-" xml:"-"`
 }
 
 type metadataIndexDocument struct {
@@ -3407,7 +3407,7 @@ type Initiator struct {
 	// the principal is an IAM User, it provides a user ARN value.
 	ID *string `type:"string"`
 
-	metadataInitiator `json:"-", xml:"-"`
+	metadataInitiator `json:"-" xml:"-"`
 }
 
 type metadataInitiator struct {
@@ -3417,7 +3417,7 @@ type metadataInitiator struct {
 type LifecycleConfiguration struct {
 	Rules []*LifecycleRule `locationName:"Rule" type:"list" flattened:"true" required:"true"`
 
-	metadataLifecycleConfiguration `json:"-", xml:"-"`
+	metadataLifecycleConfiguration `json:"-" xml:"-"`
 }
 
 type metadataLifecycleConfiguration struct {
@@ -3433,7 +3433,7 @@ type LifecycleExpiration struct {
 	// The value must be a non-zero positive integer.
 	Days *int64 `type:"integer"`
 
-	metadataLifecycleExpiration `json:"-", xml:"-"`
+	metadataLifecycleExpiration `json:"-" xml:"-"`
 }
 
 type metadataLifecycleExpiration struct {
@@ -3469,7 +3469,7 @@ type LifecycleRule struct {
 
 	Transition *Transition `type:"structure"`
 
-	metadataLifecycleRule `json:"-", xml:"-"`
+	metadataLifecycleRule `json:"-" xml:"-"`
 }
 
 type metadataLifecycleRule struct {
@@ -3477,7 +3477,7 @@ type metadataLifecycleRule struct {
 }
 
 type ListBucketsInput struct {
-	metadataListBucketsInput `json:"-", xml:"-"`
+	metadataListBucketsInput `json:"-" xml:"-"`
 }
 
 type metadataListBucketsInput struct {
@@ -3489,7 +3489,7 @@ type ListBucketsOutput struct {
 
 	Owner *Owner `type:"structure"`
 
-	metadataListBucketsOutput `json:"-", xml:"-"`
+	metadataListBucketsOutput `json:"-" xml:"-"`
 }
 
 type metadataListBucketsOutput struct {
@@ -3528,7 +3528,7 @@ type ListMultipartUploadsInput struct {
 	// is ignored.
 	UploadIDMarker *string `location:"querystring" locationName:"upload-id-marker" type:"string"`
 
-	metadataListMultipartUploadsInput `json:"-", xml:"-"`
+	metadataListMultipartUploadsInput `json:"-" xml:"-"`
 }
 
 type metadataListMultipartUploadsInput struct {
@@ -3576,7 +3576,7 @@ type ListMultipartUploadsOutput struct {
 
 	Uploads []*MultipartUpload `locationName:"Upload" type:"list" flattened:"true"`
 
-	metadataListMultipartUploadsOutput `json:"-", xml:"-"`
+	metadataListMultipartUploadsOutput `json:"-" xml:"-"`
 }
 
 type metadataListMultipartUploadsOutput struct {
@@ -3610,7 +3610,7 @@ type ListObjectVersionsInput struct {
 	// Specifies the object version you want to start listing from.
 	VersionIDMarker *string `location:"querystring" locationName:"version-id-marker" type:"string"`
 
-	metadataListObjectVersionsInput `json:"-", xml:"-"`
+	metadataListObjectVersionsInput `json:"-" xml:"-"`
 }
 
 type metadataListObjectVersionsInput struct {
@@ -3653,7 +3653,7 @@ type ListObjectVersionsOutput struct {
 
 	Versions []*ObjectVersion `locationName:"Version" type:"list" flattened:"true"`
 
-	metadataListObjectVersionsOutput `json:"-", xml:"-"`
+	metadataListObjectVersionsOutput `json:"-" xml:"-"`
 }
 
 type metadataListObjectVersionsOutput struct {
@@ -3684,7 +3684,7 @@ type ListObjectsInput struct {
 	// Limits the response to keys that begin with the specified prefix.
 	Prefix *string `location:"querystring" locationName:"prefix" type:"string"`
 
-	metadataListObjectsInput `json:"-", xml:"-"`
+	metadataListObjectsInput `json:"-" xml:"-"`
 }
 
 type metadataListObjectsInput struct {
@@ -3722,7 +3722,7 @@ type ListObjectsOutput struct {
 
 	Prefix *string `type:"string"`
 
-	metadataListObjectsOutput `json:"-", xml:"-"`
+	metadataListObjectsOutput `json:"-" xml:"-"`
 }
 
 type metadataListObjectsOutput struct {
@@ -3750,7 +3750,7 @@ type ListPartsInput struct {
 	// Upload ID identifying the multipart upload whose parts are being listed.
 	UploadID *string `location:"querystring" locationName:"uploadId" type:"string" required:"true"`
 
-	metadataListPartsInput `json:"-", xml:"-"`
+	metadataListPartsInput `json:"-" xml:"-"`
 }
 
 type metadataListPartsInput struct {
@@ -3795,7 +3795,7 @@ type ListPartsOutput struct {
 	// Upload ID identifying the multipart upload whose parts are being listed.
 	UploadID *string `locationName:"UploadId" type:"string"`
 
-	metadataListPartsOutput `json:"-", xml:"-"`
+	metadataListPartsOutput `json:"-" xml:"-"`
 }
 
 type metadataListPartsOutput struct {
@@ -3817,7 +3817,7 @@ type LoggingEnabled struct {
 	// be stored under.
 	TargetPrefix *string `type:"string"`
 
-	metadataLoggingEnabled `json:"-", xml:"-"`
+	metadataLoggingEnabled `json:"-" xml:"-"`
 }
 
 type metadataLoggingEnabled struct {
@@ -3842,7 +3842,7 @@ type MultipartUpload struct {
 	// Upload ID that identifies the multipart upload.
 	UploadID *string `locationName:"UploadId" type:"string"`
 
-	metadataMultipartUpload `json:"-", xml:"-"`
+	metadataMultipartUpload `json:"-" xml:"-"`
 }
 
 type metadataMultipartUpload struct {
@@ -3862,7 +3862,7 @@ type NoncurrentVersionExpiration struct {
 	// Service Developer Guide.
 	NoncurrentDays *int64 `type:"integer"`
 
-	metadataNoncurrentVersionExpiration `json:"-", xml:"-"`
+	metadataNoncurrentVersionExpiration `json:"-" xml:"-"`
 }
 
 type metadataNoncurrentVersionExpiration struct {
@@ -3885,7 +3885,7 @@ type NoncurrentVersionTransition struct {
 	// The class of storage used to store the object.
 	StorageClass *string `type:"string"`
 
-	metadataNoncurrentVersionTransition `json:"-", xml:"-"`
+	metadataNoncurrentVersionTransition `json:"-" xml:"-"`
 }
 
 type metadataNoncurrentVersionTransition struct {
@@ -3899,7 +3899,7 @@ type NotificationConfiguration struct {
 
 	TopicConfiguration *TopicConfiguration `type:"structure"`
 
-	metadataNotificationConfiguration `json:"-", xml:"-"`
+	metadataNotificationConfiguration `json:"-" xml:"-"`
 }
 
 type metadataNotificationConfiguration struct {
@@ -3920,7 +3920,7 @@ type Object struct {
 	// The class of storage used to store the object.
 	StorageClass *string `type:"string"`
 
-	metadataObject `json:"-", xml:"-"`
+	metadataObject `json:"-" xml:"-"`
 }
 
 type metadataObject struct {
@@ -3934,7 +3934,7 @@ type ObjectIdentifier struct {
 	// VersionId for the specific version of the object to delete.
 	VersionID *string `locationName:"VersionId" type:"string"`
 
-	metadataObjectIdentifier `json:"-", xml:"-"`
+	metadataObjectIdentifier `json:"-" xml:"-"`
 }
 
 type metadataObjectIdentifier struct {
@@ -3965,7 +3965,7 @@ type ObjectVersion struct {
 	// Version ID of an object.
 	VersionID *string `locationName:"VersionId" type:"string"`
 
-	metadataObjectVersion `json:"-", xml:"-"`
+	metadataObjectVersion `json:"-" xml:"-"`
 }
 
 type metadataObjectVersion struct {
@@ -3977,7 +3977,7 @@ type Owner struct {
 
 	ID *string `type:"string"`
 
-	metadataOwner `json:"-", xml:"-"`
+	metadataOwner `json:"-" xml:"-"`
 }
 
 type metadataOwner struct {
@@ -3997,7 +3997,7 @@ type Part struct {
 	// Size of the uploaded part data.
 	Size *int64 `type:"integer"`
 
-	metadataPart `json:"-", xml:"-"`
+	metadataPart `json:"-" xml:"-"`
 }
 
 type metadataPart struct {
@@ -4028,7 +4028,7 @@ type PutBucketACLInput struct {
 	// Allows grantee to write the ACL for the applicable bucket.
 	GrantWriteACP *string `location:"header" locationName:"x-amz-grant-write-acp" type:"string"`
 
-	metadataPutBucketACLInput `json:"-", xml:"-"`
+	metadataPutBucketACLInput `json:"-" xml:"-"`
 }
 
 type metadataPutBucketACLInput struct {
@@ -4036,7 +4036,7 @@ type metadataPutBucketACLInput struct {
 }
 
 type PutBucketACLOutput struct {
-	metadataPutBucketACLOutput `json:"-", xml:"-"`
+	metadataPutBucketACLOutput `json:"-" xml:"-"`
 }
 
 type metadataPutBucketACLOutput struct {
@@ -4048,7 +4048,7 @@ type PutBucketCORSInput struct {
 
 	CORSConfiguration *CORSConfiguration `locationName:"CORSConfiguration" type:"structure"`
 
-	metadataPutBucketCORSInput `json:"-", xml:"-"`
+	metadataPutBucketCORSInput `json:"-" xml:"-"`
 }
 
 type metadataPutBucketCORSInput struct {
@@ -4056,7 +4056,7 @@ type metadataPutBucketCORSInput struct {
 }
 
 type PutBucketCORSOutput struct {
-	metadataPutBucketCORSOutput `json:"-", xml:"-"`
+	metadataPutBucketCORSOutput `json:"-" xml:"-"`
 }
 
 type metadataPutBucketCORSOutput struct {
@@ -4068,7 +4068,7 @@ type PutBucketLifecycleInput struct {
 
 	LifecycleConfiguration *LifecycleConfiguration `locationName:"LifecycleConfiguration" type:"structure"`
 
-	metadataPutBucketLifecycleInput `json:"-", xml:"-"`
+	metadataPutBucketLifecycleInput `json:"-" xml:"-"`
 }
 
 type metadataPutBucketLifecycleInput struct {
@@ -4076,7 +4076,7 @@ type metadataPutBucketLifecycleInput struct {
 }
 
 type PutBucketLifecycleOutput struct {
-	metadataPutBucketLifecycleOutput `json:"-", xml:"-"`
+	metadataPutBucketLifecycleOutput `json:"-" xml:"-"`
 }
 
 type metadataPutBucketLifecycleOutput struct {
@@ -4088,7 +4088,7 @@ type PutBucketLoggingInput struct {
 
 	BucketLoggingStatus *BucketLoggingStatus `locationName:"BucketLoggingStatus" type:"structure" required:"true"`
 
-	metadataPutBucketLoggingInput `json:"-", xml:"-"`
+	metadataPutBucketLoggingInput `json:"-" xml:"-"`
 }
 
 type metadataPutBucketLoggingInput struct {
@@ -4096,7 +4096,7 @@ type metadataPutBucketLoggingInput struct {
 }
 
 type PutBucketLoggingOutput struct {
-	metadataPutBucketLoggingOutput `json:"-", xml:"-"`
+	metadataPutBucketLoggingOutput `json:"-" xml:"-"`
 }
 
 type metadataPutBucketLoggingOutput struct {
@@ -4108,7 +4108,7 @@ type PutBucketNotificationInput struct {
 
 	NotificationConfiguration *NotificationConfiguration `locationName:"NotificationConfiguration" type:"structure" required:"true"`
 
-	metadataPutBucketNotificationInput `json:"-", xml:"-"`
+	metadataPutBucketNotificationInput `json:"-" xml:"-"`
 }
 
 type metadataPutBucketNotificationInput struct {
@@ -4116,7 +4116,7 @@ type metadataPutBucketNotificationInput struct {
 }
 
 type PutBucketNotificationOutput struct {
-	metadataPutBucketNotificationOutput `json:"-", xml:"-"`
+	metadataPutBucketNotificationOutput `json:"-" xml:"-"`
 }
 
 type metadataPutBucketNotificationOutput struct {
@@ -4129,7 +4129,7 @@ type PutBucketPolicyInput struct {
 	// The bucket policy as a JSON document.
 	Policy *string `type:"string" required:"true"`
 
-	metadataPutBucketPolicyInput `json:"-", xml:"-"`
+	metadataPutBucketPolicyInput `json:"-" xml:"-"`
 }
 
 type metadataPutBucketPolicyInput struct {
@@ -4137,7 +4137,7 @@ type metadataPutBucketPolicyInput struct {
 }
 
 type PutBucketPolicyOutput struct {
-	metadataPutBucketPolicyOutput `json:"-", xml:"-"`
+	metadataPutBucketPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataPutBucketPolicyOutput struct {
@@ -4151,7 +4151,7 @@ type PutBucketReplicationInput struct {
 	// replication configuration size can be up to 2 MB.
 	ReplicationConfiguration *ReplicationConfiguration `locationName:"ReplicationConfiguration" type:"structure" required:"true"`
 
-	metadataPutBucketReplicationInput `json:"-", xml:"-"`
+	metadataPutBucketReplicationInput `json:"-" xml:"-"`
 }
 
 type metadataPutBucketReplicationInput struct {
@@ -4159,7 +4159,7 @@ type metadataPutBucketReplicationInput struct {
 }
 
 type PutBucketReplicationOutput struct {
-	metadataPutBucketReplicationOutput `json:"-", xml:"-"`
+	metadataPutBucketReplicationOutput `json:"-" xml:"-"`
 }
 
 type metadataPutBucketReplicationOutput struct {
@@ -4171,7 +4171,7 @@ type PutBucketRequestPaymentInput struct {
 
 	RequestPaymentConfiguration *RequestPaymentConfiguration `locationName:"RequestPaymentConfiguration" type:"structure" required:"true"`
 
-	metadataPutBucketRequestPaymentInput `json:"-", xml:"-"`
+	metadataPutBucketRequestPaymentInput `json:"-" xml:"-"`
 }
 
 type metadataPutBucketRequestPaymentInput struct {
@@ -4179,7 +4179,7 @@ type metadataPutBucketRequestPaymentInput struct {
 }
 
 type PutBucketRequestPaymentOutput struct {
-	metadataPutBucketRequestPaymentOutput `json:"-", xml:"-"`
+	metadataPutBucketRequestPaymentOutput `json:"-" xml:"-"`
 }
 
 type metadataPutBucketRequestPaymentOutput struct {
@@ -4191,7 +4191,7 @@ type PutBucketTaggingInput struct {
 
 	Tagging *Tagging `locationName:"Tagging" type:"structure" required:"true"`
 
-	metadataPutBucketTaggingInput `json:"-", xml:"-"`
+	metadataPutBucketTaggingInput `json:"-" xml:"-"`
 }
 
 type metadataPutBucketTaggingInput struct {
@@ -4199,7 +4199,7 @@ type metadataPutBucketTaggingInput struct {
 }
 
 type PutBucketTaggingOutput struct {
-	metadataPutBucketTaggingOutput `json:"-", xml:"-"`
+	metadataPutBucketTaggingOutput `json:"-" xml:"-"`
 }
 
 type metadataPutBucketTaggingOutput struct {
@@ -4215,7 +4215,7 @@ type PutBucketVersioningInput struct {
 
 	VersioningConfiguration *VersioningConfiguration `locationName:"VersioningConfiguration" type:"structure" required:"true"`
 
-	metadataPutBucketVersioningInput `json:"-", xml:"-"`
+	metadataPutBucketVersioningInput `json:"-" xml:"-"`
 }
 
 type metadataPutBucketVersioningInput struct {
@@ -4223,7 +4223,7 @@ type metadataPutBucketVersioningInput struct {
 }
 
 type PutBucketVersioningOutput struct {
-	metadataPutBucketVersioningOutput `json:"-", xml:"-"`
+	metadataPutBucketVersioningOutput `json:"-" xml:"-"`
 }
 
 type metadataPutBucketVersioningOutput struct {
@@ -4235,7 +4235,7 @@ type PutBucketWebsiteInput struct {
 
 	WebsiteConfiguration *WebsiteConfiguration `locationName:"WebsiteConfiguration" type:"structure" required:"true"`
 
-	metadataPutBucketWebsiteInput `json:"-", xml:"-"`
+	metadataPutBucketWebsiteInput `json:"-" xml:"-"`
 }
 
 type metadataPutBucketWebsiteInput struct {
@@ -4243,7 +4243,7 @@ type metadataPutBucketWebsiteInput struct {
 }
 
 type PutBucketWebsiteOutput struct {
-	metadataPutBucketWebsiteOutput `json:"-", xml:"-"`
+	metadataPutBucketWebsiteOutput `json:"-" xml:"-"`
 }
 
 type metadataPutBucketWebsiteOutput struct {
@@ -4282,7 +4282,7 @@ type PutObjectACLInput struct {
 	// at http://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html
 	RequestPayer *string `location:"header" locationName:"x-amz-request-payer" type:"string"`
 
-	metadataPutObjectACLInput `json:"-", xml:"-"`
+	metadataPutObjectACLInput `json:"-" xml:"-"`
 }
 
 type metadataPutObjectACLInput struct {
@@ -4294,7 +4294,7 @@ type PutObjectACLOutput struct {
 	// request.
 	RequestCharged *string `location:"header" locationName:"x-amz-request-charged" type:"string"`
 
-	metadataPutObjectACLOutput `json:"-", xml:"-"`
+	metadataPutObjectACLOutput `json:"-" xml:"-"`
 }
 
 type metadataPutObjectACLOutput struct {
@@ -4391,7 +4391,7 @@ type PutObjectInput struct {
 	// the value of this header in the object metadata.
 	WebsiteRedirectLocation *string `location:"header" locationName:"x-amz-website-redirect-location" type:"string"`
 
-	metadataPutObjectInput `json:"-", xml:"-"`
+	metadataPutObjectInput `json:"-" xml:"-"`
 }
 
 type metadataPutObjectInput struct {
@@ -4431,7 +4431,7 @@ type PutObjectOutput struct {
 	// Version of the object.
 	VersionID *string `location:"header" locationName:"x-amz-version-id" type:"string"`
 
-	metadataPutObjectOutput `json:"-", xml:"-"`
+	metadataPutObjectOutput `json:"-" xml:"-"`
 }
 
 type metadataPutObjectOutput struct {
@@ -4447,7 +4447,7 @@ type QueueConfiguration struct {
 
 	Queue *string `type:"string"`
 
-	metadataQueueConfiguration `json:"-", xml:"-"`
+	metadataQueueConfiguration `json:"-" xml:"-"`
 }
 
 type metadataQueueConfiguration struct {
@@ -4479,7 +4479,7 @@ type Redirect struct {
 	// be present only if ReplaceKeyPrefixWith is not provided.
 	ReplaceKeyWith *string `type:"string"`
 
-	metadataRedirect `json:"-", xml:"-"`
+	metadataRedirect `json:"-" xml:"-"`
 }
 
 type metadataRedirect struct {
@@ -4494,7 +4494,7 @@ type RedirectAllRequestsTo struct {
 	// protocol that is used in the original request.
 	Protocol *string `type:"string"`
 
-	metadataRedirectAllRequestsTo `json:"-", xml:"-"`
+	metadataRedirectAllRequestsTo `json:"-" xml:"-"`
 }
 
 type metadataRedirectAllRequestsTo struct {
@@ -4512,7 +4512,7 @@ type ReplicationConfiguration struct {
 	// configuration must have at least one rule and can contain up to 1,000 rules.
 	Rules []*ReplicationRule `locationName:"Rule" type:"list" flattened:"true" required:"true"`
 
-	metadataReplicationConfiguration `json:"-", xml:"-"`
+	metadataReplicationConfiguration `json:"-" xml:"-"`
 }
 
 type metadataReplicationConfiguration struct {
@@ -4533,7 +4533,7 @@ type ReplicationRule struct {
 	// The rule is ignored if status is not Enabled.
 	Status *string `type:"string" required:"true"`
 
-	metadataReplicationRule `json:"-", xml:"-"`
+	metadataReplicationRule `json:"-" xml:"-"`
 }
 
 type metadataReplicationRule struct {
@@ -4544,7 +4544,7 @@ type RequestPaymentConfiguration struct {
 	// Specifies who pays for the download and request fees.
 	Payer *string `type:"string" required:"true"`
 
-	metadataRequestPaymentConfiguration `json:"-", xml:"-"`
+	metadataRequestPaymentConfiguration `json:"-" xml:"-"`
 }
 
 type metadataRequestPaymentConfiguration struct {
@@ -4566,7 +4566,7 @@ type RestoreObjectInput struct {
 
 	VersionID *string `location:"querystring" locationName:"versionId" type:"string"`
 
-	metadataRestoreObjectInput `json:"-", xml:"-"`
+	metadataRestoreObjectInput `json:"-" xml:"-"`
 }
 
 type metadataRestoreObjectInput struct {
@@ -4578,7 +4578,7 @@ type RestoreObjectOutput struct {
 	// request.
 	RequestCharged *string `location:"header" locationName:"x-amz-request-charged" type:"string"`
 
-	metadataRestoreObjectOutput `json:"-", xml:"-"`
+	metadataRestoreObjectOutput `json:"-" xml:"-"`
 }
 
 type metadataRestoreObjectOutput struct {
@@ -4589,7 +4589,7 @@ type RestoreRequest struct {
 	// Lifetime of the active copy in days
 	Days *int64 `type:"integer" required:"true"`
 
-	metadataRestoreRequest `json:"-", xml:"-"`
+	metadataRestoreRequest `json:"-" xml:"-"`
 }
 
 type metadataRestoreRequest struct {
@@ -4608,7 +4608,7 @@ type RoutingRule struct {
 	// you can can specify a different error code to return.
 	Redirect *Redirect `type:"structure" required:"true"`
 
-	metadataRoutingRule `json:"-", xml:"-"`
+	metadataRoutingRule `json:"-" xml:"-"`
 }
 
 type metadataRoutingRule struct {
@@ -4622,7 +4622,7 @@ type Tag struct {
 	// Value of the tag.
 	Value *string `type:"string" required:"true"`
 
-	metadataTag `json:"-", xml:"-"`
+	metadataTag `json:"-" xml:"-"`
 }
 
 type metadataTag struct {
@@ -4632,7 +4632,7 @@ type metadataTag struct {
 type Tagging struct {
 	TagSet []*Tag `locationNameList:"Tag" type:"list" required:"true"`
 
-	metadataTagging `json:"-", xml:"-"`
+	metadataTagging `json:"-" xml:"-"`
 }
 
 type metadataTagging struct {
@@ -4645,7 +4645,7 @@ type TargetGrant struct {
 	// Logging permissions assigned to the Grantee for the bucket.
 	Permission *string `type:"string"`
 
-	metadataTargetGrant `json:"-", xml:"-"`
+	metadataTargetGrant `json:"-" xml:"-"`
 }
 
 type metadataTargetGrant struct {
@@ -4664,7 +4664,7 @@ type TopicConfiguration struct {
 	// specified events for the bucket.
 	Topic *string `type:"string"`
 
-	metadataTopicConfiguration `json:"-", xml:"-"`
+	metadataTopicConfiguration `json:"-" xml:"-"`
 }
 
 type metadataTopicConfiguration struct {
@@ -4683,7 +4683,7 @@ type Transition struct {
 	// The class of storage used to store the object.
 	StorageClass *string `type:"string"`
 
-	metadataTransition `json:"-", xml:"-"`
+	metadataTransition `json:"-" xml:"-"`
 }
 
 type metadataTransition struct {
@@ -4761,7 +4761,7 @@ type UploadPartCopyInput struct {
 	// Upload ID identifying the multipart upload whose part is being copied.
 	UploadID *string `location:"querystring" locationName:"uploadId" type:"string" required:"true"`
 
-	metadataUploadPartCopyInput `json:"-", xml:"-"`
+	metadataUploadPartCopyInput `json:"-" xml:"-"`
 }
 
 type metadataUploadPartCopyInput struct {
@@ -4797,7 +4797,7 @@ type UploadPartCopyOutput struct {
 	// (e.g., AES256, aws:kms).
 	ServerSideEncryption *string `location:"header" locationName:"x-amz-server-side-encryption" type:"string"`
 
-	metadataUploadPartCopyOutput `json:"-", xml:"-"`
+	metadataUploadPartCopyOutput `json:"-" xml:"-"`
 }
 
 type metadataUploadPartCopyOutput struct {
@@ -4844,7 +4844,7 @@ type UploadPartInput struct {
 	// Upload ID identifying the multipart upload whose part is being uploaded.
 	UploadID *string `location:"querystring" locationName:"uploadId" type:"string" required:"true"`
 
-	metadataUploadPartInput `json:"-", xml:"-"`
+	metadataUploadPartInput `json:"-" xml:"-"`
 }
 
 type metadataUploadPartInput struct {
@@ -4877,7 +4877,7 @@ type UploadPartOutput struct {
 	// (e.g., AES256, aws:kms).
 	ServerSideEncryption *string `location:"header" locationName:"x-amz-server-side-encryption" type:"string"`
 
-	metadataUploadPartOutput `json:"-", xml:"-"`
+	metadataUploadPartOutput `json:"-" xml:"-"`
 }
 
 type metadataUploadPartOutput struct {
@@ -4893,7 +4893,7 @@ type VersioningConfiguration struct {
 	// The versioning state of the bucket.
 	Status *string `type:"string"`
 
-	metadataVersioningConfiguration `json:"-", xml:"-"`
+	metadataVersioningConfiguration `json:"-" xml:"-"`
 }
 
 type metadataVersioningConfiguration struct {
@@ -4909,7 +4909,7 @@ type WebsiteConfiguration struct {
 
 	RoutingRules []*RoutingRule `locationNameList:"RoutingRule" type:"list"`
 
-	metadataWebsiteConfiguration `json:"-", xml:"-"`
+	metadataWebsiteConfiguration `json:"-" xml:"-"`
 }
 
 type metadataWebsiteConfiguration struct {

--- a/service/ses/api.go
+++ b/service/ses/api.go
@@ -767,7 +767,7 @@ type Body struct {
 	// clients, or clients on high-latency networks (such as mobile devices).
 	Text *Content `type:"structure"`
 
-	metadataBody `json:"-", xml:"-"`
+	metadataBody `json:"-" xml:"-"`
 }
 
 type metadataBody struct {
@@ -786,7 +786,7 @@ type Content struct {
 	// The textual data of the content.
 	Data *string `type:"string" required:"true"`
 
-	metadataContent `json:"-", xml:"-"`
+	metadataContent `json:"-" xml:"-"`
 }
 
 type metadataContent struct {
@@ -799,7 +799,7 @@ type DeleteIdentityInput struct {
 	// The identity to be removed from the list of identities for the AWS Account.
 	Identity *string `type:"string" required:"true"`
 
-	metadataDeleteIdentityInput `json:"-", xml:"-"`
+	metadataDeleteIdentityInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteIdentityInput struct {
@@ -809,7 +809,7 @@ type metadataDeleteIdentityInput struct {
 // An empty element. Receiving this element indicates that the request completed
 // successfully.
 type DeleteIdentityOutput struct {
-	metadataDeleteIdentityOutput `json:"-", xml:"-"`
+	metadataDeleteIdentityOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteIdentityOutput struct {
@@ -822,7 +822,7 @@ type DeleteVerifiedEmailAddressInput struct {
 	// An email address to be removed from the list of verified addresses.
 	EmailAddress *string `type:"string" required:"true"`
 
-	metadataDeleteVerifiedEmailAddressInput `json:"-", xml:"-"`
+	metadataDeleteVerifiedEmailAddressInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteVerifiedEmailAddressInput struct {
@@ -830,7 +830,7 @@ type metadataDeleteVerifiedEmailAddressInput struct {
 }
 
 type DeleteVerifiedEmailAddressOutput struct {
-	metadataDeleteVerifiedEmailAddressOutput `json:"-", xml:"-"`
+	metadataDeleteVerifiedEmailAddressOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteVerifiedEmailAddressOutput struct {
@@ -854,7 +854,7 @@ type Destination struct {
 	// The To: field(s) of the message.
 	ToAddresses []*string `type:"list"`
 
-	metadataDestination `json:"-", xml:"-"`
+	metadataDestination `json:"-" xml:"-"`
 }
 
 type metadataDestination struct {
@@ -872,7 +872,7 @@ type GetIdentityDKIMAttributesInput struct {
 	// both.
 	Identities []*string `type:"list" required:"true"`
 
-	metadataGetIdentityDKIMAttributesInput `json:"-", xml:"-"`
+	metadataGetIdentityDKIMAttributesInput `json:"-" xml:"-"`
 }
 
 type metadataGetIdentityDKIMAttributesInput struct {
@@ -884,7 +884,7 @@ type GetIdentityDKIMAttributesOutput struct {
 	// The DKIM attributes for an email address or a domain.
 	DKIMAttributes *map[string]*IdentityDKIMAttributes `locationName:"DkimAttributes" type:"map" required:"true"`
 
-	metadataGetIdentityDKIMAttributesOutput `json:"-", xml:"-"`
+	metadataGetIdentityDKIMAttributesOutput `json:"-" xml:"-"`
 }
 
 type metadataGetIdentityDKIMAttributesOutput struct {
@@ -895,7 +895,7 @@ type GetIdentityNotificationAttributesInput struct {
 	// A list of one or more identities.
 	Identities []*string `type:"list" required:"true"`
 
-	metadataGetIdentityNotificationAttributesInput `json:"-", xml:"-"`
+	metadataGetIdentityNotificationAttributesInput `json:"-" xml:"-"`
 }
 
 type metadataGetIdentityNotificationAttributesInput struct {
@@ -910,7 +910,7 @@ type GetIdentityNotificationAttributesOutput struct {
 	// A map of Identity to IdentityNotificationAttributes.
 	NotificationAttributes *map[string]*IdentityNotificationAttributes `type:"map" required:"true"`
 
-	metadataGetIdentityNotificationAttributesOutput `json:"-", xml:"-"`
+	metadataGetIdentityNotificationAttributesOutput `json:"-" xml:"-"`
 }
 
 type metadataGetIdentityNotificationAttributesOutput struct {
@@ -923,7 +923,7 @@ type GetIdentityVerificationAttributesInput struct {
 	// A list of identities.
 	Identities []*string `type:"list" required:"true"`
 
-	metadataGetIdentityVerificationAttributesInput `json:"-", xml:"-"`
+	metadataGetIdentityVerificationAttributesInput `json:"-" xml:"-"`
 }
 
 type metadataGetIdentityVerificationAttributesInput struct {
@@ -935,7 +935,7 @@ type GetIdentityVerificationAttributesOutput struct {
 	// A map of Identities to IdentityVerificationAttributes objects.
 	VerificationAttributes *map[string]*IdentityVerificationAttributes `type:"map" required:"true"`
 
-	metadataGetIdentityVerificationAttributesOutput `json:"-", xml:"-"`
+	metadataGetIdentityVerificationAttributesOutput `json:"-" xml:"-"`
 }
 
 type metadataGetIdentityVerificationAttributesOutput struct {
@@ -943,7 +943,7 @@ type metadataGetIdentityVerificationAttributesOutput struct {
 }
 
 type GetSendQuotaInput struct {
-	metadataGetSendQuotaInput `json:"-", xml:"-"`
+	metadataGetSendQuotaInput `json:"-" xml:"-"`
 }
 
 type metadataGetSendQuotaInput struct {
@@ -962,7 +962,7 @@ type GetSendQuotaOutput struct {
 	// The number of emails sent during the previous 24 hours.
 	SentLast24Hours *float64 `type:"double"`
 
-	metadataGetSendQuotaOutput `json:"-", xml:"-"`
+	metadataGetSendQuotaOutput `json:"-" xml:"-"`
 }
 
 type metadataGetSendQuotaOutput struct {
@@ -970,7 +970,7 @@ type metadataGetSendQuotaOutput struct {
 }
 
 type GetSendStatisticsInput struct {
-	metadataGetSendStatisticsInput `json:"-", xml:"-"`
+	metadataGetSendStatisticsInput `json:"-" xml:"-"`
 }
 
 type metadataGetSendStatisticsInput struct {
@@ -984,7 +984,7 @@ type GetSendStatisticsOutput struct {
 	// A list of data points, each of which represents 15 minutes of activity.
 	SendDataPoints []*SendDataPoint `type:"list"`
 
-	metadataGetSendStatisticsOutput `json:"-", xml:"-"`
+	metadataGetSendStatisticsOutput `json:"-" xml:"-"`
 }
 
 type metadataGetSendStatisticsOutput struct {
@@ -1013,7 +1013,7 @@ type IdentityDKIMAttributes struct {
 	// identities, not email address identities.)
 	DKIMVerificationStatus *string `locationName:"DkimVerificationStatus" type:"string" required:"true"`
 
-	metadataIdentityDKIMAttributes `json:"-", xml:"-"`
+	metadataIdentityDKIMAttributes `json:"-" xml:"-"`
 }
 
 type metadataIdentityDKIMAttributes struct {
@@ -1043,7 +1043,7 @@ type IdentityNotificationAttributes struct {
 	// will be published only to the specified bounce and complaint Amazon SNS topics.
 	ForwardingEnabled *bool `type:"boolean" required:"true"`
 
-	metadataIdentityNotificationAttributes `json:"-", xml:"-"`
+	metadataIdentityNotificationAttributes `json:"-" xml:"-"`
 }
 
 type metadataIdentityNotificationAttributes struct {
@@ -1059,7 +1059,7 @@ type IdentityVerificationAttributes struct {
 	// The verification token for a domain identity. Null for email address identities.
 	VerificationToken *string `type:"string"`
 
-	metadataIdentityVerificationAttributes `json:"-", xml:"-"`
+	metadataIdentityVerificationAttributes `json:"-" xml:"-"`
 }
 
 type metadataIdentityVerificationAttributes struct {
@@ -1079,7 +1079,7 @@ type ListIdentitiesInput struct {
 	// The token to use for pagination.
 	NextToken *string `type:"string"`
 
-	metadataListIdentitiesInput `json:"-", xml:"-"`
+	metadataListIdentitiesInput `json:"-" xml:"-"`
 }
 
 type metadataListIdentitiesInput struct {
@@ -1094,7 +1094,7 @@ type ListIdentitiesOutput struct {
 	// The token used for pagination.
 	NextToken *string `type:"string"`
 
-	metadataListIdentitiesOutput `json:"-", xml:"-"`
+	metadataListIdentitiesOutput `json:"-" xml:"-"`
 }
 
 type metadataListIdentitiesOutput struct {
@@ -1102,7 +1102,7 @@ type metadataListIdentitiesOutput struct {
 }
 
 type ListVerifiedEmailAddressesInput struct {
-	metadataListVerifiedEmailAddressesInput `json:"-", xml:"-"`
+	metadataListVerifiedEmailAddressesInput `json:"-" xml:"-"`
 }
 
 type metadataListVerifiedEmailAddressesInput struct {
@@ -1114,7 +1114,7 @@ type ListVerifiedEmailAddressesOutput struct {
 	// A list of email addresses that have been verified.
 	VerifiedEmailAddresses []*string `type:"list"`
 
-	metadataListVerifiedEmailAddressesOutput `json:"-", xml:"-"`
+	metadataListVerifiedEmailAddressesOutput `json:"-" xml:"-"`
 }
 
 type metadataListVerifiedEmailAddressesOutput struct {
@@ -1130,7 +1130,7 @@ type Message struct {
 	// in the recipient's inbox.
 	Subject *Content `type:"structure" required:"true"`
 
-	metadataMessage `json:"-", xml:"-"`
+	metadataMessage `json:"-" xml:"-"`
 }
 
 type metadataMessage struct {
@@ -1148,7 +1148,7 @@ type RawMessage struct {
 	// For more information, go to the Amazon SES Developer Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-raw.html).
 	Data []byte `type:"blob" required:"true"`
 
-	metadataRawMessage `json:"-", xml:"-"`
+	metadataRawMessage `json:"-" xml:"-"`
 }
 
 type metadataRawMessage struct {
@@ -1173,7 +1173,7 @@ type SendDataPoint struct {
 	// Time of the data point.
 	Timestamp *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataSendDataPoint `json:"-", xml:"-"`
+	metadataSendDataPoint `json:"-" xml:"-"`
 }
 
 type metadataSendDataPoint struct {
@@ -1211,7 +1211,7 @@ type SendEmailInput struct {
 	// For more information, see RFC 2047 (http://tools.ietf.org/html/rfc2047).
 	Source *string `type:"string" required:"true"`
 
-	metadataSendEmailInput `json:"-", xml:"-"`
+	metadataSendEmailInput `json:"-" xml:"-"`
 }
 
 type metadataSendEmailInput struct {
@@ -1223,7 +1223,7 @@ type SendEmailOutput struct {
 	// The unique message identifier returned from the SendEmail action.
 	MessageID *string `locationName:"MessageId" type:"string" required:"true"`
 
-	metadataSendEmailOutput `json:"-", xml:"-"`
+	metadataSendEmailOutput `json:"-" xml:"-"`
 }
 
 type metadataSendEmailOutput struct {
@@ -1263,7 +1263,7 @@ type SendRawEmailInput struct {
 	// text of the message.
 	Source *string `type:"string"`
 
-	metadataSendRawEmailInput `json:"-", xml:"-"`
+	metadataSendRawEmailInput `json:"-" xml:"-"`
 }
 
 type metadataSendRawEmailInput struct {
@@ -1275,7 +1275,7 @@ type SendRawEmailOutput struct {
 	// The unique message identifier returned from the SendRawEmail action.
 	MessageID *string `locationName:"MessageId" type:"string" required:"true"`
 
-	metadataSendRawEmailOutput `json:"-", xml:"-"`
+	metadataSendRawEmailOutput `json:"-" xml:"-"`
 }
 
 type metadataSendRawEmailOutput struct {
@@ -1292,7 +1292,7 @@ type SetIdentityDKIMEnabledInput struct {
 	// The identity for which DKIM signing should be enabled or disabled.
 	Identity *string `type:"string" required:"true"`
 
-	metadataSetIdentityDKIMEnabledInput `json:"-", xml:"-"`
+	metadataSetIdentityDKIMEnabledInput `json:"-" xml:"-"`
 }
 
 type metadataSetIdentityDKIMEnabledInput struct {
@@ -1302,7 +1302,7 @@ type metadataSetIdentityDKIMEnabledInput struct {
 // An empty element. Receiving this element indicates that the request completed
 // successfully.
 type SetIdentityDKIMEnabledOutput struct {
-	metadataSetIdentityDKIMEnabledOutput `json:"-", xml:"-"`
+	metadataSetIdentityDKIMEnabledOutput `json:"-" xml:"-"`
 }
 
 type metadataSetIdentityDKIMEnabledOutput struct {
@@ -1322,7 +1322,7 @@ type SetIdentityFeedbackForwardingEnabledInput struct {
 	// Examples: user@example.com, example.com.
 	Identity *string `type:"string" required:"true"`
 
-	metadataSetIdentityFeedbackForwardingEnabledInput `json:"-", xml:"-"`
+	metadataSetIdentityFeedbackForwardingEnabledInput `json:"-" xml:"-"`
 }
 
 type metadataSetIdentityFeedbackForwardingEnabledInput struct {
@@ -1332,7 +1332,7 @@ type metadataSetIdentityFeedbackForwardingEnabledInput struct {
 // An empty element. Receiving this element indicates that the request completed
 // successfully.
 type SetIdentityFeedbackForwardingEnabledOutput struct {
-	metadataSetIdentityFeedbackForwardingEnabledOutput `json:"-", xml:"-"`
+	metadataSetIdentityFeedbackForwardingEnabledOutput `json:"-" xml:"-"`
 }
 
 type metadataSetIdentityFeedbackForwardingEnabledOutput struct {
@@ -1354,7 +1354,7 @@ type SetIdentityNotificationTopicInput struct {
 	// and publishing is disabled.
 	SNSTopic *string `locationName:"SnsTopic" type:"string"`
 
-	metadataSetIdentityNotificationTopicInput `json:"-", xml:"-"`
+	metadataSetIdentityNotificationTopicInput `json:"-" xml:"-"`
 }
 
 type metadataSetIdentityNotificationTopicInput struct {
@@ -1364,7 +1364,7 @@ type metadataSetIdentityNotificationTopicInput struct {
 // An empty element. Receiving this element indicates that the request completed
 // successfully.
 type SetIdentityNotificationTopicOutput struct {
-	metadataSetIdentityNotificationTopicOutput `json:"-", xml:"-"`
+	metadataSetIdentityNotificationTopicOutput `json:"-" xml:"-"`
 }
 
 type metadataSetIdentityNotificationTopicOutput struct {
@@ -1377,7 +1377,7 @@ type VerifyDomainDKIMInput struct {
 	// The name of the domain to be verified for Easy DKIM signing.
 	Domain *string `type:"string" required:"true"`
 
-	metadataVerifyDomainDKIMInput `json:"-", xml:"-"`
+	metadataVerifyDomainDKIMInput `json:"-" xml:"-"`
 }
 
 type metadataVerifyDomainDKIMInput struct {
@@ -1400,7 +1400,7 @@ type VerifyDomainDKIMOutput struct {
 	// the Amazon SES Developer Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim-dns-records.html).
 	DKIMTokens []*string `locationName:"DkimTokens" type:"list" required:"true"`
 
-	metadataVerifyDomainDKIMOutput `json:"-", xml:"-"`
+	metadataVerifyDomainDKIMOutput `json:"-" xml:"-"`
 }
 
 type metadataVerifyDomainDKIMOutput struct {
@@ -1412,7 +1412,7 @@ type VerifyDomainIdentityInput struct {
 	// The domain to be verified.
 	Domain *string `type:"string" required:"true"`
 
-	metadataVerifyDomainIdentityInput `json:"-", xml:"-"`
+	metadataVerifyDomainIdentityInput `json:"-" xml:"-"`
 }
 
 type metadataVerifyDomainIdentityInput struct {
@@ -1425,7 +1425,7 @@ type VerifyDomainIdentityOutput struct {
 	// to complete domain verification.
 	VerificationToken *string `type:"string" required:"true"`
 
-	metadataVerifyDomainIdentityOutput `json:"-", xml:"-"`
+	metadataVerifyDomainIdentityOutput `json:"-" xml:"-"`
 }
 
 type metadataVerifyDomainIdentityOutput struct {
@@ -1437,7 +1437,7 @@ type VerifyEmailAddressInput struct {
 	// The email address to be verified.
 	EmailAddress *string `type:"string" required:"true"`
 
-	metadataVerifyEmailAddressInput `json:"-", xml:"-"`
+	metadataVerifyEmailAddressInput `json:"-" xml:"-"`
 }
 
 type metadataVerifyEmailAddressInput struct {
@@ -1445,7 +1445,7 @@ type metadataVerifyEmailAddressInput struct {
 }
 
 type VerifyEmailAddressOutput struct {
-	metadataVerifyEmailAddressOutput `json:"-", xml:"-"`
+	metadataVerifyEmailAddressOutput `json:"-" xml:"-"`
 }
 
 type metadataVerifyEmailAddressOutput struct {
@@ -1457,7 +1457,7 @@ type VerifyEmailIdentityInput struct {
 	// The email address to be verified.
 	EmailAddress *string `type:"string" required:"true"`
 
-	metadataVerifyEmailIdentityInput `json:"-", xml:"-"`
+	metadataVerifyEmailIdentityInput `json:"-" xml:"-"`
 }
 
 type metadataVerifyEmailIdentityInput struct {
@@ -1467,7 +1467,7 @@ type metadataVerifyEmailIdentityInput struct {
 // An empty element. Receiving this element indicates that the request completed
 // successfully.
 type VerifyEmailIdentityOutput struct {
-	metadataVerifyEmailIdentityOutput `json:"-", xml:"-"`
+	metadataVerifyEmailIdentityOutput `json:"-" xml:"-"`
 }
 
 type metadataVerifyEmailIdentityOutput struct {

--- a/service/sns/api.go
+++ b/service/sns/api.go
@@ -941,7 +941,7 @@ type AddPermissionInput struct {
 	// The ARN of the topic whose access control policy you wish to modify.
 	TopicARN *string `locationName:"TopicArn" type:"string" required:"true"`
 
-	metadataAddPermissionInput `json:"-", xml:"-"`
+	metadataAddPermissionInput `json:"-" xml:"-"`
 }
 
 type metadataAddPermissionInput struct {
@@ -949,7 +949,7 @@ type metadataAddPermissionInput struct {
 }
 
 type AddPermissionOutput struct {
-	metadataAddPermissionOutput `json:"-", xml:"-"`
+	metadataAddPermissionOutput `json:"-" xml:"-"`
 }
 
 type metadataAddPermissionOutput struct {
@@ -970,7 +970,7 @@ type ConfirmSubscriptionInput struct {
 	// The ARN of the topic for which you wish to confirm a subscription.
 	TopicARN *string `locationName:"TopicArn" type:"string" required:"true"`
 
-	metadataConfirmSubscriptionInput `json:"-", xml:"-"`
+	metadataConfirmSubscriptionInput `json:"-" xml:"-"`
 }
 
 type metadataConfirmSubscriptionInput struct {
@@ -982,7 +982,7 @@ type ConfirmSubscriptionOutput struct {
 	// The ARN of the created subscription.
 	SubscriptionARN *string `locationName:"SubscriptionArn" type:"string"`
 
-	metadataConfirmSubscriptionOutput `json:"-", xml:"-"`
+	metadataConfirmSubscriptionOutput `json:"-" xml:"-"`
 }
 
 type metadataConfirmSubscriptionOutput struct {
@@ -1003,7 +1003,7 @@ type CreatePlatformApplicationInput struct {
 	// (Apple Push Notification Service), APNS_SANDBOX, and GCM (Google Cloud Messaging).
 	Platform *string `type:"string" required:"true"`
 
-	metadataCreatePlatformApplicationInput `json:"-", xml:"-"`
+	metadataCreatePlatformApplicationInput `json:"-" xml:"-"`
 }
 
 type metadataCreatePlatformApplicationInput struct {
@@ -1015,7 +1015,7 @@ type CreatePlatformApplicationOutput struct {
 	// PlatformApplicationArn is returned.
 	PlatformApplicationARN *string `locationName:"PlatformApplicationArn" type:"string"`
 
-	metadataCreatePlatformApplicationOutput `json:"-", xml:"-"`
+	metadataCreatePlatformApplicationOutput `json:"-" xml:"-"`
 }
 
 type metadataCreatePlatformApplicationOutput struct {
@@ -1042,7 +1042,7 @@ type CreatePlatformEndpointInput struct {
 	// token equivalent is called the registration ID.
 	Token *string `type:"string" required:"true"`
 
-	metadataCreatePlatformEndpointInput `json:"-", xml:"-"`
+	metadataCreatePlatformEndpointInput `json:"-" xml:"-"`
 }
 
 type metadataCreatePlatformEndpointInput struct {
@@ -1054,7 +1054,7 @@ type CreatePlatformEndpointOutput struct {
 	// EndpointArn returned from CreateEndpoint action.
 	EndpointARN *string `locationName:"EndpointArn" type:"string"`
 
-	metadataCreatePlatformEndpointOutput `json:"-", xml:"-"`
+	metadataCreatePlatformEndpointOutput `json:"-" xml:"-"`
 }
 
 type metadataCreatePlatformEndpointOutput struct {
@@ -1070,7 +1070,7 @@ type CreateTopicInput struct {
 	// 256 characters long.
 	Name *string `type:"string" required:"true"`
 
-	metadataCreateTopicInput `json:"-", xml:"-"`
+	metadataCreateTopicInput `json:"-" xml:"-"`
 }
 
 type metadataCreateTopicInput struct {
@@ -1082,7 +1082,7 @@ type CreateTopicOutput struct {
 	// The Amazon Resource Name (ARN) assigned to the created topic.
 	TopicARN *string `locationName:"TopicArn" type:"string"`
 
-	metadataCreateTopicOutput `json:"-", xml:"-"`
+	metadataCreateTopicOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateTopicOutput struct {
@@ -1094,7 +1094,7 @@ type DeleteEndpointInput struct {
 	// EndpointArn of endpoint to delete.
 	EndpointARN *string `locationName:"EndpointArn" type:"string" required:"true"`
 
-	metadataDeleteEndpointInput `json:"-", xml:"-"`
+	metadataDeleteEndpointInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteEndpointInput struct {
@@ -1102,7 +1102,7 @@ type metadataDeleteEndpointInput struct {
 }
 
 type DeleteEndpointOutput struct {
-	metadataDeleteEndpointOutput `json:"-", xml:"-"`
+	metadataDeleteEndpointOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteEndpointOutput struct {
@@ -1114,7 +1114,7 @@ type DeletePlatformApplicationInput struct {
 	// PlatformApplicationArn of platform application object to delete.
 	PlatformApplicationARN *string `locationName:"PlatformApplicationArn" type:"string" required:"true"`
 
-	metadataDeletePlatformApplicationInput `json:"-", xml:"-"`
+	metadataDeletePlatformApplicationInput `json:"-" xml:"-"`
 }
 
 type metadataDeletePlatformApplicationInput struct {
@@ -1122,7 +1122,7 @@ type metadataDeletePlatformApplicationInput struct {
 }
 
 type DeletePlatformApplicationOutput struct {
-	metadataDeletePlatformApplicationOutput `json:"-", xml:"-"`
+	metadataDeletePlatformApplicationOutput `json:"-" xml:"-"`
 }
 
 type metadataDeletePlatformApplicationOutput struct {
@@ -1133,7 +1133,7 @@ type DeleteTopicInput struct {
 	// The ARN of the topic you want to delete.
 	TopicARN *string `locationName:"TopicArn" type:"string" required:"true"`
 
-	metadataDeleteTopicInput `json:"-", xml:"-"`
+	metadataDeleteTopicInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteTopicInput struct {
@@ -1141,7 +1141,7 @@ type metadataDeleteTopicInput struct {
 }
 
 type DeleteTopicOutput struct {
-	metadataDeleteTopicOutput `json:"-", xml:"-"`
+	metadataDeleteTopicOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteTopicOutput struct {
@@ -1156,7 +1156,7 @@ type Endpoint struct {
 	// EndpointArn for mobile app and device.
 	EndpointARN *string `locationName:"EndpointArn" type:"string"`
 
-	metadataEndpoint `json:"-", xml:"-"`
+	metadataEndpoint `json:"-" xml:"-"`
 }
 
 type metadataEndpoint struct {
@@ -1168,7 +1168,7 @@ type GetEndpointAttributesInput struct {
 	// EndpointArn for GetEndpointAttributes input.
 	EndpointARN *string `locationName:"EndpointArn" type:"string" required:"true"`
 
-	metadataGetEndpointAttributesInput `json:"-", xml:"-"`
+	metadataGetEndpointAttributesInput `json:"-" xml:"-"`
 }
 
 type metadataGetEndpointAttributesInput struct {
@@ -1190,7 +1190,7 @@ type GetEndpointAttributesOutput struct {
 	// service.
 	Attributes *map[string]*string `type:"map"`
 
-	metadataGetEndpointAttributesOutput `json:"-", xml:"-"`
+	metadataGetEndpointAttributesOutput `json:"-" xml:"-"`
 }
 
 type metadataGetEndpointAttributesOutput struct {
@@ -1202,7 +1202,7 @@ type GetPlatformApplicationAttributesInput struct {
 	// PlatformApplicationArn for GetPlatformApplicationAttributesInput.
 	PlatformApplicationARN *string `locationName:"PlatformApplicationArn" type:"string" required:"true"`
 
-	metadataGetPlatformApplicationAttributesInput `json:"-", xml:"-"`
+	metadataGetPlatformApplicationAttributesInput `json:"-" xml:"-"`
 }
 
 type metadataGetPlatformApplicationAttributesInput struct {
@@ -1222,7 +1222,7 @@ type GetPlatformApplicationAttributesOutput struct {
 	// endpoints.
 	Attributes *map[string]*string `type:"map"`
 
-	metadataGetPlatformApplicationAttributesOutput `json:"-", xml:"-"`
+	metadataGetPlatformApplicationAttributesOutput `json:"-" xml:"-"`
 }
 
 type metadataGetPlatformApplicationAttributesOutput struct {
@@ -1234,7 +1234,7 @@ type GetSubscriptionAttributesInput struct {
 	// The ARN of the subscription whose properties you want to get.
 	SubscriptionARN *string `locationName:"SubscriptionArn" type:"string" required:"true"`
 
-	metadataGetSubscriptionAttributesInput `json:"-", xml:"-"`
+	metadataGetSubscriptionAttributesInput `json:"-" xml:"-"`
 }
 
 type metadataGetSubscriptionAttributesInput struct {
@@ -1255,7 +1255,7 @@ type GetSubscriptionAttributesOutput struct {
 	// policy and account system defaults
 	Attributes *map[string]*string `type:"map"`
 
-	metadataGetSubscriptionAttributesOutput `json:"-", xml:"-"`
+	metadataGetSubscriptionAttributesOutput `json:"-" xml:"-"`
 }
 
 type metadataGetSubscriptionAttributesOutput struct {
@@ -1267,7 +1267,7 @@ type GetTopicAttributesInput struct {
 	// The ARN of the topic whose properties you want to get.
 	TopicARN *string `locationName:"TopicArn" type:"string" required:"true"`
 
-	metadataGetTopicAttributesInput `json:"-", xml:"-"`
+	metadataGetTopicAttributesInput `json:"-" xml:"-"`
 }
 
 type metadataGetTopicAttributesInput struct {
@@ -1290,7 +1290,7 @@ type GetTopicAttributesOutput struct {
 	// account system defaults
 	Attributes *map[string]*string `type:"map"`
 
-	metadataGetTopicAttributesOutput `json:"-", xml:"-"`
+	metadataGetTopicAttributesOutput `json:"-" xml:"-"`
 }
 
 type metadataGetTopicAttributesOutput struct {
@@ -1307,7 +1307,7 @@ type ListEndpointsByPlatformApplicationInput struct {
 	// PlatformApplicationArn for ListEndpointsByPlatformApplicationInput action.
 	PlatformApplicationARN *string `locationName:"PlatformApplicationArn" type:"string" required:"true"`
 
-	metadataListEndpointsByPlatformApplicationInput `json:"-", xml:"-"`
+	metadataListEndpointsByPlatformApplicationInput `json:"-" xml:"-"`
 }
 
 type metadataListEndpointsByPlatformApplicationInput struct {
@@ -1323,7 +1323,7 @@ type ListEndpointsByPlatformApplicationOutput struct {
 	// action if additional records are available after the first page results.
 	NextToken *string `type:"string"`
 
-	metadataListEndpointsByPlatformApplicationOutput `json:"-", xml:"-"`
+	metadataListEndpointsByPlatformApplicationOutput `json:"-" xml:"-"`
 }
 
 type metadataListEndpointsByPlatformApplicationOutput struct {
@@ -1336,7 +1336,7 @@ type ListPlatformApplicationsInput struct {
 	// retrieve additional records that are available after the first page results.
 	NextToken *string `type:"string"`
 
-	metadataListPlatformApplicationsInput `json:"-", xml:"-"`
+	metadataListPlatformApplicationsInput `json:"-" xml:"-"`
 }
 
 type metadataListPlatformApplicationsInput struct {
@@ -1352,7 +1352,7 @@ type ListPlatformApplicationsOutput struct {
 	// Platform applications returned when calling ListPlatformApplications action.
 	PlatformApplications []*PlatformApplication `type:"list"`
 
-	metadataListPlatformApplicationsOutput `json:"-", xml:"-"`
+	metadataListPlatformApplicationsOutput `json:"-" xml:"-"`
 }
 
 type metadataListPlatformApplicationsOutput struct {
@@ -1367,7 +1367,7 @@ type ListSubscriptionsByTopicInput struct {
 	// The ARN of the topic for which you wish to find subscriptions.
 	TopicARN *string `locationName:"TopicArn" type:"string" required:"true"`
 
-	metadataListSubscriptionsByTopicInput `json:"-", xml:"-"`
+	metadataListSubscriptionsByTopicInput `json:"-" xml:"-"`
 }
 
 type metadataListSubscriptionsByTopicInput struct {
@@ -1383,7 +1383,7 @@ type ListSubscriptionsByTopicOutput struct {
 	// A list of subscriptions.
 	Subscriptions []*Subscription `type:"list"`
 
-	metadataListSubscriptionsByTopicOutput `json:"-", xml:"-"`
+	metadataListSubscriptionsByTopicOutput `json:"-" xml:"-"`
 }
 
 type metadataListSubscriptionsByTopicOutput struct {
@@ -1395,7 +1395,7 @@ type ListSubscriptionsInput struct {
 	// Token returned by the previous ListSubscriptions request.
 	NextToken *string `type:"string"`
 
-	metadataListSubscriptionsInput `json:"-", xml:"-"`
+	metadataListSubscriptionsInput `json:"-" xml:"-"`
 }
 
 type metadataListSubscriptionsInput struct {
@@ -1411,7 +1411,7 @@ type ListSubscriptionsOutput struct {
 	// A list of subscriptions.
 	Subscriptions []*Subscription `type:"list"`
 
-	metadataListSubscriptionsOutput `json:"-", xml:"-"`
+	metadataListSubscriptionsOutput `json:"-" xml:"-"`
 }
 
 type metadataListSubscriptionsOutput struct {
@@ -1422,7 +1422,7 @@ type ListTopicsInput struct {
 	// Token returned by the previous ListTopics request.
 	NextToken *string `type:"string"`
 
-	metadataListTopicsInput `json:"-", xml:"-"`
+	metadataListTopicsInput `json:"-" xml:"-"`
 }
 
 type metadataListTopicsInput struct {
@@ -1438,7 +1438,7 @@ type ListTopicsOutput struct {
 	// A list of topic ARNs.
 	Topics []*Topic `type:"list"`
 
-	metadataListTopicsOutput `json:"-", xml:"-"`
+	metadataListTopicsOutput `json:"-" xml:"-"`
 }
 
 type metadataListTopicsOutput struct {
@@ -1467,7 +1467,7 @@ type MessageAttributeValue struct {
 	// see http://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters (http://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters).
 	StringValue *string `type:"string"`
 
-	metadataMessageAttributeValue `json:"-", xml:"-"`
+	metadataMessageAttributeValue `json:"-" xml:"-"`
 }
 
 type metadataMessageAttributeValue struct {
@@ -1482,7 +1482,7 @@ type PlatformApplication struct {
 	// PlatformApplicationArn for platform application object.
 	PlatformApplicationARN *string `locationName:"PlatformApplicationArn" type:"string"`
 
-	metadataPlatformApplication `json:"-", xml:"-"`
+	metadataPlatformApplication `json:"-" xml:"-"`
 }
 
 type metadataPlatformApplication struct {
@@ -1553,7 +1553,7 @@ type PublishInput struct {
 	// The topic you want to publish to.
 	TopicARN *string `locationName:"TopicArn" type:"string"`
 
-	metadataPublishInput `json:"-", xml:"-"`
+	metadataPublishInput `json:"-" xml:"-"`
 }
 
 type metadataPublishInput struct {
@@ -1567,7 +1567,7 @@ type PublishOutput struct {
 	// Length Constraint: Maximum 100 characters
 	MessageID *string `locationName:"MessageId" type:"string"`
 
-	metadataPublishOutput `json:"-", xml:"-"`
+	metadataPublishOutput `json:"-" xml:"-"`
 }
 
 type metadataPublishOutput struct {
@@ -1582,7 +1582,7 @@ type RemovePermissionInput struct {
 	// The ARN of the topic whose access control policy you wish to modify.
 	TopicARN *string `locationName:"TopicArn" type:"string" required:"true"`
 
-	metadataRemovePermissionInput `json:"-", xml:"-"`
+	metadataRemovePermissionInput `json:"-" xml:"-"`
 }
 
 type metadataRemovePermissionInput struct {
@@ -1590,7 +1590,7 @@ type metadataRemovePermissionInput struct {
 }
 
 type RemovePermissionOutput struct {
-	metadataRemovePermissionOutput `json:"-", xml:"-"`
+	metadataRemovePermissionOutput `json:"-" xml:"-"`
 }
 
 type metadataRemovePermissionOutput struct {
@@ -1615,7 +1615,7 @@ type SetEndpointAttributesInput struct {
 	// EndpointArn used for SetEndpointAttributes action.
 	EndpointARN *string `locationName:"EndpointArn" type:"string" required:"true"`
 
-	metadataSetEndpointAttributesInput `json:"-", xml:"-"`
+	metadataSetEndpointAttributesInput `json:"-" xml:"-"`
 }
 
 type metadataSetEndpointAttributesInput struct {
@@ -1623,7 +1623,7 @@ type metadataSetEndpointAttributesInput struct {
 }
 
 type SetEndpointAttributesOutput struct {
-	metadataSetEndpointAttributesOutput `json:"-", xml:"-"`
+	metadataSetEndpointAttributesOutput `json:"-" xml:"-"`
 }
 
 type metadataSetEndpointAttributesOutput struct {
@@ -1652,7 +1652,7 @@ type SetPlatformApplicationAttributesInput struct {
 	// PlatformApplicationArn for SetPlatformApplicationAttributes action.
 	PlatformApplicationARN *string `locationName:"PlatformApplicationArn" type:"string" required:"true"`
 
-	metadataSetPlatformApplicationAttributesInput `json:"-", xml:"-"`
+	metadataSetPlatformApplicationAttributesInput `json:"-" xml:"-"`
 }
 
 type metadataSetPlatformApplicationAttributesInput struct {
@@ -1660,7 +1660,7 @@ type metadataSetPlatformApplicationAttributesInput struct {
 }
 
 type SetPlatformApplicationAttributesOutput struct {
-	metadataSetPlatformApplicationAttributesOutput `json:"-", xml:"-"`
+	metadataSetPlatformApplicationAttributesOutput `json:"-" xml:"-"`
 }
 
 type metadataSetPlatformApplicationAttributesOutput struct {
@@ -1681,7 +1681,7 @@ type SetSubscriptionAttributesInput struct {
 	// The ARN of the subscription to modify.
 	SubscriptionARN *string `locationName:"SubscriptionArn" type:"string" required:"true"`
 
-	metadataSetSubscriptionAttributesInput `json:"-", xml:"-"`
+	metadataSetSubscriptionAttributesInput `json:"-" xml:"-"`
 }
 
 type metadataSetSubscriptionAttributesInput struct {
@@ -1689,7 +1689,7 @@ type metadataSetSubscriptionAttributesInput struct {
 }
 
 type SetSubscriptionAttributesOutput struct {
-	metadataSetSubscriptionAttributesOutput `json:"-", xml:"-"`
+	metadataSetSubscriptionAttributesOutput `json:"-" xml:"-"`
 }
 
 type metadataSetSubscriptionAttributesOutput struct {
@@ -1710,7 +1710,7 @@ type SetTopicAttributesInput struct {
 	// The ARN of the topic to modify.
 	TopicARN *string `locationName:"TopicArn" type:"string" required:"true"`
 
-	metadataSetTopicAttributesInput `json:"-", xml:"-"`
+	metadataSetTopicAttributesInput `json:"-" xml:"-"`
 }
 
 type metadataSetTopicAttributesInput struct {
@@ -1718,7 +1718,7 @@ type metadataSetTopicAttributesInput struct {
 }
 
 type SetTopicAttributesOutput struct {
-	metadataSetTopicAttributesOutput `json:"-", xml:"-"`
+	metadataSetTopicAttributesOutput `json:"-" xml:"-"`
 }
 
 type metadataSetTopicAttributesOutput struct {
@@ -1751,7 +1751,7 @@ type SubscribeInput struct {
 	// The ARN of the topic you want to subscribe to.
 	TopicARN *string `locationName:"TopicArn" type:"string" required:"true"`
 
-	metadataSubscribeInput `json:"-", xml:"-"`
+	metadataSubscribeInput `json:"-" xml:"-"`
 }
 
 type metadataSubscribeInput struct {
@@ -1764,7 +1764,7 @@ type SubscribeOutput struct {
 	// immediately (without requiring endpoint owner confirmation).
 	SubscriptionARN *string `locationName:"SubscriptionArn" type:"string"`
 
-	metadataSubscribeOutput `json:"-", xml:"-"`
+	metadataSubscribeOutput `json:"-" xml:"-"`
 }
 
 type metadataSubscribeOutput struct {
@@ -1788,7 +1788,7 @@ type Subscription struct {
 	// The ARN of the subscription's topic.
 	TopicARN *string `locationName:"TopicArn" type:"string"`
 
-	metadataSubscription `json:"-", xml:"-"`
+	metadataSubscription `json:"-" xml:"-"`
 }
 
 type metadataSubscription struct {
@@ -1801,7 +1801,7 @@ type Topic struct {
 	// The topic's ARN.
 	TopicARN *string `locationName:"TopicArn" type:"string"`
 
-	metadataTopic `json:"-", xml:"-"`
+	metadataTopic `json:"-" xml:"-"`
 }
 
 type metadataTopic struct {
@@ -1813,7 +1813,7 @@ type UnsubscribeInput struct {
 	// The ARN of the subscription to be deleted.
 	SubscriptionARN *string `locationName:"SubscriptionArn" type:"string" required:"true"`
 
-	metadataUnsubscribeInput `json:"-", xml:"-"`
+	metadataUnsubscribeInput `json:"-" xml:"-"`
 }
 
 type metadataUnsubscribeInput struct {
@@ -1821,7 +1821,7 @@ type metadataUnsubscribeInput struct {
 }
 
 type UnsubscribeOutput struct {
-	metadataUnsubscribeOutput `json:"-", xml:"-"`
+	metadataUnsubscribeOutput `json:"-" xml:"-"`
 }
 
 type metadataUnsubscribeOutput struct {

--- a/service/sqs/api.go
+++ b/service/sqs/api.go
@@ -868,7 +868,7 @@ type AddPermissionInput struct {
 	// The URL of the Amazon SQS queue to take action on.
 	QueueURL *string `locationName:"QueueUrl" type:"string" required:"true"`
 
-	metadataAddPermissionInput `json:"-", xml:"-"`
+	metadataAddPermissionInput `json:"-" xml:"-"`
 }
 
 type metadataAddPermissionInput struct {
@@ -876,7 +876,7 @@ type metadataAddPermissionInput struct {
 }
 
 type AddPermissionOutput struct {
-	metadataAddPermissionOutput `json:"-", xml:"-"`
+	metadataAddPermissionOutput `json:"-" xml:"-"`
 }
 
 type metadataAddPermissionOutput struct {
@@ -898,7 +898,7 @@ type BatchResultErrorEntry struct {
 	// Whether the error happened due to the sender's fault.
 	SenderFault *bool `type:"boolean" required:"true"`
 
-	metadataBatchResultErrorEntry `json:"-", xml:"-"`
+	metadataBatchResultErrorEntry `json:"-" xml:"-"`
 }
 
 type metadataBatchResultErrorEntry struct {
@@ -913,7 +913,7 @@ type ChangeMessageVisibilityBatchInput struct {
 	// The URL of the Amazon SQS queue to take action on.
 	QueueURL *string `locationName:"QueueUrl" type:"string" required:"true"`
 
-	metadataChangeMessageVisibilityBatchInput `json:"-", xml:"-"`
+	metadataChangeMessageVisibilityBatchInput `json:"-" xml:"-"`
 }
 
 type metadataChangeMessageVisibilityBatchInput struct {
@@ -930,7 +930,7 @@ type ChangeMessageVisibilityBatchOutput struct {
 	// A list of ChangeMessageVisibilityBatchResultEntry items.
 	Successful []*ChangeMessageVisibilityBatchResultEntry `locationNameList:"ChangeMessageVisibilityBatchResultEntry" type:"list" flattened:"true" required:"true"`
 
-	metadataChangeMessageVisibilityBatchOutput `json:"-", xml:"-"`
+	metadataChangeMessageVisibilityBatchOutput `json:"-" xml:"-"`
 }
 
 type metadataChangeMessageVisibilityBatchOutput struct {
@@ -961,7 +961,7 @@ type ChangeMessageVisibilityBatchRequestEntry struct {
 	// The new value (in seconds) for the message's visibility timeout.
 	VisibilityTimeout *int64 `type:"integer"`
 
-	metadataChangeMessageVisibilityBatchRequestEntry `json:"-", xml:"-"`
+	metadataChangeMessageVisibilityBatchRequestEntry `json:"-" xml:"-"`
 }
 
 type metadataChangeMessageVisibilityBatchRequestEntry struct {
@@ -973,7 +973,7 @@ type ChangeMessageVisibilityBatchResultEntry struct {
 	// Represents a message whose visibility timeout has been changed successfully.
 	ID *string `locationName:"Id" type:"string" required:"true"`
 
-	metadataChangeMessageVisibilityBatchResultEntry `json:"-", xml:"-"`
+	metadataChangeMessageVisibilityBatchResultEntry `json:"-" xml:"-"`
 }
 
 type metadataChangeMessageVisibilityBatchResultEntry struct {
@@ -992,7 +992,7 @@ type ChangeMessageVisibilityInput struct {
 	// visibility timeout.
 	VisibilityTimeout *int64 `type:"integer" required:"true"`
 
-	metadataChangeMessageVisibilityInput `json:"-", xml:"-"`
+	metadataChangeMessageVisibilityInput `json:"-" xml:"-"`
 }
 
 type metadataChangeMessageVisibilityInput struct {
@@ -1000,7 +1000,7 @@ type metadataChangeMessageVisibilityInput struct {
 }
 
 type ChangeMessageVisibilityOutput struct {
-	metadataChangeMessageVisibilityOutput `json:"-", xml:"-"`
+	metadataChangeMessageVisibilityOutput `json:"-" xml:"-"`
 }
 
 type metadataChangeMessageVisibilityOutput struct {
@@ -1035,7 +1035,7 @@ type CreateQueueInput struct {
 	// The name for the queue to be created.
 	QueueName *string `type:"string" required:"true"`
 
-	metadataCreateQueueInput `json:"-", xml:"-"`
+	metadataCreateQueueInput `json:"-" xml:"-"`
 }
 
 type metadataCreateQueueInput struct {
@@ -1047,7 +1047,7 @@ type CreateQueueOutput struct {
 	// The URL for the created Amazon SQS queue.
 	QueueURL *string `locationName:"QueueUrl" type:"string"`
 
-	metadataCreateQueueOutput `json:"-", xml:"-"`
+	metadataCreateQueueOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateQueueOutput struct {
@@ -1061,7 +1061,7 @@ type DeleteMessageBatchInput struct {
 	// The URL of the Amazon SQS queue to take action on.
 	QueueURL *string `locationName:"QueueUrl" type:"string" required:"true"`
 
-	metadataDeleteMessageBatchInput `json:"-", xml:"-"`
+	metadataDeleteMessageBatchInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteMessageBatchInput struct {
@@ -1078,7 +1078,7 @@ type DeleteMessageBatchOutput struct {
 	// A list of DeleteMessageBatchResultEntry items.
 	Successful []*DeleteMessageBatchResultEntry `locationNameList:"DeleteMessageBatchResultEntry" type:"list" flattened:"true" required:"true"`
 
-	metadataDeleteMessageBatchOutput `json:"-", xml:"-"`
+	metadataDeleteMessageBatchOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteMessageBatchOutput struct {
@@ -1095,7 +1095,7 @@ type DeleteMessageBatchRequestEntry struct {
 	// A receipt handle.
 	ReceiptHandle *string `type:"string" required:"true"`
 
-	metadataDeleteMessageBatchRequestEntry `json:"-", xml:"-"`
+	metadataDeleteMessageBatchRequestEntry `json:"-" xml:"-"`
 }
 
 type metadataDeleteMessageBatchRequestEntry struct {
@@ -1107,7 +1107,7 @@ type DeleteMessageBatchResultEntry struct {
 	// Represents a successfully deleted message.
 	ID *string `locationName:"Id" type:"string" required:"true"`
 
-	metadataDeleteMessageBatchResultEntry `json:"-", xml:"-"`
+	metadataDeleteMessageBatchResultEntry `json:"-" xml:"-"`
 }
 
 type metadataDeleteMessageBatchResultEntry struct {
@@ -1121,7 +1121,7 @@ type DeleteMessageInput struct {
 	// The receipt handle associated with the message to delete.
 	ReceiptHandle *string `type:"string" required:"true"`
 
-	metadataDeleteMessageInput `json:"-", xml:"-"`
+	metadataDeleteMessageInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteMessageInput struct {
@@ -1129,7 +1129,7 @@ type metadataDeleteMessageInput struct {
 }
 
 type DeleteMessageOutput struct {
-	metadataDeleteMessageOutput `json:"-", xml:"-"`
+	metadataDeleteMessageOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteMessageOutput struct {
@@ -1140,7 +1140,7 @@ type DeleteQueueInput struct {
 	// The URL of the Amazon SQS queue to take action on.
 	QueueURL *string `locationName:"QueueUrl" type:"string" required:"true"`
 
-	metadataDeleteQueueInput `json:"-", xml:"-"`
+	metadataDeleteQueueInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteQueueInput struct {
@@ -1148,7 +1148,7 @@ type metadataDeleteQueueInput struct {
 }
 
 type DeleteQueueOutput struct {
-	metadataDeleteQueueOutput `json:"-", xml:"-"`
+	metadataDeleteQueueOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteQueueOutput struct {
@@ -1162,7 +1162,7 @@ type GetQueueAttributesInput struct {
 	// The URL of the Amazon SQS queue to take action on.
 	QueueURL *string `locationName:"QueueUrl" type:"string" required:"true"`
 
-	metadataGetQueueAttributesInput `json:"-", xml:"-"`
+	metadataGetQueueAttributesInput `json:"-" xml:"-"`
 }
 
 type metadataGetQueueAttributesInput struct {
@@ -1174,7 +1174,7 @@ type GetQueueAttributesOutput struct {
 	// A map of attributes to the respective values.
 	Attributes *map[string]*string `locationName:"Attribute" locationNameKey:"Name" locationNameValue:"Value" type:"map" flattened:"true"`
 
-	metadataGetQueueAttributesOutput `json:"-", xml:"-"`
+	metadataGetQueueAttributesOutput `json:"-" xml:"-"`
 }
 
 type metadataGetQueueAttributesOutput struct {
@@ -1189,7 +1189,7 @@ type GetQueueURLInput struct {
 	// The AWS account ID of the account that created the queue.
 	QueueOwnerAWSAccountID *string `locationName:"QueueOwnerAWSAccountId" type:"string"`
 
-	metadataGetQueueURLInput `json:"-", xml:"-"`
+	metadataGetQueueURLInput `json:"-" xml:"-"`
 }
 
 type metadataGetQueueURLInput struct {
@@ -1202,7 +1202,7 @@ type GetQueueURLOutput struct {
 	// The URL for the queue.
 	QueueURL *string `locationName:"QueueUrl" type:"string"`
 
-	metadataGetQueueURLOutput `json:"-", xml:"-"`
+	metadataGetQueueURLOutput `json:"-" xml:"-"`
 }
 
 type metadataGetQueueURLOutput struct {
@@ -1213,7 +1213,7 @@ type ListDeadLetterSourceQueuesInput struct {
 	// The queue URL of a dead letter queue.
 	QueueURL *string `locationName:"QueueUrl" type:"string" required:"true"`
 
-	metadataListDeadLetterSourceQueuesInput `json:"-", xml:"-"`
+	metadataListDeadLetterSourceQueuesInput `json:"-" xml:"-"`
 }
 
 type metadataListDeadLetterSourceQueuesInput struct {
@@ -1226,7 +1226,7 @@ type ListDeadLetterSourceQueuesOutput struct {
 	// with a dead letter queue.
 	QueueURLs []*string `locationName:"queueUrls" locationNameList:"QueueUrl" type:"list" flattened:"true" required:"true"`
 
-	metadataListDeadLetterSourceQueuesOutput `json:"-", xml:"-"`
+	metadataListDeadLetterSourceQueuesOutput `json:"-" xml:"-"`
 }
 
 type metadataListDeadLetterSourceQueuesOutput struct {
@@ -1238,7 +1238,7 @@ type ListQueuesInput struct {
 	// begins with the specified string are returned.
 	QueueNamePrefix *string `type:"string"`
 
-	metadataListQueuesInput `json:"-", xml:"-"`
+	metadataListQueuesInput `json:"-" xml:"-"`
 }
 
 type metadataListQueuesInput struct {
@@ -1250,7 +1250,7 @@ type ListQueuesOutput struct {
 	// A list of queue URLs, up to 1000 entries.
 	QueueURLs []*string `locationName:"QueueUrls" locationNameList:"QueueUrl" type:"list" flattened:"true"`
 
-	metadataListQueuesOutput `json:"-", xml:"-"`
+	metadataListQueuesOutput `json:"-" xml:"-"`
 }
 
 type metadataListQueuesOutput struct {
@@ -1290,7 +1290,7 @@ type Message struct {
 	// you provide the last received receipt handle to delete the message.
 	ReceiptHandle *string `type:"string"`
 
-	metadataMessage `json:"-", xml:"-"`
+	metadataMessage `json:"-" xml:"-"`
 }
 
 type metadataMessage struct {
@@ -1325,7 +1325,7 @@ type MessageAttributeValue struct {
 	// see http://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters (http://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters).
 	StringValue *string `type:"string"`
 
-	metadataMessageAttributeValue `json:"-", xml:"-"`
+	metadataMessageAttributeValue `json:"-" xml:"-"`
 }
 
 type metadataMessageAttributeValue struct {
@@ -1337,7 +1337,7 @@ type PurgeQueueInput struct {
 	// API.
 	QueueURL *string `locationName:"QueueUrl" type:"string" required:"true"`
 
-	metadataPurgeQueueInput `json:"-", xml:"-"`
+	metadataPurgeQueueInput `json:"-" xml:"-"`
 }
 
 type metadataPurgeQueueInput struct {
@@ -1345,7 +1345,7 @@ type metadataPurgeQueueInput struct {
 }
 
 type PurgeQueueOutput struct {
-	metadataPurgeQueueOutput `json:"-", xml:"-"`
+	metadataPurgeQueueOutput `json:"-" xml:"-"`
 }
 
 type metadataPurgeQueueOutput struct {
@@ -1401,7 +1401,7 @@ type ReceiveMessageInput struct {
 	// sooner than WaitTimeSeconds.
 	WaitTimeSeconds *int64 `type:"integer"`
 
-	metadataReceiveMessageInput `json:"-", xml:"-"`
+	metadataReceiveMessageInput `json:"-" xml:"-"`
 }
 
 type metadataReceiveMessageInput struct {
@@ -1413,7 +1413,7 @@ type ReceiveMessageOutput struct {
 	// A list of messages.
 	Messages []*Message `locationNameList:"Message" type:"list" flattened:"true"`
 
-	metadataReceiveMessageOutput `json:"-", xml:"-"`
+	metadataReceiveMessageOutput `json:"-" xml:"-"`
 }
 
 type metadataReceiveMessageOutput struct {
@@ -1428,7 +1428,7 @@ type RemovePermissionInput struct {
 	// The URL of the Amazon SQS queue to take action on.
 	QueueURL *string `locationName:"QueueUrl" type:"string" required:"true"`
 
-	metadataRemovePermissionInput `json:"-", xml:"-"`
+	metadataRemovePermissionInput `json:"-" xml:"-"`
 }
 
 type metadataRemovePermissionInput struct {
@@ -1436,7 +1436,7 @@ type metadataRemovePermissionInput struct {
 }
 
 type RemovePermissionOutput struct {
-	metadataRemovePermissionOutput `json:"-", xml:"-"`
+	metadataRemovePermissionOutput `json:"-" xml:"-"`
 }
 
 type metadataRemovePermissionOutput struct {
@@ -1450,7 +1450,7 @@ type SendMessageBatchInput struct {
 	// The URL of the Amazon SQS queue to take action on.
 	QueueURL *string `locationName:"QueueUrl" type:"string" required:"true"`
 
-	metadataSendMessageBatchInput `json:"-", xml:"-"`
+	metadataSendMessageBatchInput `json:"-" xml:"-"`
 }
 
 type metadataSendMessageBatchInput struct {
@@ -1468,7 +1468,7 @@ type SendMessageBatchOutput struct {
 	// A list of SendMessageBatchResultEntry items.
 	Successful []*SendMessageBatchResultEntry `locationNameList:"SendMessageBatchResultEntry" type:"list" flattened:"true" required:"true"`
 
-	metadataSendMessageBatchOutput `json:"-", xml:"-"`
+	metadataSendMessageBatchOutput `json:"-" xml:"-"`
 }
 
 type metadataSendMessageBatchOutput struct {
@@ -1492,7 +1492,7 @@ type SendMessageBatchRequestEntry struct {
 	// Body of the message.
 	MessageBody *string `type:"string" required:"true"`
 
-	metadataSendMessageBatchRequestEntry `json:"-", xml:"-"`
+	metadataSendMessageBatchRequestEntry `json:"-" xml:"-"`
 }
 
 type metadataSendMessageBatchRequestEntry struct {
@@ -1519,7 +1519,7 @@ type SendMessageBatchResultEntry struct {
 	// An identifier for the message.
 	MessageID *string `locationName:"MessageId" type:"string" required:"true"`
 
-	metadataSendMessageBatchResultEntry `json:"-", xml:"-"`
+	metadataSendMessageBatchResultEntry `json:"-" xml:"-"`
 }
 
 type metadataSendMessageBatchResultEntry struct {
@@ -1544,7 +1544,7 @@ type SendMessageInput struct {
 	// The URL of the Amazon SQS queue to take action on.
 	QueueURL *string `locationName:"QueueUrl" type:"string" required:"true"`
 
-	metadataSendMessageInput `json:"-", xml:"-"`
+	metadataSendMessageInput `json:"-" xml:"-"`
 }
 
 type metadataSendMessageInput struct {
@@ -1570,7 +1570,7 @@ type SendMessageOutput struct {
 	// in the Amazon SQS Developer Guide.
 	MessageID *string `locationName:"MessageId" type:"string"`
 
-	metadataSendMessageOutput `json:"-", xml:"-"`
+	metadataSendMessageOutput `json:"-" xml:"-"`
 }
 
 type metadataSendMessageOutput struct {
@@ -1607,7 +1607,7 @@ type SetQueueAttributesInput struct {
 	// The URL of the Amazon SQS queue to take action on.
 	QueueURL *string `locationName:"QueueUrl" type:"string" required:"true"`
 
-	metadataSetQueueAttributesInput `json:"-", xml:"-"`
+	metadataSetQueueAttributesInput `json:"-" xml:"-"`
 }
 
 type metadataSetQueueAttributesInput struct {
@@ -1615,7 +1615,7 @@ type metadataSetQueueAttributesInput struct {
 }
 
 type SetQueueAttributesOutput struct {
-	metadataSetQueueAttributesOutput `json:"-", xml:"-"`
+	metadataSetQueueAttributesOutput `json:"-" xml:"-"`
 }
 
 type metadataSetQueueAttributesOutput struct {

--- a/service/ssm/api.go
+++ b/service/ssm/api.go
@@ -412,7 +412,7 @@ type Association struct {
 	// The name of the configuration document.
 	Name *string `type:"string"`
 
-	metadataAssociation `json:"-", xml:"-"`
+	metadataAssociation `json:"-" xml:"-"`
 }
 
 type metadataAssociation struct {
@@ -433,7 +433,7 @@ type AssociationDescription struct {
 	// The association status.
 	Status *AssociationStatus `type:"structure"`
 
-	metadataAssociationDescription `json:"-", xml:"-"`
+	metadataAssociationDescription `json:"-" xml:"-"`
 }
 
 type metadataAssociationDescription struct {
@@ -448,7 +448,7 @@ type AssociationFilter struct {
 	// The filter value.
 	Value *string `locationName:"value" type:"string" required:"true"`
 
-	metadataAssociationFilter `json:"-", xml:"-"`
+	metadataAssociationFilter `json:"-" xml:"-"`
 }
 
 type metadataAssociationFilter struct {
@@ -469,7 +469,7 @@ type AssociationStatus struct {
 	// The status.
 	Name *string `type:"string" required:"true"`
 
-	metadataAssociationStatus `json:"-", xml:"-"`
+	metadataAssociationStatus `json:"-" xml:"-"`
 }
 
 type metadataAssociationStatus struct {
@@ -480,7 +480,7 @@ type CreateAssociationBatchInput struct {
 	// One or more associations.
 	Entries []*CreateAssociationBatchRequestEntry `locationNameList:"entries" type:"list" required:"true"`
 
-	metadataCreateAssociationBatchInput `json:"-", xml:"-"`
+	metadataCreateAssociationBatchInput `json:"-" xml:"-"`
 }
 
 type metadataCreateAssociationBatchInput struct {
@@ -494,7 +494,7 @@ type CreateAssociationBatchOutput struct {
 	// Information about the associations that succeeded.
 	Successful []*AssociationDescription `locationNameList:"AssociationDescription" type:"list"`
 
-	metadataCreateAssociationBatchOutput `json:"-", xml:"-"`
+	metadataCreateAssociationBatchOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateAssociationBatchOutput struct {
@@ -509,7 +509,7 @@ type CreateAssociationBatchRequestEntry struct {
 	// The name of the configuration document.
 	Name *string `type:"string"`
 
-	metadataCreateAssociationBatchRequestEntry `json:"-", xml:"-"`
+	metadataCreateAssociationBatchRequestEntry `json:"-" xml:"-"`
 }
 
 type metadataCreateAssociationBatchRequestEntry struct {
@@ -523,7 +523,7 @@ type CreateAssociationInput struct {
 	// The name of the configuration document.
 	Name *string `type:"string" required:"true"`
 
-	metadataCreateAssociationInput `json:"-", xml:"-"`
+	metadataCreateAssociationInput `json:"-" xml:"-"`
 }
 
 type metadataCreateAssociationInput struct {
@@ -534,7 +534,7 @@ type CreateAssociationOutput struct {
 	// Information about the association.
 	AssociationDescription *AssociationDescription `type:"structure"`
 
-	metadataCreateAssociationOutput `json:"-", xml:"-"`
+	metadataCreateAssociationOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateAssociationOutput struct {
@@ -549,7 +549,7 @@ type CreateDocumentInput struct {
 	// A name for the configuration document.
 	Name *string `type:"string" required:"true"`
 
-	metadataCreateDocumentInput `json:"-", xml:"-"`
+	metadataCreateDocumentInput `json:"-" xml:"-"`
 }
 
 type metadataCreateDocumentInput struct {
@@ -560,7 +560,7 @@ type CreateDocumentOutput struct {
 	// Information about the configuration document.
 	DocumentDescription *DocumentDescription `type:"structure"`
 
-	metadataCreateDocumentOutput `json:"-", xml:"-"`
+	metadataCreateDocumentOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateDocumentOutput struct {
@@ -574,7 +574,7 @@ type DeleteAssociationInput struct {
 	// The name of the configuration document.
 	Name *string `type:"string" required:"true"`
 
-	metadataDeleteAssociationInput `json:"-", xml:"-"`
+	metadataDeleteAssociationInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteAssociationInput struct {
@@ -582,7 +582,7 @@ type metadataDeleteAssociationInput struct {
 }
 
 type DeleteAssociationOutput struct {
-	metadataDeleteAssociationOutput `json:"-", xml:"-"`
+	metadataDeleteAssociationOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteAssociationOutput struct {
@@ -593,7 +593,7 @@ type DeleteDocumentInput struct {
 	// The name of the configuration document.
 	Name *string `type:"string" required:"true"`
 
-	metadataDeleteDocumentInput `json:"-", xml:"-"`
+	metadataDeleteDocumentInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteDocumentInput struct {
@@ -601,7 +601,7 @@ type metadataDeleteDocumentInput struct {
 }
 
 type DeleteDocumentOutput struct {
-	metadataDeleteDocumentOutput `json:"-", xml:"-"`
+	metadataDeleteDocumentOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteDocumentOutput struct {
@@ -615,7 +615,7 @@ type DescribeAssociationInput struct {
 	// The name of the configuration document.
 	Name *string `type:"string" required:"true"`
 
-	metadataDescribeAssociationInput `json:"-", xml:"-"`
+	metadataDescribeAssociationInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeAssociationInput struct {
@@ -626,7 +626,7 @@ type DescribeAssociationOutput struct {
 	// Information about the association.
 	AssociationDescription *AssociationDescription `type:"structure"`
 
-	metadataDescribeAssociationOutput `json:"-", xml:"-"`
+	metadataDescribeAssociationOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeAssociationOutput struct {
@@ -637,7 +637,7 @@ type DescribeDocumentInput struct {
 	// The name of the configuration document.
 	Name *string `type:"string" required:"true"`
 
-	metadataDescribeDocumentInput `json:"-", xml:"-"`
+	metadataDescribeDocumentInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeDocumentInput struct {
@@ -648,7 +648,7 @@ type DescribeDocumentOutput struct {
 	// Information about the configuration document.
 	Document *DocumentDescription `type:"structure"`
 
-	metadataDescribeDocumentOutput `json:"-", xml:"-"`
+	metadataDescribeDocumentOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeDocumentOutput struct {
@@ -669,7 +669,7 @@ type DocumentDescription struct {
 	// The status of the configuration document.
 	Status *string `type:"string"`
 
-	metadataDocumentDescription `json:"-", xml:"-"`
+	metadataDocumentDescription `json:"-" xml:"-"`
 }
 
 type metadataDocumentDescription struct {
@@ -684,7 +684,7 @@ type DocumentFilter struct {
 	// The value of the filter.
 	Value *string `locationName:"value" type:"string" required:"true"`
 
-	metadataDocumentFilter `json:"-", xml:"-"`
+	metadataDocumentFilter `json:"-" xml:"-"`
 }
 
 type metadataDocumentFilter struct {
@@ -696,7 +696,7 @@ type DocumentIdentifier struct {
 	// The name of the configuration document.
 	Name *string `type:"string"`
 
-	metadataDocumentIdentifier `json:"-", xml:"-"`
+	metadataDocumentIdentifier `json:"-" xml:"-"`
 }
 
 type metadataDocumentIdentifier struct {
@@ -714,7 +714,7 @@ type FailedCreateAssociation struct {
 	// A description of the failure.
 	Message *string `type:"string"`
 
-	metadataFailedCreateAssociation `json:"-", xml:"-"`
+	metadataFailedCreateAssociation `json:"-" xml:"-"`
 }
 
 type metadataFailedCreateAssociation struct {
@@ -725,7 +725,7 @@ type GetDocumentInput struct {
 	// The name of the configuration document.
 	Name *string `type:"string" required:"true"`
 
-	metadataGetDocumentInput `json:"-", xml:"-"`
+	metadataGetDocumentInput `json:"-" xml:"-"`
 }
 
 type metadataGetDocumentInput struct {
@@ -739,7 +739,7 @@ type GetDocumentOutput struct {
 	// The name of the configuration document.
 	Name *string `type:"string"`
 
-	metadataGetDocumentOutput `json:"-", xml:"-"`
+	metadataGetDocumentOutput `json:"-" xml:"-"`
 }
 
 type metadataGetDocumentOutput struct {
@@ -759,7 +759,7 @@ type ListAssociationsInput struct {
 	// a previous call.)
 	NextToken *string `type:"string"`
 
-	metadataListAssociationsInput `json:"-", xml:"-"`
+	metadataListAssociationsInput `json:"-" xml:"-"`
 }
 
 type metadataListAssociationsInput struct {
@@ -774,7 +774,7 @@ type ListAssociationsOutput struct {
 	// items to return, the string is empty.
 	NextToken *string `type:"string"`
 
-	metadataListAssociationsOutput `json:"-", xml:"-"`
+	metadataListAssociationsOutput `json:"-" xml:"-"`
 }
 
 type metadataListAssociationsOutput struct {
@@ -794,7 +794,7 @@ type ListDocumentsInput struct {
 	// a previous call.)
 	NextToken *string `type:"string"`
 
-	metadataListDocumentsInput `json:"-", xml:"-"`
+	metadataListDocumentsInput `json:"-" xml:"-"`
 }
 
 type metadataListDocumentsInput struct {
@@ -809,7 +809,7 @@ type ListDocumentsOutput struct {
 	// items to return, the string is empty.
 	NextToken *string `type:"string"`
 
-	metadataListDocumentsOutput `json:"-", xml:"-"`
+	metadataListDocumentsOutput `json:"-" xml:"-"`
 }
 
 type metadataListDocumentsOutput struct {
@@ -826,7 +826,7 @@ type UpdateAssociationStatusInput struct {
 	// The name of the configuration document.
 	Name *string `type:"string" required:"true"`
 
-	metadataUpdateAssociationStatusInput `json:"-", xml:"-"`
+	metadataUpdateAssociationStatusInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateAssociationStatusInput struct {
@@ -837,7 +837,7 @@ type UpdateAssociationStatusOutput struct {
 	// Information about the association.
 	AssociationDescription *AssociationDescription `type:"structure"`
 
-	metadataUpdateAssociationStatusOutput `json:"-", xml:"-"`
+	metadataUpdateAssociationStatusOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateAssociationStatusOutput struct {

--- a/service/storagegateway/api.go
+++ b/service/storagegateway/api.go
@@ -2000,7 +2000,7 @@ type ActivateGatewayInput struct {
 	// Valid Values: "IBM-ULT3580-TD5"
 	TapeDriveType *string `type:"string"`
 
-	metadataActivateGatewayInput `json:"-", xml:"-"`
+	metadataActivateGatewayInput `json:"-" xml:"-"`
 }
 
 type metadataActivateGatewayInput struct {
@@ -2016,7 +2016,7 @@ type ActivateGatewayOutput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `type:"string"`
 
-	metadataActivateGatewayOutput `json:"-", xml:"-"`
+	metadataActivateGatewayOutput `json:"-" xml:"-"`
 }
 
 type metadataActivateGatewayOutput struct {
@@ -2030,7 +2030,7 @@ type AddCacheInput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `type:"string" required:"true"`
 
-	metadataAddCacheInput `json:"-", xml:"-"`
+	metadataAddCacheInput `json:"-" xml:"-"`
 }
 
 type metadataAddCacheInput struct {
@@ -2042,7 +2042,7 @@ type AddCacheOutput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `type:"string"`
 
-	metadataAddCacheOutput `json:"-", xml:"-"`
+	metadataAddCacheOutput `json:"-" xml:"-"`
 }
 
 type metadataAddCacheOutput struct {
@@ -2056,7 +2056,7 @@ type AddUploadBufferInput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `type:"string" required:"true"`
 
-	metadataAddUploadBufferInput `json:"-", xml:"-"`
+	metadataAddUploadBufferInput `json:"-" xml:"-"`
 }
 
 type metadataAddUploadBufferInput struct {
@@ -2068,7 +2068,7 @@ type AddUploadBufferOutput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `type:"string"`
 
-	metadataAddUploadBufferOutput `json:"-", xml:"-"`
+	metadataAddUploadBufferOutput `json:"-" xml:"-"`
 }
 
 type metadataAddUploadBufferOutput struct {
@@ -2088,7 +2088,7 @@ type AddWorkingStorageInput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `type:"string" required:"true"`
 
-	metadataAddWorkingStorageInput `json:"-", xml:"-"`
+	metadataAddWorkingStorageInput `json:"-" xml:"-"`
 }
 
 type metadataAddWorkingStorageInput struct {
@@ -2102,7 +2102,7 @@ type AddWorkingStorageOutput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `type:"string"`
 
-	metadataAddWorkingStorageOutput `json:"-", xml:"-"`
+	metadataAddWorkingStorageOutput `json:"-" xml:"-"`
 }
 
 type metadataAddWorkingStorageOutput struct {
@@ -2127,7 +2127,7 @@ type CachediSCSIVolume struct {
 	// Lists iSCSI information about a volume.
 	VolumeiSCSIAttributes *VolumeiSCSIAttributes `type:"structure"`
 
-	metadataCachediSCSIVolume `json:"-", xml:"-"`
+	metadataCachediSCSIVolume `json:"-" xml:"-"`
 }
 
 type metadataCachediSCSIVolume struct {
@@ -2144,7 +2144,7 @@ type CancelArchivalInput struct {
 	// for.
 	TapeARN *string `type:"string" required:"true"`
 
-	metadataCancelArchivalInput `json:"-", xml:"-"`
+	metadataCancelArchivalInput `json:"-" xml:"-"`
 }
 
 type metadataCancelArchivalInput struct {
@@ -2157,7 +2157,7 @@ type CancelArchivalOutput struct {
 	// canceled.
 	TapeARN *string `type:"string"`
 
-	metadataCancelArchivalOutput `json:"-", xml:"-"`
+	metadataCancelArchivalOutput `json:"-" xml:"-"`
 }
 
 type metadataCancelArchivalOutput struct {
@@ -2174,7 +2174,7 @@ type CancelRetrievalInput struct {
 	// for.
 	TapeARN *string `type:"string" required:"true"`
 
-	metadataCancelRetrievalInput `json:"-", xml:"-"`
+	metadataCancelRetrievalInput `json:"-" xml:"-"`
 }
 
 type metadataCancelRetrievalInput struct {
@@ -2187,7 +2187,7 @@ type CancelRetrievalOutput struct {
 	// canceled.
 	TapeARN *string `type:"string"`
 
-	metadataCancelRetrievalOutput `json:"-", xml:"-"`
+	metadataCancelRetrievalOutput `json:"-" xml:"-"`
 }
 
 type metadataCancelRetrievalOutput struct {
@@ -2214,7 +2214,7 @@ type ChapInfo struct {
 	// (-).
 	TargetARN *string `type:"string"`
 
-	metadataChapInfo `json:"-", xml:"-"`
+	metadataChapInfo `json:"-" xml:"-"`
 }
 
 type metadataChapInfo struct {
@@ -2236,7 +2236,7 @@ type CreateCachediSCSIVolumeInput struct {
 
 	VolumeSizeInBytes *int64 `type:"long" required:"true"`
 
-	metadataCreateCachediSCSIVolumeInput `json:"-", xml:"-"`
+	metadataCreateCachediSCSIVolumeInput `json:"-" xml:"-"`
 }
 
 type metadataCreateCachediSCSIVolumeInput struct {
@@ -2248,7 +2248,7 @@ type CreateCachediSCSIVolumeOutput struct {
 
 	VolumeARN *string `type:"string"`
 
-	metadataCreateCachediSCSIVolumeOutput `json:"-", xml:"-"`
+	metadataCreateCachediSCSIVolumeOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateCachediSCSIVolumeOutput struct {
@@ -2260,7 +2260,7 @@ type CreateSnapshotFromVolumeRecoveryPointInput struct {
 
 	VolumeARN *string `type:"string" required:"true"`
 
-	metadataCreateSnapshotFromVolumeRecoveryPointInput `json:"-", xml:"-"`
+	metadataCreateSnapshotFromVolumeRecoveryPointInput `json:"-" xml:"-"`
 }
 
 type metadataCreateSnapshotFromVolumeRecoveryPointInput struct {
@@ -2274,7 +2274,7 @@ type CreateSnapshotFromVolumeRecoveryPointOutput struct {
 
 	VolumeRecoveryPointTime *string `type:"string"`
 
-	metadataCreateSnapshotFromVolumeRecoveryPointOutput `json:"-", xml:"-"`
+	metadataCreateSnapshotFromVolumeRecoveryPointOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateSnapshotFromVolumeRecoveryPointOutput struct {
@@ -2294,7 +2294,7 @@ type CreateSnapshotInput struct {
 	// to return a list of gateway volumes.
 	VolumeARN *string `type:"string" required:"true"`
 
-	metadataCreateSnapshotInput `json:"-", xml:"-"`
+	metadataCreateSnapshotInput `json:"-" xml:"-"`
 }
 
 type metadataCreateSnapshotInput struct {
@@ -2311,7 +2311,7 @@ type CreateSnapshotOutput struct {
 	// The Amazon Resource Name (ARN) of the volume of which the snapshot was taken.
 	VolumeARN *string `type:"string"`
 
-	metadataCreateSnapshotOutput `json:"-", xml:"-"`
+	metadataCreateSnapshotOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateSnapshotOutput struct {
@@ -2359,7 +2359,7 @@ type CreateStorediSCSIVolumeInput struct {
 	// The target name must be unique across all volumes of a gateway.
 	TargetName *string `type:"string" required:"true"`
 
-	metadataCreateStorediSCSIVolumeInput `json:"-", xml:"-"`
+	metadataCreateStorediSCSIVolumeInput `json:"-" xml:"-"`
 }
 
 type metadataCreateStorediSCSIVolumeInput struct {
@@ -2378,7 +2378,7 @@ type CreateStorediSCSIVolumeOutput struct {
 	// The size of the volume in bytes.
 	VolumeSizeInBytes *int64 `type:"long"`
 
-	metadataCreateStorediSCSIVolumeOutput `json:"-", xml:"-"`
+	metadataCreateStorediSCSIVolumeOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateStorediSCSIVolumeOutput struct {
@@ -2413,7 +2413,7 @@ type CreateTapesInput struct {
 	// The size must be gigabyte (1024*1024*1024 byte) aligned.
 	TapeSizeInBytes *int64 `type:"long" required:"true"`
 
-	metadataCreateTapesInput `json:"-", xml:"-"`
+	metadataCreateTapesInput `json:"-" xml:"-"`
 }
 
 type metadataCreateTapesInput struct {
@@ -2426,7 +2426,7 @@ type CreateTapesOutput struct {
 	// that were created.
 	TapeARNs []*string `type:"list"`
 
-	metadataCreateTapesOutput `json:"-", xml:"-"`
+	metadataCreateTapesOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateTapesOutput struct {
@@ -2440,7 +2440,7 @@ type DeleteBandwidthRateLimitInput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `type:"string" required:"true"`
 
-	metadataDeleteBandwidthRateLimitInput `json:"-", xml:"-"`
+	metadataDeleteBandwidthRateLimitInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteBandwidthRateLimitInput struct {
@@ -2454,7 +2454,7 @@ type DeleteBandwidthRateLimitOutput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `type:"string"`
 
-	metadataDeleteBandwidthRateLimitOutput `json:"-", xml:"-"`
+	metadataDeleteBandwidthRateLimitOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteBandwidthRateLimitOutput struct {
@@ -2472,7 +2472,7 @@ type DeleteChapCredentialsInput struct {
 	// operation to return to retrieve the TargetARN for specified VolumeARN.
 	TargetARN *string `type:"string" required:"true"`
 
-	metadataDeleteChapCredentialsInput `json:"-", xml:"-"`
+	metadataDeleteChapCredentialsInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteChapCredentialsInput struct {
@@ -2487,7 +2487,7 @@ type DeleteChapCredentialsOutput struct {
 	// The Amazon Resource Name (ARN) of the target.
 	TargetARN *string `type:"string"`
 
-	metadataDeleteChapCredentialsOutput `json:"-", xml:"-"`
+	metadataDeleteChapCredentialsOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteChapCredentialsOutput struct {
@@ -2500,7 +2500,7 @@ type DeleteGatewayInput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `type:"string" required:"true"`
 
-	metadataDeleteGatewayInput `json:"-", xml:"-"`
+	metadataDeleteGatewayInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteGatewayInput struct {
@@ -2513,7 +2513,7 @@ type DeleteGatewayOutput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `type:"string"`
 
-	metadataDeleteGatewayOutput `json:"-", xml:"-"`
+	metadataDeleteGatewayOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteGatewayOutput struct {
@@ -2523,7 +2523,7 @@ type metadataDeleteGatewayOutput struct {
 type DeleteSnapshotScheduleInput struct {
 	VolumeARN *string `type:"string" required:"true"`
 
-	metadataDeleteSnapshotScheduleInput `json:"-", xml:"-"`
+	metadataDeleteSnapshotScheduleInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteSnapshotScheduleInput struct {
@@ -2533,7 +2533,7 @@ type metadataDeleteSnapshotScheduleInput struct {
 type DeleteSnapshotScheduleOutput struct {
 	VolumeARN *string `type:"string"`
 
-	metadataDeleteSnapshotScheduleOutput `json:"-", xml:"-"`
+	metadataDeleteSnapshotScheduleOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteSnapshotScheduleOutput struct {
@@ -2546,7 +2546,7 @@ type DeleteTapeArchiveInput struct {
 	// tape shelf (VTS).
 	TapeARN *string `type:"string" required:"true"`
 
-	metadataDeleteTapeArchiveInput `json:"-", xml:"-"`
+	metadataDeleteTapeArchiveInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteTapeArchiveInput struct {
@@ -2559,7 +2559,7 @@ type DeleteTapeArchiveOutput struct {
 	// the virtual tape shelf (VTS).
 	TapeARN *string `type:"string"`
 
-	metadataDeleteTapeArchiveOutput `json:"-", xml:"-"`
+	metadataDeleteTapeArchiveOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteTapeArchiveOutput struct {
@@ -2576,7 +2576,7 @@ type DeleteTapeInput struct {
 	// The Amazon Resource Name (ARN) of the virtual tape to delete.
 	TapeARN *string `type:"string" required:"true"`
 
-	metadataDeleteTapeInput `json:"-", xml:"-"`
+	metadataDeleteTapeInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteTapeInput struct {
@@ -2588,7 +2588,7 @@ type DeleteTapeOutput struct {
 	// The Amazon Resource Name (ARN) of the deleted virtual tape.
 	TapeARN *string `type:"string"`
 
-	metadataDeleteTapeOutput `json:"-", xml:"-"`
+	metadataDeleteTapeOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteTapeOutput struct {
@@ -2601,7 +2601,7 @@ type DeleteVolumeInput struct {
 	// to return a list of gateway volumes.
 	VolumeARN *string `type:"string" required:"true"`
 
-	metadataDeleteVolumeInput `json:"-", xml:"-"`
+	metadataDeleteVolumeInput `json:"-" xml:"-"`
 }
 
 type metadataDeleteVolumeInput struct {
@@ -2614,7 +2614,7 @@ type DeleteVolumeOutput struct {
 	// is the same ARN you provided in the request.
 	VolumeARN *string `type:"string"`
 
-	metadataDeleteVolumeOutput `json:"-", xml:"-"`
+	metadataDeleteVolumeOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteVolumeOutput struct {
@@ -2627,7 +2627,7 @@ type DescribeBandwidthRateLimitInput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `type:"string" required:"true"`
 
-	metadataDescribeBandwidthRateLimitInput `json:"-", xml:"-"`
+	metadataDescribeBandwidthRateLimitInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeBandwidthRateLimitInput struct {
@@ -2648,7 +2648,7 @@ type DescribeBandwidthRateLimitOutput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `type:"string"`
 
-	metadataDescribeBandwidthRateLimitOutput `json:"-", xml:"-"`
+	metadataDescribeBandwidthRateLimitOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeBandwidthRateLimitOutput struct {
@@ -2660,7 +2660,7 @@ type DescribeCacheInput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `type:"string" required:"true"`
 
-	metadataDescribeCacheInput `json:"-", xml:"-"`
+	metadataDescribeCacheInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeCacheInput struct {
@@ -2684,7 +2684,7 @@ type DescribeCacheOutput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `type:"string"`
 
-	metadataDescribeCacheOutput `json:"-", xml:"-"`
+	metadataDescribeCacheOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeCacheOutput struct {
@@ -2694,7 +2694,7 @@ type metadataDescribeCacheOutput struct {
 type DescribeCachediSCSIVolumesInput struct {
 	VolumeARNs []*string `type:"list" required:"true"`
 
-	metadataDescribeCachediSCSIVolumesInput `json:"-", xml:"-"`
+	metadataDescribeCachediSCSIVolumesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeCachediSCSIVolumesInput struct {
@@ -2707,7 +2707,7 @@ type DescribeCachediSCSIVolumesOutput struct {
 	// volume.
 	CachediSCSIVolumes []*CachediSCSIVolume `type:"list"`
 
-	metadataDescribeCachediSCSIVolumesOutput `json:"-", xml:"-"`
+	metadataDescribeCachediSCSIVolumesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeCachediSCSIVolumesOutput struct {
@@ -2721,7 +2721,7 @@ type DescribeChapCredentialsInput struct {
 	// operation to return to retrieve the TargetARN for specified VolumeARN.
 	TargetARN *string `type:"string" required:"true"`
 
-	metadataDescribeChapCredentialsInput `json:"-", xml:"-"`
+	metadataDescribeChapCredentialsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeChapCredentialsInput struct {
@@ -2746,7 +2746,7 @@ type DescribeChapCredentialsOutput struct {
 	//   TargetARN: The Amazon Resource Name (ARN) of the storage volume.
 	ChapCredentials []*ChapInfo `type:"list"`
 
-	metadataDescribeChapCredentialsOutput `json:"-", xml:"-"`
+	metadataDescribeChapCredentialsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeChapCredentialsOutput struct {
@@ -2759,7 +2759,7 @@ type DescribeGatewayInformationInput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `type:"string" required:"true"`
 
-	metadataDescribeGatewayInformationInput `json:"-", xml:"-"`
+	metadataDescribeGatewayInformationInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeGatewayInformationInput struct {
@@ -2793,7 +2793,7 @@ type DescribeGatewayInformationOutput struct {
 	// this field is not returned in the response.
 	NextUpdateAvailabilityDate *string `type:"string"`
 
-	metadataDescribeGatewayInformationOutput `json:"-", xml:"-"`
+	metadataDescribeGatewayInformationOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeGatewayInformationOutput struct {
@@ -2806,7 +2806,7 @@ type DescribeMaintenanceStartTimeInput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `type:"string" required:"true"`
 
-	metadataDescribeMaintenanceStartTimeInput `json:"-", xml:"-"`
+	metadataDescribeMaintenanceStartTimeInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeMaintenanceStartTimeInput struct {
@@ -2826,7 +2826,7 @@ type DescribeMaintenanceStartTimeOutput struct {
 
 	Timezone *string `type:"string"`
 
-	metadataDescribeMaintenanceStartTimeOutput `json:"-", xml:"-"`
+	metadataDescribeMaintenanceStartTimeOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeMaintenanceStartTimeOutput struct {
@@ -2840,7 +2840,7 @@ type DescribeSnapshotScheduleInput struct {
 	// to return a list of gateway volumes.
 	VolumeARN *string `type:"string" required:"true"`
 
-	metadataDescribeSnapshotScheduleInput `json:"-", xml:"-"`
+	metadataDescribeSnapshotScheduleInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeSnapshotScheduleInput struct {
@@ -2858,7 +2858,7 @@ type DescribeSnapshotScheduleOutput struct {
 
 	VolumeARN *string `type:"string"`
 
-	metadataDescribeSnapshotScheduleOutput `json:"-", xml:"-"`
+	metadataDescribeSnapshotScheduleOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeSnapshotScheduleOutput struct {
@@ -2872,7 +2872,7 @@ type DescribeStorediSCSIVolumesInput struct {
 	// same gateway. Use ListVolumes to get volume ARNs for a gateway.
 	VolumeARNs []*string `type:"list" required:"true"`
 
-	metadataDescribeStorediSCSIVolumesInput `json:"-", xml:"-"`
+	metadataDescribeStorediSCSIVolumesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeStorediSCSIVolumesInput struct {
@@ -2882,7 +2882,7 @@ type metadataDescribeStorediSCSIVolumesInput struct {
 type DescribeStorediSCSIVolumesOutput struct {
 	StorediSCSIVolumes []*StorediSCSIVolume `type:"list"`
 
-	metadataDescribeStorediSCSIVolumesOutput `json:"-", xml:"-"`
+	metadataDescribeStorediSCSIVolumesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeStorediSCSIVolumesOutput struct {
@@ -2903,7 +2903,7 @@ type DescribeTapeArchivesInput struct {
 	// the virtual tapes you want to describe.
 	TapeARNs []*string `type:"list"`
 
-	metadataDescribeTapeArchivesInput `json:"-", xml:"-"`
+	metadataDescribeTapeArchivesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeTapeArchivesInput struct {
@@ -2925,7 +2925,7 @@ type DescribeTapeArchivesOutput struct {
 	// the tapes, status of the tapes, progress of the description and tape barcode.
 	TapeArchives []*TapeArchive `type:"list"`
 
-	metadataDescribeTapeArchivesOutput `json:"-", xml:"-"`
+	metadataDescribeTapeArchivesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeTapeArchivesOutput struct {
@@ -2946,7 +2946,7 @@ type DescribeTapeRecoveryPointsInput struct {
 	// the virtual tape recovery points.
 	Marker *string `type:"string"`
 
-	metadataDescribeTapeRecoveryPointsInput `json:"-", xml:"-"`
+	metadataDescribeTapeRecoveryPointsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeTapeRecoveryPointsInput struct {
@@ -2970,7 +2970,7 @@ type DescribeTapeRecoveryPointsOutput struct {
 	// An array of TapeRecoveryPointInfos that are available for the specified gateway.
 	TapeRecoveryPointInfos []*TapeRecoveryPointInfo `type:"list"`
 
-	metadataDescribeTapeRecoveryPointsOutput `json:"-", xml:"-"`
+	metadataDescribeTapeRecoveryPointsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeTapeRecoveryPointsOutput struct {
@@ -3001,7 +3001,7 @@ type DescribeTapesInput struct {
 	// with the specified gateway.
 	TapeARNs []*string `type:"list"`
 
-	metadataDescribeTapesInput `json:"-", xml:"-"`
+	metadataDescribeTapesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeTapesInput struct {
@@ -3020,7 +3020,7 @@ type DescribeTapesOutput struct {
 	// An array of virtual tape descriptions.
 	Tapes []*Tape `type:"list"`
 
-	metadataDescribeTapesOutput `json:"-", xml:"-"`
+	metadataDescribeTapesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeTapesOutput struct {
@@ -3032,7 +3032,7 @@ type DescribeUploadBufferInput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `type:"string" required:"true"`
 
-	metadataDescribeUploadBufferInput `json:"-", xml:"-"`
+	metadataDescribeUploadBufferInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeUploadBufferInput struct {
@@ -3050,7 +3050,7 @@ type DescribeUploadBufferOutput struct {
 
 	UploadBufferUsedInBytes *int64 `type:"long"`
 
-	metadataDescribeUploadBufferOutput `json:"-", xml:"-"`
+	metadataDescribeUploadBufferOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeUploadBufferOutput struct {
@@ -3079,7 +3079,7 @@ type DescribeVTLDevicesInput struct {
 	// gateway.
 	VTLDeviceARNs []*string `type:"list"`
 
-	metadataDescribeVTLDevicesInput `json:"-", xml:"-"`
+	metadataDescribeVTLDevicesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeVTLDevicesInput struct {
@@ -3102,7 +3102,7 @@ type DescribeVTLDevicesOutput struct {
 	// of the VTL devices.
 	VTLDevices []*VTLDevice `type:"list"`
 
-	metadataDescribeVTLDevicesOutput `json:"-", xml:"-"`
+	metadataDescribeVTLDevicesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeVTLDevicesOutput struct {
@@ -3115,7 +3115,7 @@ type DescribeWorkingStorageInput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `type:"string" required:"true"`
 
-	metadataDescribeWorkingStorageInput `json:"-", xml:"-"`
+	metadataDescribeWorkingStorageInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeWorkingStorageInput struct {
@@ -3142,7 +3142,7 @@ type DescribeWorkingStorageOutput struct {
 	// is configured for the gateway, this field returns 0.
 	WorkingStorageUsedInBytes *int64 `type:"long"`
 
-	metadataDescribeWorkingStorageOutput `json:"-", xml:"-"`
+	metadataDescribeWorkingStorageOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeWorkingStorageOutput struct {
@@ -3164,7 +3164,7 @@ type DeviceiSCSIAttributes struct {
 	// name(iqn) of a tape drive or media changer target.
 	TargetARN *string `type:"string"`
 
-	metadataDeviceiSCSIAttributes `json:"-", xml:"-"`
+	metadataDeviceiSCSIAttributes `json:"-" xml:"-"`
 }
 
 type metadataDeviceiSCSIAttributes struct {
@@ -3177,7 +3177,7 @@ type DisableGatewayInput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `type:"string" required:"true"`
 
-	metadataDisableGatewayInput `json:"-", xml:"-"`
+	metadataDisableGatewayInput `json:"-" xml:"-"`
 }
 
 type metadataDisableGatewayInput struct {
@@ -3189,7 +3189,7 @@ type DisableGatewayOutput struct {
 	// The unique Amazon Resource Name of the disabled gateway.
 	GatewayARN *string `type:"string"`
 
-	metadataDisableGatewayOutput `json:"-", xml:"-"`
+	metadataDisableGatewayOutput `json:"-" xml:"-"`
 }
 
 type metadataDisableGatewayOutput struct {
@@ -3211,7 +3211,7 @@ type Disk struct {
 
 	DiskStatus *string `type:"string"`
 
-	metadataDisk `json:"-", xml:"-"`
+	metadataDisk `json:"-" xml:"-"`
 }
 
 type metadataDisk struct {
@@ -3227,7 +3227,7 @@ type GatewayInfo struct {
 
 	GatewayType *string `type:"string"`
 
-	metadataGatewayInfo `json:"-", xml:"-"`
+	metadataGatewayInfo `json:"-" xml:"-"`
 }
 
 type metadataGatewayInfo struct {
@@ -3246,7 +3246,7 @@ type ListGatewaysInput struct {
 	// list of gateways.
 	Marker *string `type:"string"`
 
-	metadataListGatewaysInput `json:"-", xml:"-"`
+	metadataListGatewaysInput `json:"-" xml:"-"`
 }
 
 type metadataListGatewaysInput struct {
@@ -3258,7 +3258,7 @@ type ListGatewaysOutput struct {
 
 	Marker *string `type:"string"`
 
-	metadataListGatewaysOutput `json:"-", xml:"-"`
+	metadataListGatewaysOutput `json:"-" xml:"-"`
 }
 
 type metadataListGatewaysOutput struct {
@@ -3271,7 +3271,7 @@ type ListLocalDisksInput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `type:"string" required:"true"`
 
-	metadataListLocalDisksInput `json:"-", xml:"-"`
+	metadataListLocalDisksInput `json:"-" xml:"-"`
 }
 
 type metadataListLocalDisksInput struct {
@@ -3285,7 +3285,7 @@ type ListLocalDisksOutput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `type:"string"`
 
-	metadataListLocalDisksOutput `json:"-", xml:"-"`
+	metadataListLocalDisksOutput `json:"-" xml:"-"`
 }
 
 type metadataListLocalDisksOutput struct {
@@ -3297,7 +3297,7 @@ type ListVolumeRecoveryPointsInput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `type:"string" required:"true"`
 
-	metadataListVolumeRecoveryPointsInput `json:"-", xml:"-"`
+	metadataListVolumeRecoveryPointsInput `json:"-" xml:"-"`
 }
 
 type metadataListVolumeRecoveryPointsInput struct {
@@ -3311,7 +3311,7 @@ type ListVolumeRecoveryPointsOutput struct {
 
 	VolumeRecoveryPointInfos []*VolumeRecoveryPointInfo `type:"list"`
 
-	metadataListVolumeRecoveryPointsOutput `json:"-", xml:"-"`
+	metadataListVolumeRecoveryPointsOutput `json:"-" xml:"-"`
 }
 
 type metadataListVolumeRecoveryPointsOutput struct {
@@ -3335,7 +3335,7 @@ type ListVolumesInput struct {
 	// Volumes request.
 	Marker *string `type:"string"`
 
-	metadataListVolumesInput `json:"-", xml:"-"`
+	metadataListVolumesInput `json:"-" xml:"-"`
 }
 
 type metadataListVolumesInput struct {
@@ -3351,7 +3351,7 @@ type ListVolumesOutput struct {
 
 	VolumeInfos []*VolumeInfo `type:"list"`
 
-	metadataListVolumesOutput `json:"-", xml:"-"`
+	metadataListVolumesOutput `json:"-" xml:"-"`
 }
 
 type metadataListVolumesOutput struct {
@@ -3372,7 +3372,7 @@ type NetworkInterface struct {
 	// This is currently unsupported and will not be returned in output.
 	MACAddress *string `locationName:"MacAddress" type:"string"`
 
-	metadataNetworkInterface `json:"-", xml:"-"`
+	metadataNetworkInterface `json:"-" xml:"-"`
 }
 
 type metadataNetworkInterface struct {
@@ -3384,7 +3384,7 @@ type ResetCacheInput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `type:"string" required:"true"`
 
-	metadataResetCacheInput `json:"-", xml:"-"`
+	metadataResetCacheInput `json:"-" xml:"-"`
 }
 
 type metadataResetCacheInput struct {
@@ -3396,7 +3396,7 @@ type ResetCacheOutput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `type:"string"`
 
-	metadataResetCacheOutput `json:"-", xml:"-"`
+	metadataResetCacheOutput `json:"-" xml:"-"`
 }
 
 type metadataResetCacheOutput struct {
@@ -3417,7 +3417,7 @@ type RetrieveTapeArchiveInput struct {
 	// the virtual tape shelf (VTS).
 	TapeARN *string `type:"string" required:"true"`
 
-	metadataRetrieveTapeArchiveInput `json:"-", xml:"-"`
+	metadataRetrieveTapeArchiveInput `json:"-" xml:"-"`
 }
 
 type metadataRetrieveTapeArchiveInput struct {
@@ -3429,7 +3429,7 @@ type RetrieveTapeArchiveOutput struct {
 	// The Amazon Resource Name (ARN) of the retrieved virtual tape.
 	TapeARN *string `type:"string"`
 
-	metadataRetrieveTapeArchiveOutput `json:"-", xml:"-"`
+	metadataRetrieveTapeArchiveOutput `json:"-" xml:"-"`
 }
 
 type metadataRetrieveTapeArchiveOutput struct {
@@ -3446,7 +3446,7 @@ type RetrieveTapeRecoveryPointInput struct {
 	// retrieve the recovery point.
 	TapeARN *string `type:"string" required:"true"`
 
-	metadataRetrieveTapeRecoveryPointInput `json:"-", xml:"-"`
+	metadataRetrieveTapeRecoveryPointInput `json:"-" xml:"-"`
 }
 
 type metadataRetrieveTapeRecoveryPointInput struct {
@@ -3459,7 +3459,7 @@ type RetrieveTapeRecoveryPointOutput struct {
 	// point was retrieved.
 	TapeARN *string `type:"string"`
 
-	metadataRetrieveTapeRecoveryPointOutput `json:"-", xml:"-"`
+	metadataRetrieveTapeRecoveryPointOutput `json:"-" xml:"-"`
 }
 
 type metadataRetrieveTapeRecoveryPointOutput struct {
@@ -3472,7 +3472,7 @@ type ShutdownGatewayInput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `type:"string" required:"true"`
 
-	metadataShutdownGatewayInput `json:"-", xml:"-"`
+	metadataShutdownGatewayInput `json:"-" xml:"-"`
 }
 
 type metadataShutdownGatewayInput struct {
@@ -3485,7 +3485,7 @@ type ShutdownGatewayOutput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `type:"string"`
 
-	metadataShutdownGatewayOutput `json:"-", xml:"-"`
+	metadataShutdownGatewayOutput `json:"-" xml:"-"`
 }
 
 type metadataShutdownGatewayOutput struct {
@@ -3498,7 +3498,7 @@ type StartGatewayInput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `type:"string" required:"true"`
 
-	metadataStartGatewayInput `json:"-", xml:"-"`
+	metadataStartGatewayInput `json:"-" xml:"-"`
 }
 
 type metadataStartGatewayInput struct {
@@ -3511,7 +3511,7 @@ type StartGatewayOutput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `type:"string"`
 
-	metadataStartGatewayOutput `json:"-", xml:"-"`
+	metadataStartGatewayOutput `json:"-" xml:"-"`
 }
 
 type metadataStartGatewayOutput struct {
@@ -3528,7 +3528,7 @@ type StorageGatewayError struct {
 	// Human-readable text that provides detail about the error that occurred.
 	ErrorDetails *map[string]*string `locationName:"errorDetails" type:"map"`
 
-	metadataStorageGatewayError `json:"-", xml:"-"`
+	metadataStorageGatewayError `json:"-" xml:"-"`
 }
 
 type metadataStorageGatewayError struct {
@@ -3557,7 +3557,7 @@ type StorediSCSIVolume struct {
 	// Lists iSCSI information about a volume.
 	VolumeiSCSIAttributes *VolumeiSCSIAttributes `type:"structure"`
 
-	metadataStorediSCSIVolume `json:"-", xml:"-"`
+	metadataStorediSCSIVolume `json:"-" xml:"-"`
 }
 
 type metadataStorediSCSIVolume struct {
@@ -3588,7 +3588,7 @@ type Tape struct {
 	// with.
 	VTLDevice *string `type:"string"`
 
-	metadataTape `json:"-", xml:"-"`
+	metadataTape `json:"-" xml:"-"`
 }
 
 type metadataTape struct {
@@ -3621,7 +3621,7 @@ type TapeArchive struct {
 	// The current state of the archived virtual tape.
 	TapeStatus *string `type:"string"`
 
-	metadataTapeArchive `json:"-", xml:"-"`
+	metadataTapeArchive `json:"-" xml:"-"`
 }
 
 type metadataTapeArchive struct {
@@ -3645,7 +3645,7 @@ type TapeRecoveryPointInfo struct {
 
 	TapeStatus *string `type:"string"`
 
-	metadataTapeRecoveryPointInfo `json:"-", xml:"-"`
+	metadataTapeRecoveryPointInfo `json:"-" xml:"-"`
 }
 
 type metadataTapeRecoveryPointInfo struct {
@@ -3666,7 +3666,7 @@ type UpdateBandwidthRateLimitInput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `type:"string" required:"true"`
 
-	metadataUpdateBandwidthRateLimitInput `json:"-", xml:"-"`
+	metadataUpdateBandwidthRateLimitInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateBandwidthRateLimitInput struct {
@@ -3680,7 +3680,7 @@ type UpdateBandwidthRateLimitOutput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `type:"string"`
 
-	metadataUpdateBandwidthRateLimitOutput `json:"-", xml:"-"`
+	metadataUpdateBandwidthRateLimitOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateBandwidthRateLimitOutput struct {
@@ -3707,7 +3707,7 @@ type UpdateChapCredentialsInput struct {
 	// operation to return to retrieve the TargetARN for specified VolumeARN.
 	TargetARN *string `type:"string" required:"true"`
 
-	metadataUpdateChapCredentialsInput `json:"-", xml:"-"`
+	metadataUpdateChapCredentialsInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateChapCredentialsInput struct {
@@ -3724,7 +3724,7 @@ type UpdateChapCredentialsOutput struct {
 	// in the request.
 	TargetARN *string `type:"string"`
 
-	metadataUpdateChapCredentialsOutput `json:"-", xml:"-"`
+	metadataUpdateChapCredentialsOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateChapCredentialsOutput struct {
@@ -3742,7 +3742,7 @@ type UpdateGatewayInformationInput struct {
 
 	GatewayTimezone *string `type:"string"`
 
-	metadataUpdateGatewayInformationInput `json:"-", xml:"-"`
+	metadataUpdateGatewayInformationInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateGatewayInformationInput struct {
@@ -3755,7 +3755,7 @@ type UpdateGatewayInformationOutput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `type:"string"`
 
-	metadataUpdateGatewayInformationOutput `json:"-", xml:"-"`
+	metadataUpdateGatewayInformationOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateGatewayInformationOutput struct {
@@ -3768,7 +3768,7 @@ type UpdateGatewaySoftwareNowInput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `type:"string" required:"true"`
 
-	metadataUpdateGatewaySoftwareNowInput `json:"-", xml:"-"`
+	metadataUpdateGatewaySoftwareNowInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateGatewaySoftwareNowInput struct {
@@ -3781,7 +3781,7 @@ type UpdateGatewaySoftwareNowOutput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `type:"string"`
 
-	metadataUpdateGatewaySoftwareNowOutput `json:"-", xml:"-"`
+	metadataUpdateGatewaySoftwareNowOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateGatewaySoftwareNowOutput struct {
@@ -3810,7 +3810,7 @@ type UpdateMaintenanceStartTimeInput struct {
 	// the gateway.
 	MinuteOfHour *int64 `type:"integer" required:"true"`
 
-	metadataUpdateMaintenanceStartTimeInput `json:"-", xml:"-"`
+	metadataUpdateMaintenanceStartTimeInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateMaintenanceStartTimeInput struct {
@@ -3824,7 +3824,7 @@ type UpdateMaintenanceStartTimeOutput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `type:"string"`
 
-	metadataUpdateMaintenanceStartTimeOutput `json:"-", xml:"-"`
+	metadataUpdateMaintenanceStartTimeOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateMaintenanceStartTimeOutput struct {
@@ -3851,7 +3851,7 @@ type UpdateSnapshotScheduleInput struct {
 	// to return a list of gateway volumes.
 	VolumeARN *string `type:"string" required:"true"`
 
-	metadataUpdateSnapshotScheduleInput `json:"-", xml:"-"`
+	metadataUpdateSnapshotScheduleInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateSnapshotScheduleInput struct {
@@ -3862,7 +3862,7 @@ type metadataUpdateSnapshotScheduleInput struct {
 type UpdateSnapshotScheduleOutput struct {
 	VolumeARN *string `type:"string"`
 
-	metadataUpdateSnapshotScheduleOutput `json:"-", xml:"-"`
+	metadataUpdateSnapshotScheduleOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateSnapshotScheduleOutput struct {
@@ -3879,7 +3879,7 @@ type UpdateVTLDeviceTypeInput struct {
 	// The Amazon Resource Name (ARN) of the medium changer you want to select.
 	VTLDeviceARN *string `type:"string" required:"true"`
 
-	metadataUpdateVTLDeviceTypeInput `json:"-", xml:"-"`
+	metadataUpdateVTLDeviceTypeInput `json:"-" xml:"-"`
 }
 
 type metadataUpdateVTLDeviceTypeInput struct {
@@ -3891,7 +3891,7 @@ type UpdateVTLDeviceTypeOutput struct {
 	// The Amazon Resource Name (ARN) of the medium changer you have selected.
 	VTLDeviceARN *string `type:"string"`
 
-	metadataUpdateVTLDeviceTypeOutput `json:"-", xml:"-"`
+	metadataUpdateVTLDeviceTypeOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateVTLDeviceTypeOutput struct {
@@ -3913,7 +3913,7 @@ type VTLDevice struct {
 
 	VTLDeviceVendor *string `type:"string"`
 
-	metadataVTLDevice `json:"-", xml:"-"`
+	metadataVTLDevice `json:"-" xml:"-"`
 }
 
 type metadataVTLDevice struct {
@@ -3925,7 +3925,7 @@ type VolumeInfo struct {
 
 	VolumeType *string `type:"string"`
 
-	metadataVolumeInfo `json:"-", xml:"-"`
+	metadataVolumeInfo `json:"-" xml:"-"`
 }
 
 type metadataVolumeInfo struct {
@@ -3941,7 +3941,7 @@ type VolumeRecoveryPointInfo struct {
 
 	VolumeUsageInBytes *int64 `type:"long"`
 
-	metadataVolumeRecoveryPointInfo `json:"-", xml:"-"`
+	metadataVolumeRecoveryPointInfo `json:"-" xml:"-"`
 }
 
 type metadataVolumeRecoveryPointInfo struct {
@@ -3965,7 +3965,7 @@ type VolumeiSCSIAttributes struct {
 	// The Amazon Resource Name (ARN) of the volume target.
 	TargetARN *string `type:"string"`
 
-	metadataVolumeiSCSIAttributes `json:"-", xml:"-"`
+	metadataVolumeiSCSIAttributes `json:"-" xml:"-"`
 }
 
 type metadataVolumeiSCSIAttributes struct {

--- a/service/sts/api.go
+++ b/service/sts/api.go
@@ -533,7 +533,7 @@ type AssumeRoleInput struct {
 	// is missing or expired, the AssumeRole call returns an "access denied" error.
 	TokenCode *string `type:"string"`
 
-	metadataAssumeRoleInput `json:"-", xml:"-"`
+	metadataAssumeRoleInput `json:"-" xml:"-"`
 }
 
 type metadataAssumeRoleInput struct {
@@ -559,7 +559,7 @@ type AssumeRoleOutput struct {
 	// which means the policy exceeded the allowed space.
 	PackedPolicySize *int64 `type:"integer"`
 
-	metadataAssumeRoleOutput `json:"-", xml:"-"`
+	metadataAssumeRoleOutput `json:"-" xml:"-"`
 }
 
 type metadataAssumeRoleOutput struct {
@@ -601,7 +601,7 @@ type AssumeRoleWithSAMLInput struct {
 	// in the Using IAM guide.
 	SAMLAssertion *string `type:"string" required:"true"`
 
-	metadataAssumeRoleWithSAMLInput `json:"-", xml:"-"`
+	metadataAssumeRoleWithSAMLInput `json:"-" xml:"-"`
 }
 
 type metadataAssumeRoleWithSAMLInput struct {
@@ -654,7 +654,7 @@ type AssumeRoleWithSAMLOutput struct {
 	// is returned with no modifications.
 	SubjectType *string `type:"string"`
 
-	metadataAssumeRoleWithSAMLOutput `json:"-", xml:"-"`
+	metadataAssumeRoleWithSAMLOutput `json:"-" xml:"-"`
 }
 
 type metadataAssumeRoleWithSAMLOutput struct {
@@ -703,7 +703,7 @@ type AssumeRoleWithWebIdentityInput struct {
 	// the application makes an AssumeRoleWithWebIdentity call.
 	WebIdentityToken *string `type:"string" required:"true"`
 
-	metadataAssumeRoleWithWebIdentityInput `json:"-", xml:"-"`
+	metadataAssumeRoleWithWebIdentityInput `json:"-" xml:"-"`
 }
 
 type metadataAssumeRoleWithWebIdentityInput struct {
@@ -750,7 +750,7 @@ type AssumeRoleWithWebIdentityOutput struct {
 	// claim.
 	SubjectFromWebIdentityToken *string `type:"string"`
 
-	metadataAssumeRoleWithWebIdentityOutput `json:"-", xml:"-"`
+	metadataAssumeRoleWithWebIdentityOutput `json:"-" xml:"-"`
 }
 
 type metadataAssumeRoleWithWebIdentityOutput struct {
@@ -771,7 +771,7 @@ type AssumedRoleUser struct {
 	// role is created.
 	AssumedRoleID *string `locationName:"AssumedRoleId" type:"string" required:"true"`
 
-	metadataAssumedRoleUser `json:"-", xml:"-"`
+	metadataAssumedRoleUser `json:"-" xml:"-"`
 }
 
 type metadataAssumedRoleUser struct {
@@ -792,7 +792,7 @@ type Credentials struct {
 	// The token that users must pass to the service API to use the temporary credentials.
 	SessionToken *string `type:"string" required:"true"`
 
-	metadataCredentials `json:"-", xml:"-"`
+	metadataCredentials `json:"-" xml:"-"`
 }
 
 type metadataCredentials struct {
@@ -803,7 +803,7 @@ type DecodeAuthorizationMessageInput struct {
 	// The encoded message that was returned with the response.
 	EncodedMessage *string `type:"string" required:"true"`
 
-	metadataDecodeAuthorizationMessageInput `json:"-", xml:"-"`
+	metadataDecodeAuthorizationMessageInput `json:"-" xml:"-"`
 }
 
 type metadataDecodeAuthorizationMessageInput struct {
@@ -818,7 +818,7 @@ type DecodeAuthorizationMessageOutput struct {
 	// see DecodeAuthorizationMessage.
 	DecodedMessage *string `type:"string"`
 
-	metadataDecodeAuthorizationMessageOutput `json:"-", xml:"-"`
+	metadataDecodeAuthorizationMessageOutput `json:"-" xml:"-"`
 }
 
 type metadataDecodeAuthorizationMessageOutput struct {
@@ -837,7 +837,7 @@ type FederatedUser struct {
 	// similar to the unique ID of an IAM user.
 	FederatedUserID *string `locationName:"FederatedUserId" type:"string" required:"true"`
 
-	metadataFederatedUser `json:"-", xml:"-"`
+	metadataFederatedUser `json:"-" xml:"-"`
 }
 
 type metadataFederatedUser struct {
@@ -880,7 +880,7 @@ type GetFederationTokenInput struct {
 	// in Using Temporary Security Credentials.
 	Policy *string `type:"string"`
 
-	metadataGetFederationTokenInput `json:"-", xml:"-"`
+	metadataGetFederationTokenInput `json:"-" xml:"-"`
 }
 
 type metadataGetFederationTokenInput struct {
@@ -904,7 +904,7 @@ type GetFederationTokenOutput struct {
 	// of the allowed value.
 	PackedPolicySize *int64 `type:"integer"`
 
-	metadataGetFederationTokenOutput `json:"-", xml:"-"`
+	metadataGetFederationTokenOutput `json:"-" xml:"-"`
 }
 
 type metadataGetFederationTokenOutput struct {
@@ -936,7 +936,7 @@ type GetSessionTokenInput struct {
 	// response when requesting resources that require MFA authentication.
 	TokenCode *string `type:"string"`
 
-	metadataGetSessionTokenInput `json:"-", xml:"-"`
+	metadataGetSessionTokenInput `json:"-" xml:"-"`
 }
 
 type metadataGetSessionTokenInput struct {
@@ -949,7 +949,7 @@ type GetSessionTokenOutput struct {
 	// The session credentials for API authentication.
 	Credentials *Credentials `type:"structure"`
 
-	metadataGetSessionTokenOutput `json:"-", xml:"-"`
+	metadataGetSessionTokenOutput `json:"-" xml:"-"`
 }
 
 type metadataGetSessionTokenOutput struct {

--- a/service/support/api.go
+++ b/service/support/api.go
@@ -594,7 +594,7 @@ type AddAttachmentsToSetInput struct {
 	// set, and the size limit is 5 MB per attachment.
 	Attachments []*Attachment `locationName:"attachments" type:"list" required:"true"`
 
-	metadataAddAttachmentsToSetInput `json:"-", xml:"-"`
+	metadataAddAttachmentsToSetInput `json:"-" xml:"-"`
 }
 
 type metadataAddAttachmentsToSetInput struct {
@@ -613,7 +613,7 @@ type AddAttachmentsToSetOutput struct {
 	// The time and date when the attachment set expires.
 	ExpiryTime *string `locationName:"expiryTime" type:"string"`
 
-	metadataAddAttachmentsToSetOutput `json:"-", xml:"-"`
+	metadataAddAttachmentsToSetOutput `json:"-" xml:"-"`
 }
 
 type metadataAddAttachmentsToSetOutput struct {
@@ -637,7 +637,7 @@ type AddCommunicationToCaseInput struct {
 	// The body of an email communication to add to the support case.
 	CommunicationBody *string `locationName:"communicationBody" type:"string" required:"true"`
 
-	metadataAddCommunicationToCaseInput `json:"-", xml:"-"`
+	metadataAddCommunicationToCaseInput `json:"-" xml:"-"`
 }
 
 type metadataAddCommunicationToCaseInput struct {
@@ -649,7 +649,7 @@ type AddCommunicationToCaseOutput struct {
 	// True if AddCommunicationToCase succeeds. Otherwise, returns an error.
 	Result *bool `locationName:"result" type:"boolean"`
 
-	metadataAddCommunicationToCaseOutput `json:"-", xml:"-"`
+	metadataAddCommunicationToCaseOutput `json:"-" xml:"-"`
 }
 
 type metadataAddCommunicationToCaseOutput struct {
@@ -665,7 +665,7 @@ type Attachment struct {
 	// The name of the attachment file.
 	FileName *string `locationName:"fileName" type:"string"`
 
-	metadataAttachment `json:"-", xml:"-"`
+	metadataAttachment `json:"-" xml:"-"`
 }
 
 type metadataAttachment struct {
@@ -681,7 +681,7 @@ type AttachmentDetails struct {
 	// The file name of the attachment.
 	FileName *string `locationName:"fileName" type:"string"`
 
-	metadataAttachmentDetails `json:"-", xml:"-"`
+	metadataAttachmentDetails `json:"-" xml:"-"`
 }
 
 type metadataAttachmentDetails struct {
@@ -752,7 +752,7 @@ type CaseDetails struct {
 	// The time that the case was case created in the AWS Support Center.
 	TimeCreated *string `locationName:"timeCreated" type:"string"`
 
-	metadataCaseDetails `json:"-", xml:"-"`
+	metadataCaseDetails `json:"-" xml:"-"`
 }
 
 type metadataCaseDetails struct {
@@ -769,7 +769,7 @@ type Category struct {
 	// The category name for the support case.
 	Name *string `locationName:"name" type:"string"`
 
-	metadataCategory `json:"-", xml:"-"`
+	metadataCategory `json:"-" xml:"-"`
 }
 
 type metadataCategory struct {
@@ -796,7 +796,7 @@ type Communication struct {
 	// The time the communication was created.
 	TimeCreated *string `locationName:"timeCreated" type:"string"`
 
-	metadataCommunication `json:"-", xml:"-"`
+	metadataCommunication `json:"-" xml:"-"`
 }
 
 type metadataCommunication struct {
@@ -840,7 +840,7 @@ type CreateCaseInput struct {
 	// The title of the AWS Support case.
 	Subject *string `locationName:"subject" type:"string" required:"true"`
 
-	metadataCreateCaseInput `json:"-", xml:"-"`
+	metadataCreateCaseInput `json:"-" xml:"-"`
 }
 
 type metadataCreateCaseInput struct {
@@ -854,7 +854,7 @@ type CreateCaseOutput struct {
 	// an alphanumeric string formatted as shown in this example: case-12345678910-2013-c4c1d2bf33c5cf47
 	CaseID *string `locationName:"caseId" type:"string"`
 
-	metadataCreateCaseOutput `json:"-", xml:"-"`
+	metadataCreateCaseOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateCaseOutput struct {
@@ -866,7 +866,7 @@ type DescribeAttachmentInput struct {
 	// operation.
 	AttachmentID *string `locationName:"attachmentId" type:"string" required:"true"`
 
-	metadataDescribeAttachmentInput `json:"-", xml:"-"`
+	metadataDescribeAttachmentInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeAttachmentInput struct {
@@ -879,7 +879,7 @@ type DescribeAttachmentOutput struct {
 	// The attachment content and file name.
 	Attachment *Attachment `locationName:"attachment" type:"structure"`
 
-	metadataDescribeAttachmentOutput `json:"-", xml:"-"`
+	metadataDescribeAttachmentOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeAttachmentOutput struct {
@@ -921,7 +921,7 @@ type DescribeCasesInput struct {
 	// A resumption point for pagination.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataDescribeCasesInput `json:"-", xml:"-"`
+	metadataDescribeCasesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeCasesInput struct {
@@ -937,7 +937,7 @@ type DescribeCasesOutput struct {
 	// A resumption point for pagination.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataDescribeCasesOutput `json:"-", xml:"-"`
+	metadataDescribeCasesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeCasesOutput struct {
@@ -963,7 +963,7 @@ type DescribeCommunicationsInput struct {
 	// A resumption point for pagination.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataDescribeCommunicationsInput `json:"-", xml:"-"`
+	metadataDescribeCommunicationsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeCommunicationsInput struct {
@@ -978,7 +978,7 @@ type DescribeCommunicationsOutput struct {
 	// A resumption point for pagination.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataDescribeCommunicationsOutput `json:"-", xml:"-"`
+	metadataDescribeCommunicationsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeCommunicationsOutput struct {
@@ -994,7 +994,7 @@ type DescribeServicesInput struct {
 	// A JSON-formatted list of service codes available for AWS services.
 	ServiceCodeList []*string `locationName:"serviceCodeList" type:"list"`
 
-	metadataDescribeServicesInput `json:"-", xml:"-"`
+	metadataDescribeServicesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeServicesInput struct {
@@ -1006,7 +1006,7 @@ type DescribeServicesOutput struct {
 	// A JSON-formatted list of AWS services.
 	Services []*Service `locationName:"services" type:"list"`
 
-	metadataDescribeServicesOutput `json:"-", xml:"-"`
+	metadataDescribeServicesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeServicesOutput struct {
@@ -1019,7 +1019,7 @@ type DescribeSeverityLevelsInput struct {
 	// must be passed explicitly for operations that take them.
 	Language *string `locationName:"language" type:"string"`
 
-	metadataDescribeSeverityLevelsInput `json:"-", xml:"-"`
+	metadataDescribeSeverityLevelsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeSeverityLevelsInput struct {
@@ -1032,7 +1032,7 @@ type DescribeSeverityLevelsOutput struct {
 	// are defined by your service level agreement with AWS.
 	SeverityLevels []*SeverityLevel `locationName:"severityLevels" type:"list"`
 
-	metadataDescribeSeverityLevelsOutput `json:"-", xml:"-"`
+	metadataDescribeSeverityLevelsOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeSeverityLevelsOutput struct {
@@ -1043,7 +1043,7 @@ type DescribeTrustedAdvisorCheckRefreshStatusesInput struct {
 	// The IDs of the Trusted Advisor checks.
 	CheckIDs []*string `locationName:"checkIds" type:"list" required:"true"`
 
-	metadataDescribeTrustedAdvisorCheckRefreshStatusesInput `json:"-", xml:"-"`
+	metadataDescribeTrustedAdvisorCheckRefreshStatusesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeTrustedAdvisorCheckRefreshStatusesInput struct {
@@ -1056,7 +1056,7 @@ type DescribeTrustedAdvisorCheckRefreshStatusesOutput struct {
 	// The refresh status of the specified Trusted Advisor checks.
 	Statuses []*TrustedAdvisorCheckRefreshStatus `locationName:"statuses" type:"list" required:"true"`
 
-	metadataDescribeTrustedAdvisorCheckRefreshStatusesOutput `json:"-", xml:"-"`
+	metadataDescribeTrustedAdvisorCheckRefreshStatusesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeTrustedAdvisorCheckRefreshStatusesOutput struct {
@@ -1072,7 +1072,7 @@ type DescribeTrustedAdvisorCheckResultInput struct {
 	// must be passed explicitly for operations that take them.
 	Language *string `locationName:"language" type:"string"`
 
-	metadataDescribeTrustedAdvisorCheckResultInput `json:"-", xml:"-"`
+	metadataDescribeTrustedAdvisorCheckResultInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeTrustedAdvisorCheckResultInput struct {
@@ -1085,7 +1085,7 @@ type DescribeTrustedAdvisorCheckResultOutput struct {
 	// The detailed results of the Trusted Advisor check.
 	Result *TrustedAdvisorCheckResult `locationName:"result" type:"structure"`
 
-	metadataDescribeTrustedAdvisorCheckResultOutput `json:"-", xml:"-"`
+	metadataDescribeTrustedAdvisorCheckResultOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeTrustedAdvisorCheckResultOutput struct {
@@ -1096,7 +1096,7 @@ type DescribeTrustedAdvisorCheckSummariesInput struct {
 	// The IDs of the Trusted Advisor checks.
 	CheckIDs []*string `locationName:"checkIds" type:"list" required:"true"`
 
-	metadataDescribeTrustedAdvisorCheckSummariesInput `json:"-", xml:"-"`
+	metadataDescribeTrustedAdvisorCheckSummariesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeTrustedAdvisorCheckSummariesInput struct {
@@ -1109,7 +1109,7 @@ type DescribeTrustedAdvisorCheckSummariesOutput struct {
 	// The summary information for the requested Trusted Advisor checks.
 	Summaries []*TrustedAdvisorCheckSummary `locationName:"summaries" type:"list" required:"true"`
 
-	metadataDescribeTrustedAdvisorCheckSummariesOutput `json:"-", xml:"-"`
+	metadataDescribeTrustedAdvisorCheckSummariesOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeTrustedAdvisorCheckSummariesOutput struct {
@@ -1122,7 +1122,7 @@ type DescribeTrustedAdvisorChecksInput struct {
 	// must be passed explicitly for operations that take them.
 	Language *string `locationName:"language" type:"string" required:"true"`
 
-	metadataDescribeTrustedAdvisorChecksInput `json:"-", xml:"-"`
+	metadataDescribeTrustedAdvisorChecksInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeTrustedAdvisorChecksInput struct {
@@ -1135,7 +1135,7 @@ type DescribeTrustedAdvisorChecksOutput struct {
 	// Information about all available Trusted Advisor checks.
 	Checks []*TrustedAdvisorCheckDescription `locationName:"checks" type:"list" required:"true"`
 
-	metadataDescribeTrustedAdvisorChecksOutput `json:"-", xml:"-"`
+	metadataDescribeTrustedAdvisorChecksOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeTrustedAdvisorChecksOutput struct {
@@ -1150,7 +1150,7 @@ type RecentCaseCommunications struct {
 	// A resumption point for pagination.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataRecentCaseCommunications `json:"-", xml:"-"`
+	metadataRecentCaseCommunications `json:"-" xml:"-"`
 }
 
 type metadataRecentCaseCommunications struct {
@@ -1161,7 +1161,7 @@ type RefreshTrustedAdvisorCheckInput struct {
 	// The unique identifier for the Trusted Advisor check.
 	CheckID *string `locationName:"checkId" type:"string" required:"true"`
 
-	metadataRefreshTrustedAdvisorCheckInput `json:"-", xml:"-"`
+	metadataRefreshTrustedAdvisorCheckInput `json:"-" xml:"-"`
 }
 
 type metadataRefreshTrustedAdvisorCheckInput struct {
@@ -1174,7 +1174,7 @@ type RefreshTrustedAdvisorCheckOutput struct {
 	// the check is eligible for refresh.
 	Status *TrustedAdvisorCheckRefreshStatus `locationName:"status" type:"structure" required:"true"`
 
-	metadataRefreshTrustedAdvisorCheckOutput `json:"-", xml:"-"`
+	metadataRefreshTrustedAdvisorCheckOutput `json:"-" xml:"-"`
 }
 
 type metadataRefreshTrustedAdvisorCheckOutput struct {
@@ -1186,7 +1186,7 @@ type ResolveCaseInput struct {
 	// an alphanumeric string formatted as shown in this example: case-12345678910-2013-c4c1d2bf33c5cf47
 	CaseID *string `locationName:"caseId" type:"string"`
 
-	metadataResolveCaseInput `json:"-", xml:"-"`
+	metadataResolveCaseInput `json:"-" xml:"-"`
 }
 
 type metadataResolveCaseInput struct {
@@ -1201,7 +1201,7 @@ type ResolveCaseOutput struct {
 	// The status of the case when the ResolveCase request was sent.
 	InitialCaseStatus *string `locationName:"initialCaseStatus" type:"string"`
 
-	metadataResolveCaseOutput `json:"-", xml:"-"`
+	metadataResolveCaseOutput `json:"-" xml:"-"`
 }
 
 type metadataResolveCaseOutput struct {
@@ -1223,7 +1223,7 @@ type Service struct {
 	// code.
 	Name *string `locationName:"name" type:"string"`
 
-	metadataService `json:"-", xml:"-"`
+	metadataService `json:"-" xml:"-"`
 }
 
 type metadataService struct {
@@ -1240,7 +1240,7 @@ type SeverityLevel struct {
 	// The name of the severity level that corresponds to the severity level code.
 	Name *string `locationName:"name" type:"string"`
 
-	metadataSeverityLevel `json:"-", xml:"-"`
+	metadataSeverityLevel `json:"-" xml:"-"`
 }
 
 type metadataSeverityLevel struct {
@@ -1254,7 +1254,7 @@ type TrustedAdvisorCategorySpecificSummary struct {
 	// is in the Cost Optimizing category.
 	CostOptimizing *TrustedAdvisorCostOptimizingSummary `locationName:"costOptimizing" type:"structure"`
 
-	metadataTrustedAdvisorCategorySpecificSummary `json:"-", xml:"-"`
+	metadataTrustedAdvisorCategorySpecificSummary `json:"-" xml:"-"`
 }
 
 type metadataTrustedAdvisorCategorySpecificSummary struct {
@@ -1283,7 +1283,7 @@ type TrustedAdvisorCheckDescription struct {
 	// The display name for the Trusted Advisor check.
 	Name *string `locationName:"name" type:"string" required:"true"`
 
-	metadataTrustedAdvisorCheckDescription `json:"-", xml:"-"`
+	metadataTrustedAdvisorCheckDescription `json:"-" xml:"-"`
 }
 
 type metadataTrustedAdvisorCheckDescription struct {
@@ -1303,7 +1303,7 @@ type TrustedAdvisorCheckRefreshStatus struct {
 	// "none", "enqueued", "processing", "success", or "abandoned".
 	Status *string `locationName:"status" type:"string" required:"true"`
 
-	metadataTrustedAdvisorCheckRefreshStatus `json:"-", xml:"-"`
+	metadataTrustedAdvisorCheckRefreshStatus `json:"-" xml:"-"`
 }
 
 type metadataTrustedAdvisorCheckRefreshStatus struct {
@@ -1333,7 +1333,7 @@ type TrustedAdvisorCheckResult struct {
 	// The time of the last refresh of the check.
 	Timestamp *string `locationName:"timestamp" type:"string" required:"true"`
 
-	metadataTrustedAdvisorCheckResult `json:"-", xml:"-"`
+	metadataTrustedAdvisorCheckResult `json:"-" xml:"-"`
 }
 
 type metadataTrustedAdvisorCheckResult struct {
@@ -1364,7 +1364,7 @@ type TrustedAdvisorCheckSummary struct {
 	// The time of the last refresh of the check.
 	Timestamp *string `locationName:"timestamp" type:"string" required:"true"`
 
-	metadataTrustedAdvisorCheckSummary `json:"-", xml:"-"`
+	metadataTrustedAdvisorCheckSummary `json:"-" xml:"-"`
 }
 
 type metadataTrustedAdvisorCheckSummary struct {
@@ -1382,7 +1382,7 @@ type TrustedAdvisorCostOptimizingSummary struct {
 	// actions are taken.
 	EstimatedPercentMonthlySavings *float64 `locationName:"estimatedPercentMonthlySavings" type:"double" required:"true"`
 
-	metadataTrustedAdvisorCostOptimizingSummary `json:"-", xml:"-"`
+	metadataTrustedAdvisorCostOptimizingSummary `json:"-" xml:"-"`
 }
 
 type metadataTrustedAdvisorCostOptimizingSummary struct {
@@ -1411,7 +1411,7 @@ type TrustedAdvisorResourceDetail struct {
 	// The status code for the resource identified in the Trusted Advisor check.
 	Status *string `locationName:"status" type:"string" required:"true"`
 
-	metadataTrustedAdvisorResourceDetail `json:"-", xml:"-"`
+	metadataTrustedAdvisorResourceDetail `json:"-" xml:"-"`
 }
 
 type metadataTrustedAdvisorResourceDetail struct {
@@ -1436,7 +1436,7 @@ type TrustedAdvisorResourcesSummary struct {
 	// marked as suppressed by the user.
 	ResourcesSuppressed *int64 `locationName:"resourcesSuppressed" type:"long" required:"true"`
 
-	metadataTrustedAdvisorResourcesSummary `json:"-", xml:"-"`
+	metadataTrustedAdvisorResourcesSummary `json:"-" xml:"-"`
 }
 
 type metadataTrustedAdvisorResourcesSummary struct {

--- a/service/swf/api.go
+++ b/service/swf/api.go
@@ -1683,7 +1683,7 @@ type ActivityTaskCancelRequestedEventAttributes struct {
 	// back the chain of events leading up to this event.
 	DecisionTaskCompletedEventID *int64 `locationName:"decisionTaskCompletedEventId" type:"long" required:"true"`
 
-	metadataActivityTaskCancelRequestedEventAttributes `json:"-", xml:"-"`
+	metadataActivityTaskCancelRequestedEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataActivityTaskCancelRequestedEventAttributes struct {
@@ -1710,7 +1710,7 @@ type ActivityTaskCanceledEventAttributes struct {
 	// back the chain of events leading up to this event.
 	StartedEventID *int64 `locationName:"startedEventId" type:"long" required:"true"`
 
-	metadataActivityTaskCanceledEventAttributes `json:"-", xml:"-"`
+	metadataActivityTaskCanceledEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataActivityTaskCanceledEventAttributes struct {
@@ -1732,7 +1732,7 @@ type ActivityTaskCompletedEventAttributes struct {
 	// back the chain of events leading up to this event.
 	StartedEventID *int64 `locationName:"startedEventId" type:"long" required:"true"`
 
-	metadataActivityTaskCompletedEventAttributes `json:"-", xml:"-"`
+	metadataActivityTaskCompletedEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataActivityTaskCompletedEventAttributes struct {
@@ -1757,7 +1757,7 @@ type ActivityTaskFailedEventAttributes struct {
 	// back the chain of events leading up to this event.
 	StartedEventID *int64 `locationName:"startedEventId" type:"long" required:"true"`
 
-	metadataActivityTaskFailedEventAttributes `json:"-", xml:"-"`
+	metadataActivityTaskFailedEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataActivityTaskFailedEventAttributes struct {
@@ -1817,7 +1817,7 @@ type ActivityTaskScheduledEventAttributes struct {
 	// in the Amazon Simple Workflow Developer Guide.
 	TaskPriority *string `locationName:"taskPriority" type:"string"`
 
-	metadataActivityTaskScheduledEventAttributes `json:"-", xml:"-"`
+	metadataActivityTaskScheduledEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataActivityTaskScheduledEventAttributes struct {
@@ -1835,7 +1835,7 @@ type ActivityTaskStartedEventAttributes struct {
 	// by tracing back the chain of events leading up to this event.
 	ScheduledEventID *int64 `locationName:"scheduledEventId" type:"long" required:"true"`
 
-	metadataActivityTaskStartedEventAttributes `json:"-", xml:"-"`
+	metadataActivityTaskStartedEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataActivityTaskStartedEventAttributes struct {
@@ -1861,7 +1861,7 @@ type ActivityTaskTimedOutEventAttributes struct {
 	// The type of the timeout that caused this event.
 	TimeoutType *string `locationName:"timeoutType" type:"string" required:"true"`
 
-	metadataActivityTaskTimedOutEventAttributes `json:"-", xml:"-"`
+	metadataActivityTaskTimedOutEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataActivityTaskTimedOutEventAttributes struct {
@@ -1882,7 +1882,7 @@ type ActivityType struct {
 	// a domain.
 	Version *string `locationName:"version" type:"string" required:"true"`
 
-	metadataActivityType `json:"-", xml:"-"`
+	metadataActivityType `json:"-" xml:"-"`
 }
 
 type metadataActivityType struct {
@@ -1948,7 +1948,7 @@ type ActivityTypeConfiguration struct {
 	// 0. The value "NONE" can be used to specify unlimited duration.
 	DefaultTaskStartToCloseTimeout *string `locationName:"defaultTaskStartToCloseTimeout" type:"string"`
 
-	metadataActivityTypeConfiguration `json:"-", xml:"-"`
+	metadataActivityTypeConfiguration `json:"-" xml:"-"`
 }
 
 type metadataActivityTypeConfiguration struct {
@@ -1972,7 +1972,7 @@ type ActivityTypeInfo struct {
 	// The current status of the activity type.
 	Status *string `locationName:"status" type:"string" required:"true"`
 
-	metadataActivityTypeInfo `json:"-", xml:"-"`
+	metadataActivityTypeInfo `json:"-" xml:"-"`
 }
 
 type metadataActivityTypeInfo struct {
@@ -1998,7 +1998,7 @@ type CancelTimerDecisionAttributes struct {
 	// Required. The unique Id of the timer to cancel.
 	TimerID *string `locationName:"timerId" type:"string" required:"true"`
 
-	metadataCancelTimerDecisionAttributes `json:"-", xml:"-"`
+	metadataCancelTimerDecisionAttributes `json:"-" xml:"-"`
 }
 
 type metadataCancelTimerDecisionAttributes struct {
@@ -2024,7 +2024,7 @@ type CancelTimerFailedEventAttributes struct {
 	// The timerId provided in the CancelTimer decision that failed.
 	TimerID *string `locationName:"timerId" type:"string" required:"true"`
 
-	metadataCancelTimerFailedEventAttributes `json:"-", xml:"-"`
+	metadataCancelTimerFailedEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataCancelTimerFailedEventAttributes struct {
@@ -2050,7 +2050,7 @@ type CancelWorkflowExecutionDecisionAttributes struct {
 	// Optional. details of the cancellation.
 	Details *string `locationName:"details" type:"string"`
 
-	metadataCancelWorkflowExecutionDecisionAttributes `json:"-", xml:"-"`
+	metadataCancelWorkflowExecutionDecisionAttributes `json:"-" xml:"-"`
 }
 
 type metadataCancelWorkflowExecutionDecisionAttributes struct {
@@ -2073,7 +2073,7 @@ type CancelWorkflowExecutionFailedEventAttributes struct {
 	// back the chain of events leading up to this event.
 	DecisionTaskCompletedEventID *int64 `locationName:"decisionTaskCompletedEventId" type:"long" required:"true"`
 
-	metadataCancelWorkflowExecutionFailedEventAttributes `json:"-", xml:"-"`
+	metadataCancelWorkflowExecutionFailedEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataCancelWorkflowExecutionFailedEventAttributes struct {
@@ -2102,7 +2102,7 @@ type ChildWorkflowExecutionCanceledEventAttributes struct {
 	// The type of the child workflow execution.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
 
-	metadataChildWorkflowExecutionCanceledEventAttributes `json:"-", xml:"-"`
+	metadataChildWorkflowExecutionCanceledEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataChildWorkflowExecutionCanceledEventAttributes struct {
@@ -2131,7 +2131,7 @@ type ChildWorkflowExecutionCompletedEventAttributes struct {
 	// The type of the child workflow execution.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
 
-	metadataChildWorkflowExecutionCompletedEventAttributes `json:"-", xml:"-"`
+	metadataChildWorkflowExecutionCompletedEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataChildWorkflowExecutionCompletedEventAttributes struct {
@@ -2163,7 +2163,7 @@ type ChildWorkflowExecutionFailedEventAttributes struct {
 	// The type of the child workflow execution.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
 
-	metadataChildWorkflowExecutionFailedEventAttributes `json:"-", xml:"-"`
+	metadataChildWorkflowExecutionFailedEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataChildWorkflowExecutionFailedEventAttributes struct {
@@ -2184,7 +2184,7 @@ type ChildWorkflowExecutionStartedEventAttributes struct {
 	// The type of the child workflow execution.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
 
-	metadataChildWorkflowExecutionStartedEventAttributes `json:"-", xml:"-"`
+	metadataChildWorkflowExecutionStartedEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataChildWorkflowExecutionStartedEventAttributes struct {
@@ -2210,7 +2210,7 @@ type ChildWorkflowExecutionTerminatedEventAttributes struct {
 	// The type of the child workflow execution.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
 
-	metadataChildWorkflowExecutionTerminatedEventAttributes `json:"-", xml:"-"`
+	metadataChildWorkflowExecutionTerminatedEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataChildWorkflowExecutionTerminatedEventAttributes struct {
@@ -2240,7 +2240,7 @@ type ChildWorkflowExecutionTimedOutEventAttributes struct {
 	// The type of the child workflow execution.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
 
-	metadataChildWorkflowExecutionTimedOutEventAttributes `json:"-", xml:"-"`
+	metadataChildWorkflowExecutionTimedOutEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataChildWorkflowExecutionTimedOutEventAttributes struct {
@@ -2254,7 +2254,7 @@ type CloseStatusFilter struct {
 	// for it to meet the criteria of this filter.
 	Status *string `locationName:"status" type:"string" required:"true"`
 
-	metadataCloseStatusFilter `json:"-", xml:"-"`
+	metadataCloseStatusFilter `json:"-" xml:"-"`
 }
 
 type metadataCloseStatusFilter struct {
@@ -2281,7 +2281,7 @@ type CompleteWorkflowExecutionDecisionAttributes struct {
 	// defined.
 	Result *string `locationName:"result" type:"string"`
 
-	metadataCompleteWorkflowExecutionDecisionAttributes `json:"-", xml:"-"`
+	metadataCompleteWorkflowExecutionDecisionAttributes `json:"-" xml:"-"`
 }
 
 type metadataCompleteWorkflowExecutionDecisionAttributes struct {
@@ -2304,7 +2304,7 @@ type CompleteWorkflowExecutionFailedEventAttributes struct {
 	// back the chain of events leading up to this event.
 	DecisionTaskCompletedEventID *int64 `locationName:"decisionTaskCompletedEventId" type:"long" required:"true"`
 
-	metadataCompleteWorkflowExecutionFailedEventAttributes `json:"-", xml:"-"`
+	metadataCompleteWorkflowExecutionFailedEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataCompleteWorkflowExecutionFailedEventAttributes struct {
@@ -2399,7 +2399,7 @@ type ContinueAsNewWorkflowExecutionDecisionAttributes struct {
 
 	WorkflowTypeVersion *string `locationName:"workflowTypeVersion" type:"string"`
 
-	metadataContinueAsNewWorkflowExecutionDecisionAttributes `json:"-", xml:"-"`
+	metadataContinueAsNewWorkflowExecutionDecisionAttributes `json:"-" xml:"-"`
 }
 
 type metadataContinueAsNewWorkflowExecutionDecisionAttributes struct {
@@ -2422,7 +2422,7 @@ type ContinueAsNewWorkflowExecutionFailedEventAttributes struct {
 	// tracing back the chain of events leading up to this event.
 	DecisionTaskCompletedEventID *int64 `locationName:"decisionTaskCompletedEventId" type:"long" required:"true"`
 
-	metadataContinueAsNewWorkflowExecutionFailedEventAttributes `json:"-", xml:"-"`
+	metadataContinueAsNewWorkflowExecutionFailedEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataContinueAsNewWorkflowExecutionFailedEventAttributes struct {
@@ -2474,7 +2474,7 @@ type CountClosedWorkflowExecutionsInput struct {
 	// exclusive. You can specify at most one of these in a request.
 	TypeFilter *WorkflowTypeFilter `locationName:"typeFilter" type:"structure"`
 
-	metadataCountClosedWorkflowExecutionsInput `json:"-", xml:"-"`
+	metadataCountClosedWorkflowExecutionsInput `json:"-" xml:"-"`
 }
 
 type metadataCountClosedWorkflowExecutionsInput struct {
@@ -2509,7 +2509,7 @@ type CountOpenWorkflowExecutionsInput struct {
 	// specify at most one of these in a request.
 	TypeFilter *WorkflowTypeFilter `locationName:"typeFilter" type:"structure"`
 
-	metadataCountOpenWorkflowExecutionsInput `json:"-", xml:"-"`
+	metadataCountOpenWorkflowExecutionsInput `json:"-" xml:"-"`
 }
 
 type metadataCountOpenWorkflowExecutionsInput struct {
@@ -2523,7 +2523,7 @@ type CountPendingActivityTasksInput struct {
 	// The name of the task list.
 	TaskList *TaskList `locationName:"taskList" type:"structure" required:"true"`
 
-	metadataCountPendingActivityTasksInput `json:"-", xml:"-"`
+	metadataCountPendingActivityTasksInput `json:"-" xml:"-"`
 }
 
 type metadataCountPendingActivityTasksInput struct {
@@ -2537,7 +2537,7 @@ type CountPendingDecisionTasksInput struct {
 	// The name of the task list.
 	TaskList *TaskList `locationName:"taskList" type:"structure" required:"true"`
 
-	metadataCountPendingDecisionTasksInput `json:"-", xml:"-"`
+	metadataCountPendingDecisionTasksInput `json:"-" xml:"-"`
 }
 
 type metadataCountPendingDecisionTasksInput struct {
@@ -2699,7 +2699,7 @@ type Decision struct {
 	// types.
 	StartTimerDecisionAttributes *StartTimerDecisionAttributes `locationName:"startTimerDecisionAttributes" type:"structure"`
 
-	metadataDecision `json:"-", xml:"-"`
+	metadataDecision `json:"-" xml:"-"`
 }
 
 type metadataDecision struct {
@@ -2721,7 +2721,7 @@ type DecisionTaskCompletedEventAttributes struct {
 	// back the chain of events leading up to this event.
 	StartedEventID *int64 `locationName:"startedEventId" type:"long" required:"true"`
 
-	metadataDecisionTaskCompletedEventAttributes `json:"-", xml:"-"`
+	metadataDecisionTaskCompletedEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataDecisionTaskCompletedEventAttributes struct {
@@ -2750,7 +2750,7 @@ type DecisionTaskScheduledEventAttributes struct {
 	// in the Amazon Simple Workflow Developer Guide.
 	TaskPriority *string `locationName:"taskPriority" type:"string"`
 
-	metadataDecisionTaskScheduledEventAttributes `json:"-", xml:"-"`
+	metadataDecisionTaskScheduledEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataDecisionTaskScheduledEventAttributes struct {
@@ -2768,7 +2768,7 @@ type DecisionTaskStartedEventAttributes struct {
 	// by tracing back the chain of events leading up to this event.
 	ScheduledEventID *int64 `locationName:"scheduledEventId" type:"long" required:"true"`
 
-	metadataDecisionTaskStartedEventAttributes `json:"-", xml:"-"`
+	metadataDecisionTaskStartedEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataDecisionTaskStartedEventAttributes struct {
@@ -2790,7 +2790,7 @@ type DecisionTaskTimedOutEventAttributes struct {
 	// The type of timeout that expired before the decision task could be completed.
 	TimeoutType *string `locationName:"timeoutType" type:"string" required:"true"`
 
-	metadataDecisionTaskTimedOutEventAttributes `json:"-", xml:"-"`
+	metadataDecisionTaskTimedOutEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataDecisionTaskTimedOutEventAttributes struct {
@@ -2804,7 +2804,7 @@ type DeprecateActivityTypeInput struct {
 	// The name of the domain in which the activity type is registered.
 	Domain *string `locationName:"domain" type:"string" required:"true"`
 
-	metadataDeprecateActivityTypeInput `json:"-", xml:"-"`
+	metadataDeprecateActivityTypeInput `json:"-" xml:"-"`
 }
 
 type metadataDeprecateActivityTypeInput struct {
@@ -2812,7 +2812,7 @@ type metadataDeprecateActivityTypeInput struct {
 }
 
 type DeprecateActivityTypeOutput struct {
-	metadataDeprecateActivityTypeOutput `json:"-", xml:"-"`
+	metadataDeprecateActivityTypeOutput `json:"-" xml:"-"`
 }
 
 type metadataDeprecateActivityTypeOutput struct {
@@ -2823,7 +2823,7 @@ type DeprecateDomainInput struct {
 	// The name of the domain to deprecate.
 	Name *string `locationName:"name" type:"string" required:"true"`
 
-	metadataDeprecateDomainInput `json:"-", xml:"-"`
+	metadataDeprecateDomainInput `json:"-" xml:"-"`
 }
 
 type metadataDeprecateDomainInput struct {
@@ -2831,7 +2831,7 @@ type metadataDeprecateDomainInput struct {
 }
 
 type DeprecateDomainOutput struct {
-	metadataDeprecateDomainOutput `json:"-", xml:"-"`
+	metadataDeprecateDomainOutput `json:"-" xml:"-"`
 }
 
 type metadataDeprecateDomainOutput struct {
@@ -2845,7 +2845,7 @@ type DeprecateWorkflowTypeInput struct {
 	// The workflow type to deprecate.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
 
-	metadataDeprecateWorkflowTypeInput `json:"-", xml:"-"`
+	metadataDeprecateWorkflowTypeInput `json:"-" xml:"-"`
 }
 
 type metadataDeprecateWorkflowTypeInput struct {
@@ -2853,7 +2853,7 @@ type metadataDeprecateWorkflowTypeInput struct {
 }
 
 type DeprecateWorkflowTypeOutput struct {
-	metadataDeprecateWorkflowTypeOutput `json:"-", xml:"-"`
+	metadataDeprecateWorkflowTypeOutput `json:"-" xml:"-"`
 }
 
 type metadataDeprecateWorkflowTypeOutput struct {
@@ -2868,7 +2868,7 @@ type DescribeActivityTypeInput struct {
 	// The name of the domain in which the activity type is registered.
 	Domain *string `locationName:"domain" type:"string" required:"true"`
 
-	metadataDescribeActivityTypeInput `json:"-", xml:"-"`
+	metadataDescribeActivityTypeInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeActivityTypeInput struct {
@@ -2891,7 +2891,7 @@ type DescribeActivityTypeOutput struct {
 	// You cannot create new tasks of this type.
 	TypeInfo *ActivityTypeInfo `locationName:"typeInfo" type:"structure" required:"true"`
 
-	metadataDescribeActivityTypeOutput `json:"-", xml:"-"`
+	metadataDescribeActivityTypeOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeActivityTypeOutput struct {
@@ -2902,7 +2902,7 @@ type DescribeDomainInput struct {
 	// The name of the domain to describe.
 	Name *string `locationName:"name" type:"string" required:"true"`
 
-	metadataDescribeDomainInput `json:"-", xml:"-"`
+	metadataDescribeDomainInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeDomainInput struct {
@@ -2917,7 +2917,7 @@ type DescribeDomainOutput struct {
 	// Contains general information about a domain.
 	DomainInfo *DomainInfo `locationName:"domainInfo" type:"structure" required:"true"`
 
-	metadataDescribeDomainOutput `json:"-", xml:"-"`
+	metadataDescribeDomainOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeDomainOutput struct {
@@ -2931,7 +2931,7 @@ type DescribeWorkflowExecutionInput struct {
 	// The workflow execution to describe.
 	Execution *WorkflowExecution `locationName:"execution" type:"structure" required:"true"`
 
-	metadataDescribeWorkflowExecutionInput `json:"-", xml:"-"`
+	metadataDescribeWorkflowExecutionInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeWorkflowExecutionInput struct {
@@ -2961,7 +2961,7 @@ type DescribeWorkflowExecutionOutput struct {
 	// tasks of all types.
 	OpenCounts *WorkflowExecutionOpenCounts `locationName:"openCounts" type:"structure" required:"true"`
 
-	metadataDescribeWorkflowExecutionOutput `json:"-", xml:"-"`
+	metadataDescribeWorkflowExecutionOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeWorkflowExecutionOutput struct {
@@ -2975,7 +2975,7 @@ type DescribeWorkflowTypeInput struct {
 	// The workflow type to describe.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
 
-	metadataDescribeWorkflowTypeInput `json:"-", xml:"-"`
+	metadataDescribeWorkflowTypeInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeWorkflowTypeInput struct {
@@ -2998,7 +2998,7 @@ type DescribeWorkflowTypeOutput struct {
 	// You cannot create new workflow executions of this type.
 	TypeInfo *WorkflowTypeInfo `locationName:"typeInfo" type:"structure" required:"true"`
 
-	metadataDescribeWorkflowTypeOutput `json:"-", xml:"-"`
+	metadataDescribeWorkflowTypeOutput `json:"-" xml:"-"`
 }
 
 type metadataDescribeWorkflowTypeOutput struct {
@@ -3010,7 +3010,7 @@ type DomainConfiguration struct {
 	// The retention period for workflow executions in this domain.
 	WorkflowExecutionRetentionPeriodInDays *string `locationName:"workflowExecutionRetentionPeriodInDays" type:"string" required:"true"`
 
-	metadataDomainConfiguration `json:"-", xml:"-"`
+	metadataDomainConfiguration `json:"-" xml:"-"`
 }
 
 type metadataDomainConfiguration struct {
@@ -3033,7 +3033,7 @@ type DomainInfo struct {
 	// in use. You should not create new workflow executions in this domain.
 	Status *string `locationName:"status" type:"string" required:"true"`
 
-	metadataDomainInfo `json:"-", xml:"-"`
+	metadataDomainInfo `json:"-" xml:"-"`
 }
 
 type metadataDomainInfo struct {
@@ -3052,7 +3052,7 @@ type ExecutionTimeFilter struct {
 	// Specifies the oldest start or close date and time to return.
 	OldestDate *time.Time `locationName:"oldestDate" type:"timestamp" timestampFormat:"unix" required:"true"`
 
-	metadataExecutionTimeFilter `json:"-", xml:"-"`
+	metadataExecutionTimeFilter `json:"-" xml:"-"`
 }
 
 type metadataExecutionTimeFilter struct {
@@ -3070,7 +3070,7 @@ type ExternalWorkflowExecutionCancelRequestedEventAttributes struct {
 	// The external workflow execution to which the cancellation request was delivered.
 	WorkflowExecution *WorkflowExecution `locationName:"workflowExecution" type:"structure" required:"true"`
 
-	metadataExternalWorkflowExecutionCancelRequestedEventAttributes `json:"-", xml:"-"`
+	metadataExternalWorkflowExecutionCancelRequestedEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataExternalWorkflowExecutionCancelRequestedEventAttributes struct {
@@ -3088,7 +3088,7 @@ type ExternalWorkflowExecutionSignaledEventAttributes struct {
 	// The external workflow execution that the signal was delivered to.
 	WorkflowExecution *WorkflowExecution `locationName:"workflowExecution" type:"structure" required:"true"`
 
-	metadataExternalWorkflowExecutionSignaledEventAttributes `json:"-", xml:"-"`
+	metadataExternalWorkflowExecutionSignaledEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataExternalWorkflowExecutionSignaledEventAttributes struct {
@@ -3117,7 +3117,7 @@ type FailWorkflowExecutionDecisionAttributes struct {
 	// A descriptive reason for the failure that may help in diagnostics.
 	Reason *string `locationName:"reason" type:"string"`
 
-	metadataFailWorkflowExecutionDecisionAttributes `json:"-", xml:"-"`
+	metadataFailWorkflowExecutionDecisionAttributes `json:"-" xml:"-"`
 }
 
 type metadataFailWorkflowExecutionDecisionAttributes struct {
@@ -3140,7 +3140,7 @@ type FailWorkflowExecutionFailedEventAttributes struct {
 	// chain of events leading up to this event.
 	DecisionTaskCompletedEventID *int64 `locationName:"decisionTaskCompletedEventId" type:"long" required:"true"`
 
-	metadataFailWorkflowExecutionFailedEventAttributes `json:"-", xml:"-"`
+	metadataFailWorkflowExecutionFailedEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataFailWorkflowExecutionFailedEventAttributes struct {
@@ -3175,7 +3175,7 @@ type GetWorkflowExecutionHistoryInput struct {
 	// are returned in ascending order of the eventTimeStamp of the events.
 	ReverseOrder *bool `locationName:"reverseOrder" type:"boolean"`
 
-	metadataGetWorkflowExecutionHistoryInput `json:"-", xml:"-"`
+	metadataGetWorkflowExecutionHistoryInput `json:"-" xml:"-"`
 }
 
 type metadataGetWorkflowExecutionHistoryInput struct {
@@ -3197,7 +3197,7 @@ type GetWorkflowExecutionHistoryOutput struct {
 	// in a single call.
 	NextPageToken *string `locationName:"nextPageToken" type:"string"`
 
-	metadataGetWorkflowExecutionHistoryOutput `json:"-", xml:"-"`
+	metadataGetWorkflowExecutionHistoryOutput `json:"-" xml:"-"`
 }
 
 type metadataGetWorkflowExecutionHistoryOutput struct {
@@ -3499,7 +3499,7 @@ type HistoryEvent struct {
 	// event types.
 	WorkflowExecutionTimedOutEventAttributes *WorkflowExecutionTimedOutEventAttributes `locationName:"workflowExecutionTimedOutEventAttributes" type:"structure"`
 
-	metadataHistoryEvent `json:"-", xml:"-"`
+	metadataHistoryEvent `json:"-" xml:"-"`
 }
 
 type metadataHistoryEvent struct {
@@ -3537,7 +3537,7 @@ type ListActivityTypesInput struct {
 	// are returned in ascending alphabetical order by name of the activity types.
 	ReverseOrder *bool `locationName:"reverseOrder" type:"boolean"`
 
-	metadataListActivityTypesInput `json:"-", xml:"-"`
+	metadataListActivityTypesInput `json:"-" xml:"-"`
 }
 
 type metadataListActivityTypesInput struct {
@@ -3557,7 +3557,7 @@ type ListActivityTypesOutput struct {
 	// List of activity type information.
 	TypeInfos []*ActivityTypeInfo `locationName:"typeInfos" type:"list" required:"true"`
 
-	metadataListActivityTypesOutput `json:"-", xml:"-"`
+	metadataListActivityTypesOutput `json:"-" xml:"-"`
 }
 
 type metadataListActivityTypesOutput struct {
@@ -3634,7 +3634,7 @@ type ListClosedWorkflowExecutionsInput struct {
 	// exclusive. You can specify at most one of these in a request.
 	TypeFilter *WorkflowTypeFilter `locationName:"typeFilter" type:"structure"`
 
-	metadataListClosedWorkflowExecutionsInput `json:"-", xml:"-"`
+	metadataListClosedWorkflowExecutionsInput `json:"-" xml:"-"`
 }
 
 type metadataListClosedWorkflowExecutionsInput struct {
@@ -3666,7 +3666,7 @@ type ListDomainsInput struct {
 	// are returned in ascending alphabetical order by name of the domains.
 	ReverseOrder *bool `locationName:"reverseOrder" type:"boolean"`
 
-	metadataListDomainsInput `json:"-", xml:"-"`
+	metadataListDomainsInput `json:"-" xml:"-"`
 }
 
 type metadataListDomainsInput struct {
@@ -3686,7 +3686,7 @@ type ListDomainsOutput struct {
 	// in a single call.
 	NextPageToken *string `locationName:"nextPageToken" type:"string"`
 
-	metadataListDomainsOutput `json:"-", xml:"-"`
+	metadataListDomainsOutput `json:"-" xml:"-"`
 }
 
 type metadataListDomainsOutput struct {
@@ -3741,7 +3741,7 @@ type ListOpenWorkflowExecutionsInput struct {
 	// specify at most one of these in a request.
 	TypeFilter *WorkflowTypeFilter `locationName:"typeFilter" type:"structure"`
 
-	metadataListOpenWorkflowExecutionsInput `json:"-", xml:"-"`
+	metadataListOpenWorkflowExecutionsInput `json:"-" xml:"-"`
 }
 
 type metadataListOpenWorkflowExecutionsInput struct {
@@ -3780,7 +3780,7 @@ type ListWorkflowTypesInput struct {
 	// types.
 	ReverseOrder *bool `locationName:"reverseOrder" type:"boolean"`
 
-	metadataListWorkflowTypesInput `json:"-", xml:"-"`
+	metadataListWorkflowTypesInput `json:"-" xml:"-"`
 }
 
 type metadataListWorkflowTypesInput struct {
@@ -3800,7 +3800,7 @@ type ListWorkflowTypesOutput struct {
 	// The list of workflow type information.
 	TypeInfos []*WorkflowTypeInfo `locationName:"typeInfos" type:"list" required:"true"`
 
-	metadataListWorkflowTypesOutput `json:"-", xml:"-"`
+	metadataListWorkflowTypesOutput `json:"-" xml:"-"`
 }
 
 type metadataListWorkflowTypesOutput struct {
@@ -3821,7 +3821,7 @@ type MarkerRecordedEventAttributes struct {
 	// The name of the marker.
 	MarkerName *string `locationName:"markerName" type:"string" required:"true"`
 
-	metadataMarkerRecordedEventAttributes `json:"-", xml:"-"`
+	metadataMarkerRecordedEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataMarkerRecordedEventAttributes struct {
@@ -3837,7 +3837,7 @@ type PendingTaskCount struct {
 	// supported by this API and the count returned is the truncated value.
 	Truncated *bool `locationName:"truncated" type:"boolean"`
 
-	metadataPendingTaskCount `json:"-", xml:"-"`
+	metadataPendingTaskCount `json:"-" xml:"-"`
 }
 
 type metadataPendingTaskCount struct {
@@ -3861,7 +3861,7 @@ type PollForActivityTaskInput struct {
 	// string quotarnquot.
 	TaskList *TaskList `locationName:"taskList" type:"structure" required:"true"`
 
-	metadataPollForActivityTaskInput `json:"-", xml:"-"`
+	metadataPollForActivityTaskInput `json:"-" xml:"-"`
 }
 
 type metadataPollForActivityTaskInput struct {
@@ -3891,7 +3891,7 @@ type PollForActivityTaskOutput struct {
 	// The workflow execution that started this activity task.
 	WorkflowExecution *WorkflowExecution `locationName:"workflowExecution" type:"structure" required:"true"`
 
-	metadataPollForActivityTaskOutput `json:"-", xml:"-"`
+	metadataPollForActivityTaskOutput `json:"-" xml:"-"`
 }
 
 type metadataPollForActivityTaskOutput struct {
@@ -3941,7 +3941,7 @@ type PollForDecisionTaskInput struct {
 	// string quotarnquot.
 	TaskList *TaskList `locationName:"taskList" type:"structure" required:"true"`
 
-	metadataPollForDecisionTaskInput `json:"-", xml:"-"`
+	metadataPollForDecisionTaskInput `json:"-" xml:"-"`
 }
 
 type metadataPollForDecisionTaskInput struct {
@@ -3983,7 +3983,7 @@ type PollForDecisionTaskOutput struct {
 	// The type of the workflow execution for which this decision task was created.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
 
-	metadataPollForDecisionTaskOutput `json:"-", xml:"-"`
+	metadataPollForDecisionTaskOutput `json:"-" xml:"-"`
 }
 
 type metadataPollForDecisionTaskOutput struct {
@@ -4001,7 +4001,7 @@ type RecordActivityTaskHeartbeatInput struct {
 	// be passed. This enables it to provide its progress and respond with results.
 	TaskToken *string `locationName:"taskToken" type:"string" required:"true"`
 
-	metadataRecordActivityTaskHeartbeatInput `json:"-", xml:"-"`
+	metadataRecordActivityTaskHeartbeatInput `json:"-" xml:"-"`
 }
 
 type metadataRecordActivityTaskHeartbeatInput struct {
@@ -4013,7 +4013,7 @@ type RecordActivityTaskHeartbeatOutput struct {
 	// Set to true if cancellation of the task is requested.
 	CancelRequested *bool `locationName:"cancelRequested" type:"boolean" required:"true"`
 
-	metadataRecordActivityTaskHeartbeatOutput `json:"-", xml:"-"`
+	metadataRecordActivityTaskHeartbeatOutput `json:"-" xml:"-"`
 }
 
 type metadataRecordActivityTaskHeartbeatOutput struct {
@@ -4042,7 +4042,7 @@ type RecordMarkerDecisionAttributes struct {
 	// Required. The name of the marker.
 	MarkerName *string `locationName:"markerName" type:"string" required:"true"`
 
-	metadataRecordMarkerDecisionAttributes `json:"-", xml:"-"`
+	metadataRecordMarkerDecisionAttributes `json:"-" xml:"-"`
 }
 
 type metadataRecordMarkerDecisionAttributes struct {
@@ -4068,7 +4068,7 @@ type RecordMarkerFailedEventAttributes struct {
 	// The marker's name.
 	MarkerName *string `locationName:"markerName" type:"string" required:"true"`
 
-	metadataRecordMarkerFailedEventAttributes `json:"-", xml:"-"`
+	metadataRecordMarkerFailedEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataRecordMarkerFailedEventAttributes struct {
@@ -4151,7 +4151,7 @@ type RegisterActivityTypeInput struct {
 	// it must not contain the literal string quotarnquot.
 	Version *string `locationName:"version" type:"string" required:"true"`
 
-	metadataRegisterActivityTypeInput `json:"-", xml:"-"`
+	metadataRegisterActivityTypeInput `json:"-" xml:"-"`
 }
 
 type metadataRegisterActivityTypeInput struct {
@@ -4159,7 +4159,7 @@ type metadataRegisterActivityTypeInput struct {
 }
 
 type RegisterActivityTypeOutput struct {
-	metadataRegisterActivityTypeOutput `json:"-", xml:"-"`
+	metadataRegisterActivityTypeOutput `json:"-" xml:"-"`
 }
 
 type metadataRegisterActivityTypeOutput struct {
@@ -4192,7 +4192,7 @@ type RegisterDomainInput struct {
 	// in the Amazon SWF Developer Guide.
 	WorkflowExecutionRetentionPeriodInDays *string `locationName:"workflowExecutionRetentionPeriodInDays" type:"string" required:"true"`
 
-	metadataRegisterDomainInput `json:"-", xml:"-"`
+	metadataRegisterDomainInput `json:"-" xml:"-"`
 }
 
 type metadataRegisterDomainInput struct {
@@ -4200,7 +4200,7 @@ type metadataRegisterDomainInput struct {
 }
 
 type RegisterDomainOutput struct {
-	metadataRegisterDomainOutput `json:"-", xml:"-"`
+	metadataRegisterDomainOutput `json:"-" xml:"-"`
 }
 
 type metadataRegisterDomainOutput struct {
@@ -4283,7 +4283,7 @@ type RegisterWorkflowTypeInput struct {
 	// Also, it must not contain the literal string quotarnquot.
 	Version *string `locationName:"version" type:"string" required:"true"`
 
-	metadataRegisterWorkflowTypeInput `json:"-", xml:"-"`
+	metadataRegisterWorkflowTypeInput `json:"-" xml:"-"`
 }
 
 type metadataRegisterWorkflowTypeInput struct {
@@ -4291,7 +4291,7 @@ type metadataRegisterWorkflowTypeInput struct {
 }
 
 type RegisterWorkflowTypeOutput struct {
-	metadataRegisterWorkflowTypeOutput `json:"-", xml:"-"`
+	metadataRegisterWorkflowTypeOutput `json:"-" xml:"-"`
 }
 
 type metadataRegisterWorkflowTypeOutput struct {
@@ -4317,7 +4317,7 @@ type RequestCancelActivityTaskDecisionAttributes struct {
 	// The activityId of the activity task to be canceled.
 	ActivityID *string `locationName:"activityId" type:"string" required:"true"`
 
-	metadataRequestCancelActivityTaskDecisionAttributes `json:"-", xml:"-"`
+	metadataRequestCancelActivityTaskDecisionAttributes `json:"-" xml:"-"`
 }
 
 type metadataRequestCancelActivityTaskDecisionAttributes struct {
@@ -4343,7 +4343,7 @@ type RequestCancelActivityTaskFailedEventAttributes struct {
 	// back the chain of events leading up to this event.
 	DecisionTaskCompletedEventID *int64 `locationName:"decisionTaskCompletedEventId" type:"long" required:"true"`
 
-	metadataRequestCancelActivityTaskFailedEventAttributes `json:"-", xml:"-"`
+	metadataRequestCancelActivityTaskFailedEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataRequestCancelActivityTaskFailedEventAttributes struct {
@@ -4376,7 +4376,7 @@ type RequestCancelExternalWorkflowExecutionDecisionAttributes struct {
 	// Required. The workflowId of the external workflow execution to cancel.
 	WorkflowID *string `locationName:"workflowId" type:"string" required:"true"`
 
-	metadataRequestCancelExternalWorkflowExecutionDecisionAttributes `json:"-", xml:"-"`
+	metadataRequestCancelExternalWorkflowExecutionDecisionAttributes `json:"-" xml:"-"`
 }
 
 type metadataRequestCancelExternalWorkflowExecutionDecisionAttributes struct {
@@ -4414,7 +4414,7 @@ type RequestCancelExternalWorkflowExecutionFailedEventAttributes struct {
 	// be delivered.
 	WorkflowID *string `locationName:"workflowId" type:"string" required:"true"`
 
-	metadataRequestCancelExternalWorkflowExecutionFailedEventAttributes `json:"-", xml:"-"`
+	metadataRequestCancelExternalWorkflowExecutionFailedEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataRequestCancelExternalWorkflowExecutionFailedEventAttributes struct {
@@ -4439,7 +4439,7 @@ type RequestCancelExternalWorkflowExecutionInitiatedEventAttributes struct {
 	// The workflowId of the external workflow execution to be canceled.
 	WorkflowID *string `locationName:"workflowId" type:"string" required:"true"`
 
-	metadataRequestCancelExternalWorkflowExecutionInitiatedEventAttributes `json:"-", xml:"-"`
+	metadataRequestCancelExternalWorkflowExecutionInitiatedEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataRequestCancelExternalWorkflowExecutionInitiatedEventAttributes struct {
@@ -4456,7 +4456,7 @@ type RequestCancelWorkflowExecutionInput struct {
 	// The workflowId of the workflow execution to cancel.
 	WorkflowID *string `locationName:"workflowId" type:"string" required:"true"`
 
-	metadataRequestCancelWorkflowExecutionInput `json:"-", xml:"-"`
+	metadataRequestCancelWorkflowExecutionInput `json:"-" xml:"-"`
 }
 
 type metadataRequestCancelWorkflowExecutionInput struct {
@@ -4464,7 +4464,7 @@ type metadataRequestCancelWorkflowExecutionInput struct {
 }
 
 type RequestCancelWorkflowExecutionOutput struct {
-	metadataRequestCancelWorkflowExecutionOutput `json:"-", xml:"-"`
+	metadataRequestCancelWorkflowExecutionOutput `json:"-" xml:"-"`
 }
 
 type metadataRequestCancelWorkflowExecutionOutput struct {
@@ -4482,7 +4482,7 @@ type RespondActivityTaskCanceledInput struct {
 	// be passed. This enables it to provide its progress and respond with results.
 	TaskToken *string `locationName:"taskToken" type:"string" required:"true"`
 
-	metadataRespondActivityTaskCanceledInput `json:"-", xml:"-"`
+	metadataRespondActivityTaskCanceledInput `json:"-" xml:"-"`
 }
 
 type metadataRespondActivityTaskCanceledInput struct {
@@ -4490,7 +4490,7 @@ type metadataRespondActivityTaskCanceledInput struct {
 }
 
 type RespondActivityTaskCanceledOutput struct {
-	metadataRespondActivityTaskCanceledOutput `json:"-", xml:"-"`
+	metadataRespondActivityTaskCanceledOutput `json:"-" xml:"-"`
 }
 
 type metadataRespondActivityTaskCanceledOutput struct {
@@ -4509,7 +4509,7 @@ type RespondActivityTaskCompletedInput struct {
 	// be passed. This enables it to provide its progress and respond with results.
 	TaskToken *string `locationName:"taskToken" type:"string" required:"true"`
 
-	metadataRespondActivityTaskCompletedInput `json:"-", xml:"-"`
+	metadataRespondActivityTaskCompletedInput `json:"-" xml:"-"`
 }
 
 type metadataRespondActivityTaskCompletedInput struct {
@@ -4517,7 +4517,7 @@ type metadataRespondActivityTaskCompletedInput struct {
 }
 
 type RespondActivityTaskCompletedOutput struct {
-	metadataRespondActivityTaskCompletedOutput `json:"-", xml:"-"`
+	metadataRespondActivityTaskCompletedOutput `json:"-" xml:"-"`
 }
 
 type metadataRespondActivityTaskCompletedOutput struct {
@@ -4538,7 +4538,7 @@ type RespondActivityTaskFailedInput struct {
 	// be passed. This enables it to provide its progress and respond with results.
 	TaskToken *string `locationName:"taskToken" type:"string" required:"true"`
 
-	metadataRespondActivityTaskFailedInput `json:"-", xml:"-"`
+	metadataRespondActivityTaskFailedInput `json:"-" xml:"-"`
 }
 
 type metadataRespondActivityTaskFailedInput struct {
@@ -4546,7 +4546,7 @@ type metadataRespondActivityTaskFailedInput struct {
 }
 
 type RespondActivityTaskFailedOutput struct {
-	metadataRespondActivityTaskFailedOutput `json:"-", xml:"-"`
+	metadataRespondActivityTaskFailedOutput `json:"-" xml:"-"`
 }
 
 type metadataRespondActivityTaskFailedOutput struct {
@@ -4568,7 +4568,7 @@ type RespondDecisionTaskCompletedInput struct {
 	// be passed. This enables it to provide its progress and respond with results.
 	TaskToken *string `locationName:"taskToken" type:"string" required:"true"`
 
-	metadataRespondDecisionTaskCompletedInput `json:"-", xml:"-"`
+	metadataRespondDecisionTaskCompletedInput `json:"-" xml:"-"`
 }
 
 type metadataRespondDecisionTaskCompletedInput struct {
@@ -4576,7 +4576,7 @@ type metadataRespondDecisionTaskCompletedInput struct {
 }
 
 type RespondDecisionTaskCompletedOutput struct {
-	metadataRespondDecisionTaskCompletedOutput `json:"-", xml:"-"`
+	metadataRespondDecisionTaskCompletedOutput `json:"-" xml:"-"`
 }
 
 type metadataRespondDecisionTaskCompletedOutput struct {
@@ -4692,7 +4692,7 @@ type ScheduleActivityTaskDecisionAttributes struct {
 	// in the Amazon Simple Workflow Developer Guide.
 	TaskPriority *string `locationName:"taskPriority" type:"string"`
 
-	metadataScheduleActivityTaskDecisionAttributes `json:"-", xml:"-"`
+	metadataScheduleActivityTaskDecisionAttributes `json:"-" xml:"-"`
 }
 
 type metadataScheduleActivityTaskDecisionAttributes struct {
@@ -4721,7 +4721,7 @@ type ScheduleActivityTaskFailedEventAttributes struct {
 	// up to this event.
 	DecisionTaskCompletedEventID *int64 `locationName:"decisionTaskCompletedEventId" type:"long" required:"true"`
 
-	metadataScheduleActivityTaskFailedEventAttributes `json:"-", xml:"-"`
+	metadataScheduleActivityTaskFailedEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataScheduleActivityTaskFailedEventAttributes struct {
@@ -4762,7 +4762,7 @@ type SignalExternalWorkflowExecutionDecisionAttributes struct {
 	// Required. The workflowId of the workflow execution to be signaled.
 	WorkflowID *string `locationName:"workflowId" type:"string" required:"true"`
 
-	metadataSignalExternalWorkflowExecutionDecisionAttributes `json:"-", xml:"-"`
+	metadataSignalExternalWorkflowExecutionDecisionAttributes `json:"-" xml:"-"`
 }
 
 type metadataSignalExternalWorkflowExecutionDecisionAttributes struct {
@@ -4801,7 +4801,7 @@ type SignalExternalWorkflowExecutionFailedEventAttributes struct {
 	// delivered to.
 	WorkflowID *string `locationName:"workflowId" type:"string" required:"true"`
 
-	metadataSignalExternalWorkflowExecutionFailedEventAttributes `json:"-", xml:"-"`
+	metadataSignalExternalWorkflowExecutionFailedEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataSignalExternalWorkflowExecutionFailedEventAttributes struct {
@@ -4832,7 +4832,7 @@ type SignalExternalWorkflowExecutionInitiatedEventAttributes struct {
 	// The workflowId of the external workflow execution.
 	WorkflowID *string `locationName:"workflowId" type:"string" required:"true"`
 
-	metadataSignalExternalWorkflowExecutionInitiatedEventAttributes `json:"-", xml:"-"`
+	metadataSignalExternalWorkflowExecutionInitiatedEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataSignalExternalWorkflowExecutionInitiatedEventAttributes struct {
@@ -4856,7 +4856,7 @@ type SignalWorkflowExecutionInput struct {
 	// The workflowId of the workflow execution to signal.
 	WorkflowID *string `locationName:"workflowId" type:"string" required:"true"`
 
-	metadataSignalWorkflowExecutionInput `json:"-", xml:"-"`
+	metadataSignalWorkflowExecutionInput `json:"-" xml:"-"`
 }
 
 type metadataSignalWorkflowExecutionInput struct {
@@ -4864,7 +4864,7 @@ type metadataSignalWorkflowExecutionInput struct {
 }
 
 type SignalWorkflowExecutionOutput struct {
-	metadataSignalWorkflowExecutionOutput `json:"-", xml:"-"`
+	metadataSignalWorkflowExecutionOutput `json:"-" xml:"-"`
 }
 
 type metadataSignalWorkflowExecutionOutput struct {
@@ -4981,7 +4981,7 @@ type StartChildWorkflowExecutionDecisionAttributes struct {
 	// Required. The type of the workflow execution to be started.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
 
-	metadataStartChildWorkflowExecutionDecisionAttributes `json:"-", xml:"-"`
+	metadataStartChildWorkflowExecutionDecisionAttributes `json:"-" xml:"-"`
 }
 
 type metadataStartChildWorkflowExecutionDecisionAttributes struct {
@@ -5019,7 +5019,7 @@ type StartChildWorkflowExecutionFailedEventAttributes struct {
 	// failed.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
 
-	metadataStartChildWorkflowExecutionFailedEventAttributes `json:"-", xml:"-"`
+	metadataStartChildWorkflowExecutionFailedEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataStartChildWorkflowExecutionFailedEventAttributes struct {
@@ -5090,7 +5090,7 @@ type StartChildWorkflowExecutionInitiatedEventAttributes struct {
 	// The type of the child workflow execution.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
 
-	metadataStartChildWorkflowExecutionInitiatedEventAttributes `json:"-", xml:"-"`
+	metadataStartChildWorkflowExecutionInitiatedEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataStartChildWorkflowExecutionInitiatedEventAttributes struct {
@@ -5131,7 +5131,7 @@ type StartTimerDecisionAttributes struct {
 	// string quotarnquot.
 	TimerID *string `locationName:"timerId" type:"string" required:"true"`
 
-	metadataStartTimerDecisionAttributes `json:"-", xml:"-"`
+	metadataStartTimerDecisionAttributes `json:"-" xml:"-"`
 }
 
 type metadataStartTimerDecisionAttributes struct {
@@ -5157,7 +5157,7 @@ type StartTimerFailedEventAttributes struct {
 	// The timerId provided in the StartTimer decision that failed.
 	TimerID *string `locationName:"timerId" type:"string" required:"true"`
 
-	metadataStartTimerFailedEventAttributes `json:"-", xml:"-"`
+	metadataStartTimerFailedEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataStartTimerFailedEventAttributes struct {
@@ -5265,7 +5265,7 @@ type StartWorkflowExecutionInput struct {
 	// The type of the workflow to start.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
 
-	metadataStartWorkflowExecutionInput `json:"-", xml:"-"`
+	metadataStartWorkflowExecutionInput `json:"-" xml:"-"`
 }
 
 type metadataStartWorkflowExecutionInput struct {
@@ -5278,7 +5278,7 @@ type StartWorkflowExecutionOutput struct {
 	// can be used to uniquely identify the workflow execution within a domain.
 	RunID *string `locationName:"runId" type:"string"`
 
-	metadataStartWorkflowExecutionOutput `json:"-", xml:"-"`
+	metadataStartWorkflowExecutionOutput `json:"-" xml:"-"`
 }
 
 type metadataStartWorkflowExecutionOutput struct {
@@ -5291,7 +5291,7 @@ type TagFilter struct {
 	// it to meet the filter criteria.
 	Tag *string `locationName:"tag" type:"string" required:"true"`
 
-	metadataTagFilter `json:"-", xml:"-"`
+	metadataTagFilter `json:"-" xml:"-"`
 }
 
 type metadataTagFilter struct {
@@ -5303,7 +5303,7 @@ type TaskList struct {
 	// The name of the task list.
 	Name *string `locationName:"name" type:"string" required:"true"`
 
-	metadataTaskList `json:"-", xml:"-"`
+	metadataTaskList `json:"-" xml:"-"`
 }
 
 type metadataTaskList struct {
@@ -5344,7 +5344,7 @@ type TerminateWorkflowExecutionInput struct {
 	// The workflowId of the workflow execution to terminate.
 	WorkflowID *string `locationName:"workflowId" type:"string" required:"true"`
 
-	metadataTerminateWorkflowExecutionInput `json:"-", xml:"-"`
+	metadataTerminateWorkflowExecutionInput `json:"-" xml:"-"`
 }
 
 type metadataTerminateWorkflowExecutionInput struct {
@@ -5352,7 +5352,7 @@ type metadataTerminateWorkflowExecutionInput struct {
 }
 
 type TerminateWorkflowExecutionOutput struct {
-	metadataTerminateWorkflowExecutionOutput `json:"-", xml:"-"`
+	metadataTerminateWorkflowExecutionOutput `json:"-" xml:"-"`
 }
 
 type metadataTerminateWorkflowExecutionOutput struct {
@@ -5375,7 +5375,7 @@ type TimerCanceledEventAttributes struct {
 	// The unique Id of the timer that was canceled.
 	TimerID *string `locationName:"timerId" type:"string" required:"true"`
 
-	metadataTimerCanceledEventAttributes `json:"-", xml:"-"`
+	metadataTimerCanceledEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataTimerCanceledEventAttributes struct {
@@ -5392,7 +5392,7 @@ type TimerFiredEventAttributes struct {
 	// The unique Id of the timer that fired.
 	TimerID *string `locationName:"timerId" type:"string" required:"true"`
 
-	metadataTimerFiredEventAttributes `json:"-", xml:"-"`
+	metadataTimerFiredEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataTimerFiredEventAttributes struct {
@@ -5420,7 +5420,7 @@ type TimerStartedEventAttributes struct {
 	// The unique Id of the timer that was started.
 	TimerID *string `locationName:"timerId" type:"string" required:"true"`
 
-	metadataTimerStartedEventAttributes `json:"-", xml:"-"`
+	metadataTimerStartedEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataTimerStartedEventAttributes struct {
@@ -5435,7 +5435,7 @@ type WorkflowExecution struct {
 	// The user defined identifier associated with the workflow execution.
 	WorkflowID *string `locationName:"workflowId" type:"string" required:"true"`
 
-	metadataWorkflowExecution `json:"-", xml:"-"`
+	metadataWorkflowExecution `json:"-" xml:"-"`
 }
 
 type metadataWorkflowExecution struct {
@@ -5459,7 +5459,7 @@ type WorkflowExecutionCancelRequestedEventAttributes struct {
 	// The external workflow execution for which the cancellation was requested.
 	ExternalWorkflowExecution *WorkflowExecution `locationName:"externalWorkflowExecution" type:"structure"`
 
-	metadataWorkflowExecutionCancelRequestedEventAttributes `json:"-", xml:"-"`
+	metadataWorkflowExecutionCancelRequestedEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataWorkflowExecutionCancelRequestedEventAttributes struct {
@@ -5477,7 +5477,7 @@ type WorkflowExecutionCanceledEventAttributes struct {
 	// Details for the cancellation (if any).
 	Details *string `locationName:"details" type:"string"`
 
-	metadataWorkflowExecutionCanceledEventAttributes `json:"-", xml:"-"`
+	metadataWorkflowExecutionCanceledEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataWorkflowExecutionCanceledEventAttributes struct {
@@ -5495,7 +5495,7 @@ type WorkflowExecutionCompletedEventAttributes struct {
 	// The result produced by the workflow execution upon successful completion.
 	Result *string `locationName:"result" type:"string"`
 
-	metadataWorkflowExecutionCompletedEventAttributes `json:"-", xml:"-"`
+	metadataWorkflowExecutionCompletedEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataWorkflowExecutionCompletedEventAttributes struct {
@@ -5544,7 +5544,7 @@ type WorkflowExecutionConfiguration struct {
 	// 0. The value "NONE" can be used to specify unlimited duration.
 	TaskStartToCloseTimeout *string `locationName:"taskStartToCloseTimeout" type:"string" required:"true"`
 
-	metadataWorkflowExecutionConfiguration `json:"-", xml:"-"`
+	metadataWorkflowExecutionConfiguration `json:"-" xml:"-"`
 }
 
 type metadataWorkflowExecutionConfiguration struct {
@@ -5601,7 +5601,7 @@ type WorkflowExecutionContinuedAsNewEventAttributes struct {
 	// Represents a workflow type.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
 
-	metadataWorkflowExecutionContinuedAsNewEventAttributes `json:"-", xml:"-"`
+	metadataWorkflowExecutionContinuedAsNewEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataWorkflowExecutionContinuedAsNewEventAttributes struct {
@@ -5618,7 +5618,7 @@ type WorkflowExecutionCount struct {
 	// supported by this API and the count returned is the truncated value.
 	Truncated *bool `locationName:"truncated" type:"boolean"`
 
-	metadataWorkflowExecutionCount `json:"-", xml:"-"`
+	metadataWorkflowExecutionCount `json:"-" xml:"-"`
 }
 
 type metadataWorkflowExecutionCount struct {
@@ -5639,7 +5639,7 @@ type WorkflowExecutionFailedEventAttributes struct {
 	// The descriptive reason provided for the failure (if any).
 	Reason *string `locationName:"reason" type:"string"`
 
-	metadataWorkflowExecutionFailedEventAttributes `json:"-", xml:"-"`
+	metadataWorkflowExecutionFailedEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataWorkflowExecutionFailedEventAttributes struct {
@@ -5651,7 +5651,7 @@ type WorkflowExecutionFilter struct {
 	// The workflowId to pass of match the criteria of this filter.
 	WorkflowID *string `locationName:"workflowId" type:"string" required:"true"`
 
-	metadataWorkflowExecutionFilter `json:"-", xml:"-"`
+	metadataWorkflowExecutionFilter `json:"-" xml:"-"`
 }
 
 type metadataWorkflowExecutionFilter struct {
@@ -5700,7 +5700,7 @@ type WorkflowExecutionInfo struct {
 	// The type of the workflow execution.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
 
-	metadataWorkflowExecutionInfo `json:"-", xml:"-"`
+	metadataWorkflowExecutionInfo `json:"-" xml:"-"`
 }
 
 type metadataWorkflowExecutionInfo struct {
@@ -5720,7 +5720,7 @@ type WorkflowExecutionInfos struct {
 	// in a single call.
 	NextPageToken *string `locationName:"nextPageToken" type:"string"`
 
-	metadataWorkflowExecutionInfos `json:"-", xml:"-"`
+	metadataWorkflowExecutionInfos `json:"-" xml:"-"`
 }
 
 type metadataWorkflowExecutionInfos struct {
@@ -5744,7 +5744,7 @@ type WorkflowExecutionOpenCounts struct {
 	// yet.
 	OpenTimers *int64 `locationName:"openTimers" type:"integer" required:"true"`
 
-	metadataWorkflowExecutionOpenCounts `json:"-", xml:"-"`
+	metadataWorkflowExecutionOpenCounts `json:"-" xml:"-"`
 }
 
 type metadataWorkflowExecutionOpenCounts struct {
@@ -5773,7 +5773,7 @@ type WorkflowExecutionSignaledEventAttributes struct {
 	// inputs to determine how to the process the signal.
 	SignalName *string `locationName:"signalName" type:"string" required:"true"`
 
-	metadataWorkflowExecutionSignaledEventAttributes `json:"-", xml:"-"`
+	metadataWorkflowExecutionSignaledEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataWorkflowExecutionSignaledEventAttributes struct {
@@ -5839,7 +5839,7 @@ type WorkflowExecutionStartedEventAttributes struct {
 	// The workflow type of this execution.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
 
-	metadataWorkflowExecutionStartedEventAttributes `json:"-", xml:"-"`
+	metadataWorkflowExecutionStartedEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataWorkflowExecutionStartedEventAttributes struct {
@@ -5870,7 +5870,7 @@ type WorkflowExecutionTerminatedEventAttributes struct {
 	// The reason provided for the termination (if any).
 	Reason *string `locationName:"reason" type:"string"`
 
-	metadataWorkflowExecutionTerminatedEventAttributes `json:"-", xml:"-"`
+	metadataWorkflowExecutionTerminatedEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataWorkflowExecutionTerminatedEventAttributes struct {
@@ -5893,7 +5893,7 @@ type WorkflowExecutionTimedOutEventAttributes struct {
 	// The type of timeout that caused this event.
 	TimeoutType *string `locationName:"timeoutType" type:"string" required:"true"`
 
-	metadataWorkflowExecutionTimedOutEventAttributes `json:"-", xml:"-"`
+	metadataWorkflowExecutionTimedOutEventAttributes `json:"-" xml:"-"`
 }
 
 type metadataWorkflowExecutionTimedOutEventAttributes struct {
@@ -5914,7 +5914,7 @@ type WorkflowType struct {
 	// a domain.
 	Version *string `locationName:"version" type:"string" required:"true"`
 
-	metadataWorkflowType `json:"-", xml:"-"`
+	metadataWorkflowType `json:"-" xml:"-"`
 }
 
 type metadataWorkflowType struct {
@@ -5978,7 +5978,7 @@ type WorkflowTypeConfiguration struct {
 	// 0. The value "NONE" can be used to specify unlimited duration.
 	DefaultTaskStartToCloseTimeout *string `locationName:"defaultTaskStartToCloseTimeout" type:"string"`
 
-	metadataWorkflowTypeConfiguration `json:"-", xml:"-"`
+	metadataWorkflowTypeConfiguration `json:"-" xml:"-"`
 }
 
 type metadataWorkflowTypeConfiguration struct {
@@ -5994,7 +5994,7 @@ type WorkflowTypeFilter struct {
 	// Version of the workflow type.
 	Version *string `locationName:"version" type:"string"`
 
-	metadataWorkflowTypeFilter `json:"-", xml:"-"`
+	metadataWorkflowTypeFilter `json:"-" xml:"-"`
 }
 
 type metadataWorkflowTypeFilter struct {
@@ -6019,7 +6019,7 @@ type WorkflowTypeInfo struct {
 	// The workflow type this information is about.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
 
-	metadataWorkflowTypeInfo `json:"-", xml:"-"`
+	metadataWorkflowTypeInfo `json:"-" xml:"-"`
 }
 
 type metadataWorkflowTypeInfo struct {


### PR DESCRIPTION
Tags should be space separated with the values of a tag being comma separated.
See [playground example](https://play.golang.org/p/MAnakYbuor).

This modifies the tags to do what they were intended to I believe.

I also made a minor spacing change in `integration/generate.go` so that the `go vet` tool doesn't complain about anything anywhere anymore.