### PR TITLE
Fixes retry support to not fail due to body not being rewound between retry attempts. (#204+#196)

### DIFF
--- a/aws/handler_functions.go
+++ b/aws/handler_functions.go
@@ -29,10 +29,10 @@ func BuildContentLength(r *Request) {
 	case lener:
 		length = int64(body.Len())
 	case io.Seeker:
-		cur, _ := body.Seek(0, 1)
+		r.bodyStart, _ = body.Seek(0, 1)
 		end, _ := body.Seek(0, 2)
-		body.Seek(cur, 0) // make sure to seek back to original location
-		length = end - cur
+		body.Seek(r.bodyStart, 0) // make sure to seek back to original location
+		length = end - r.bodyStart
 	default:
 		panic("Cannot get length of body, must provide `ContentLength`")
 	}
@@ -62,6 +62,9 @@ func ValidateResponseHandler(r *Request) {
 func RetryHandler(r *Request) {
 	r.Retryable = r.Service.ShouldRetry(r)
 	r.RetryDelay = r.Service.RetryRules(r)
+	if r.Retryable {
+		r.ResetReaderBody()
+	}
 }
 
 func AfterRetryHandler(r *Request) {

--- a/aws/handler_functions.go
+++ b/aws/handler_functions.go
@@ -51,12 +51,15 @@ func SendHandler(r *Request) {
 
 func ValidateResponseHandler(r *Request) {
 	if r.HTTPResponse.StatusCode == 0 || r.HTTPResponse.StatusCode >= 400 {
+		// this may be replaced by an UnmarshalError handler
 		r.Error = &APIError{
 			StatusCode: r.HTTPResponse.StatusCode,
-			Code:       "UnknownError",
-			Message:    "unknown error",
+			Message:    r.HTTPResponse.Status,
 		}
 	}
+}
+
+func RetryHandler(r *Request) {
 	r.Retryable = r.Service.ShouldRetry(r)
 	r.RetryDelay = r.Service.RetryRules(r)
 }

--- a/aws/request.go
+++ b/aws/request.go
@@ -19,6 +19,7 @@ type Request struct {
 	HTTPRequest  *http.Request
 	HTTPResponse *http.Response
 	Body         io.ReadSeeker
+	bodyStart    int64 // offset from beginning of Body that the request body starts
 	Params       interface{}
 	Error        error
 	Data         interface{}
@@ -85,6 +86,11 @@ func (r *Request) SetBufferBody(buf []byte) {
 func (r *Request) SetReaderBody(reader io.ReadSeeker) {
 	r.HTTPRequest.Body = ioutil.NopCloser(reader)
 	r.Body = reader
+}
+
+func (r *Request) ResetReaderBody() {
+	r.Body.Seek(r.bodyStart, 0)
+	r.HTTPRequest.Body = ioutil.NopCloser(r.Body)
 }
 
 func (r *Request) Presign(expireTime time.Duration) (string, error) {

--- a/aws/request.go
+++ b/aws/request.go
@@ -136,10 +136,10 @@ func (r *Request) Send() error {
 		r.Handlers.UnmarshalMeta.Run(r)
 		r.Handlers.ValidateResponse.Run(r)
 		if r.Error != nil {
+			r.Handlers.UnmarshalError.Run(r)
 			r.Handlers.Retry.Run(r)
 			r.Handlers.AfterRetry.Run(r)
 			if r.Error != nil {
-				r.Handlers.UnmarshalError.Run(r)
 				return r.Error
 			}
 			continue

--- a/aws/request.go
+++ b/aws/request.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
+	"strings"
 	"time"
 )
 
@@ -81,6 +82,10 @@ func (r *Request) DataFilled() bool {
 
 func (r *Request) SetBufferBody(buf []byte) {
 	r.SetReaderBody(bytes.NewReader(buf))
+}
+
+func (r *Request) SetStringBody(s string) {
+	r.SetReaderBody(strings.NewReader(s))
 }
 
 func (r *Request) SetReaderBody(reader io.ReadSeeker) {

--- a/aws/request_test.go
+++ b/aws/request_test.go
@@ -59,11 +59,12 @@ type jsonErrorResponse struct {
 	Message string `json:"message"`
 }
 
-func TestRequestRecoverRetry(t *testing.T) {
+// test that retries occur for 5xx status codes
+func TestRequestRecoverRetry5xx(t *testing.T) {
 	reqNum := 0
 	reqs := []http.Response{
 		http.Response{StatusCode: 500, Body: body(`{"__type":"UnknownError","message":"An error occurred."}`)},
-		http.Response{StatusCode: 500, Body: body(`{"__type":"UnknownError","message":"An error occurred."}`)},
+		http.Response{StatusCode: 501, Body: body(`{"__type":"UnknownError","message":"An error occurred."}`)},
 		http.Response{StatusCode: 200, Body: body(`{"data":"valid"}`)},
 	}
 
@@ -82,6 +83,54 @@ func TestRequestRecoverRetry(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 2, int(r.RetryCount))
 	assert.Equal(t, "valid", out.Data)
+}
+
+// test that retries occur for 4xx status codes with a response type that can be retried - see `shouldRetry`
+func TestRequestRecoverRetry4xxRetryable(t *testing.T) {
+	reqNum := 0
+	reqs := []http.Response{
+		http.Response{StatusCode: 400, Body: body(`{"__type":"Throttling","message":"Rate exceeded."}`)},
+		http.Response{StatusCode: 429, Body: body(`{"__type":"ProvisionedThroughputExceededException","message":"Rate exceeded."}`)},
+		http.Response{StatusCode: 200, Body: body(`{"data":"valid"}`)},
+	}
+
+	s := NewService(&Config{MaxRetries: 10})
+	s.Handlers.Validate.Clear()
+	s.Handlers.Unmarshal.PushBack(unmarshal)
+	s.Handlers.UnmarshalError.PushBack(unmarshalError)
+	s.Handlers.Send.Clear() // mock sending
+	s.Handlers.Send.PushBack(func(r *Request) {
+		r.HTTPResponse = &reqs[reqNum]
+		reqNum++
+	})
+	out := &testData{}
+	r := NewRequest(s, &Operation{Name: "Operation"}, nil, out)
+	err := r.Send()
+	assert.Nil(t, err)
+	assert.Equal(t, 2, int(r.RetryCount))
+	assert.Equal(t, "valid", out.Data)
+}
+
+// test that retries don't occur for 4xx status codes with a response type that can't be retried
+func TestRequest4xxUnretryable(t *testing.T) {
+	s := NewService(&Config{MaxRetries: 10})
+	s.Handlers.Validate.Clear()
+	s.Handlers.Unmarshal.PushBack(unmarshal)
+	s.Handlers.UnmarshalError.PushBack(unmarshalError)
+	s.Handlers.Send.Clear() // mock sending
+	s.Handlers.Send.PushBack(func(r *Request) {
+		r.HTTPResponse = &http.Response{StatusCode: 401, Body: body(`{"__type":"SignatureDoesNotMatch","message":"Signature does not match."}`)}
+	})
+	out := &testData{}
+	r := NewRequest(s, &Operation{Name: "Operation"}, nil, out)
+	err := r.Send()
+	apiErr := Error(err)
+	assert.NotNil(t, err)
+	assert.NotNil(t, apiErr)
+	assert.Equal(t, 401, apiErr.StatusCode)
+	assert.Equal(t, "SignatureDoesNotMatch", apiErr.Code)
+	assert.Equal(t, "Signature does not match.", apiErr.Message)
+	assert.Equal(t, 0, int(r.RetryCount))
 }
 
 func TestRequestExhaustRetries(t *testing.T) {

--- a/aws/service.go
+++ b/aws/service.go
@@ -55,6 +55,7 @@ func (s *Service) Initialize() {
 	s.Handlers.Build.PushBack(UserAgentHandler)
 	s.Handlers.Sign.PushBack(BuildContentLength)
 	s.Handlers.Send.PushBack(SendHandler)
+	s.Handlers.Retry.PushBack(RetryHandler)
 	s.Handlers.AfterRetry.PushBack(AfterRetryHandler)
 	s.Handlers.ValidateResponse.PushBack(ValidateResponseHandler)
 	s.AddDebugHandlers()

--- a/aws/service.go
+++ b/aws/service.go
@@ -130,14 +130,20 @@ func retryRules(r *Request) time.Duration {
 	return delay * time.Millisecond
 }
 
+// Collection of service response codes which are generically
+// retryable for all services.
+var retryableCodes = map[string]struct{} {
+	"ExpiredTokenException": struct{}{},
+	"ProvisionedThroughputExceededException": struct{}{},
+	"Throttling": struct{}{},
+}
+
 func shouldRetry(r *Request) bool {
 	if r.HTTPResponse.StatusCode >= 500 {
 		return true
 	}
 	if err := Error(r.Error); err != nil {
-		switch err.Code {
-		case "ExpiredTokenException":
-		case "ProvisionedThroughputExceededException", "Throttling":
+		if _, ok := retryableCodes[err.Code]; ok {
 			return true
 		}
 	}

--- a/aws/service.go
+++ b/aws/service.go
@@ -133,7 +133,8 @@ func retryRules(r *Request) time.Duration {
 func shouldRetry(r *Request) bool {
 	if r.HTTPResponse.StatusCode >= 500 {
 		return true
-	} else if err := Error(r.Error); err != nil {
+	}
+	if err := Error(r.Error); err != nil {
 		switch err.Code {
 		case "ExpiredTokenException":
 		case "ProvisionedThroughputExceededException", "Throttling":

--- a/aws/types.go
+++ b/aws/types.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"fmt"
 	"io"
 	"time"
 )
@@ -60,4 +61,53 @@ func (r ReaderSeekerCloser) Close() error {
 		return t.Close()
 	}
 	return nil
+}
+
+// A SettableBool provides a boolean value which includes the state if
+// the value was set or unset.  The set state is in addition to the value's
+// value(true|false)
+type SettableBool struct {
+	value bool
+	set   bool
+}
+
+// SetBool returns a SettableBool with a value set
+func SetBool(value bool) SettableBool {
+	return SettableBool{value: value, set: true}
+}
+
+// Get returns the value. Will always be false if the SettableBool was not set.
+func (b *SettableBool) Get() bool {
+	if !b.set {
+		return false
+	}
+	return b.value
+}
+
+// Set sets the value and updates the state that the value has been set.
+func (b *SettableBool) Set(value bool) {
+	b.value = value
+	b.set = true
+}
+
+// IsSet returns if the value has been set
+func (b *SettableBool) IsSet() bool {
+	return b.set
+}
+
+// Reset resets the state and value of the SettableBool to its initial default
+// state of not set and zero value.
+func (b *SettableBool) Reset() {
+	b.value = false
+	b.set = false
+}
+
+// String returns the string representation of the value if set. Zero if not set.
+func (b *SettableBool) String() string {
+	return fmt.Sprintf("%t", b.Get())
+}
+
+// GoString returns the string representation of the SettableBool value and state
+func (b *SettableBool) GoString() string {
+	return fmt.Sprintf("Bool{value:%t, set:%t}", b.value, b.set)
 }

--- a/internal/protocol/rest/build.go
+++ b/internal/protocol/rest/build.go
@@ -81,7 +81,7 @@ func buildBody(r *aws.Request, v reflect.Value) {
 					case []byte:
 						r.SetBufferBody(reader)
 					case string:
-						r.SetBufferBody([]byte(reader))
+						r.SetStringBody(reader)
 					default:
 						r.Error = fmt.Errorf("unknown payload type %s", payload.Type())
 					}

--- a/service/dynamodb/customizations.go
+++ b/service/dynamodb/customizations.go
@@ -74,7 +74,7 @@ func validateCRC32(r *aws.Request) {
 
 	if crc != uint32(expected) {
 		// CRC does not match, set a retryable error
-		r.Retryable = true
+		r.Retryable.Set(true)
 		r.Error = &aws.APIError{
 			Code:    "CRC32CheckFailed",
 			Message: "CRC32 integrity check failed",

--- a/service/sqs/checksums.go
+++ b/service/sqs/checksums.go
@@ -98,7 +98,7 @@ func checksumsMatch(body, expectedMD5 *string) error {
 }
 
 func setChecksumError(r *aws.Request, format string, args ...interface{}) {
-	r.Retryable = true
+	r.Retryable.Set(true)
 	r.Error = &aws.APIError{
 		StatusCode: r.HTTPResponse.StatusCode,
 		Code:       "InvalidChecksum",


### PR DESCRIPTION
Fixes retry support to not fail due to body not being rewound between retry attempts.

Merged #196 and #204 together along with other changes to make sure rewind works in all cases, Made sure the ordering of handler's setting Request.Retryable vs the Service.ShouldRetry are consistent. A Request Handler setting Request.Retryable will prevent RetryHandler calling Service.ShouldRetry. The Service's delay value wills still be applied though.

Verified all tests pass and used @josharian's [script to ping for aws request limits](https://gist.github.com/josharian/b77539174c0ac5a5ca13) to verify retries were handled correctly.

Please try this out this PR and let me know if you hit retry failures still.



