### PR TITLE
signer/v4: Encode "+" to "%20"

### DIFF
--- a/internal/signer/v4/v4.go
+++ b/internal/signer/v4/v4.go
@@ -231,7 +231,7 @@ func (v4 *signer) buildCanonicalHeaders() {
 }
 
 func (v4 *signer) buildCanonicalString() {
-	v4.Request.URL.RawQuery = v4.Query.Encode()
+	v4.Request.URL.RawQuery = strings.Replace(v4.Query.Encode(), "+", "%20", -1)
 	uri := v4.Request.URL.Opaque
 	if uri != "" {
 		uri = "/" + strings.Join(strings.Split(uri, "/")[3:], "/")


### PR DESCRIPTION
`Query.Encode()` will replace " " with "+", but the v4 spec calls for
replacing " " with "%20" instead.

Fixes #219