### PR TITLE
Add s3.HostedZoneIDForRegion

### DIFF
--- a/service/s3/hosted_zones.go
+++ b/service/s3/hosted_zones.go
@@ -1,0 +1,23 @@
+package s3
+
+// http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints
+var hostedZoneIDsMap = map[string]string{
+	"us-east-1":      "Z3AQBSTGFYJSTF",
+	"us-west-2":      "Z3BJ6K6RIION7M",
+	"us-west-1":      "Z2F56UZL2M1ACD",
+	"eu-west-1":      "Z1BKCTXD74EZPE",
+	"central-1":      "Z21DNDUVLTQW6Q",
+	"ap-southeast-1": "Z3O0J2DXBE1FTB",
+	"ap-southeast-2": "Z1WCIGYICN2BYD",
+	"ap-northeast-1": "Z2M4EHUR26P7ZW",
+	"sa-east-1":      "Z7KQH4QJS55SO",
+	"us-gov-west-1":  "Z31GFT0UA1I2HV",
+}
+
+func HostedZoneIDForRegion(region string) string {
+	if region == "" {
+		region = "us-east-1"
+	}
+
+	return hostedZoneIDsMap[region]
+}

--- a/service/s3/hosted_zones_test.go
+++ b/service/s3/hosted_zones_test.go
@@ -1,0 +1,18 @@
+package s3
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHostedZoneIDForRegion(t *testing.T) {
+	assert.Equal(t, "Z3AQBSTGFYJSTF", HostedZoneIDForRegion("us-east-1"))
+	assert.Equal(t, "Z1WCIGYICN2BYD", HostedZoneIDForRegion("ap-southeast-2"))
+
+	// Empty string should default to us-east-1
+	assert.Equal(t, "Z3AQBSTGFYJSTF", HostedZoneIDForRegion(""))
+
+	// Bad input should be empty string
+	assert.Equal(t, "", HostedZoneIDForRegion("not-a-region"))
+}


### PR DESCRIPTION
Needed to support https://github.com/hashicorp/terraform/issues/1769

I didn't see a way to automatically generate this. Please let me know if that's a possibility, or if there's a better location to place this.