### PR TITLE
Updated README.md to mention environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ aws_secret_access_key = MY-SECRET-KEY
 You can learn more about the credentials file from this
 [blog post](http://blogs.aws.amazon.com/security/post/Tx3D6U6WSFGOK2H/A-New-and-Standardized-Way-to-Manage-Credentials-in-the-AWS-SDKs).
 
+Alternatively, you can set the following environment variables:
+```
+AWS_ACCESS_KEY_ID=AKID1234567890
+AWS_SECRET_ACCESS_KEY=MY-SECRET-KEY
+```
+
 ## Using
 
 To use a service in the SDK, create a service variable by calling the `New()`


### PR DESCRIPTION
The ~/.aws/credentials file is only one option for setting credentials.  It's mentioned in the blog post linked from the README, but I think it would be useful to explicitly mention that you can use environment variables as well.