### PR TITLE
s3manager: Fix memory leak

### DIFF
--- a/service/s3/s3manager/upload.go
+++ b/service/s3/s3manager/upload.go
@@ -315,7 +315,8 @@ func (u *multiuploader) send(c chunk) error {
 		return err
 	}
 
-	completed := &s3.CompletedPart{ETag: resp.ETag, PartNumber: &c.num}
+	n := c.num
+	completed := &s3.CompletedPart{ETag: resp.ETag, PartNumber: &n}
 
 	u.m.Lock()
 	u.parts = append(u.parts, completed)


### PR DESCRIPTION
First, thanks for landing s3manager -- I was about to implement this myself.

I've been trying to use s3manager to perform fast concurrent S3 uploads in a backup tool at work. I'm putting pretty large files; my test file is 60GB. Unfortunately, I ran into a variety of issues. I fixed some of them here.

The biggest issue was a memory leak. It turns out that the current s3manager code causes the entire input reader contents to be retained, and in my test that is far larger than the available system memory. The bug is due to a slightly subtle GC interaction where a reference to each chunk buffer is held onto for the duration of the whole multi-part upload.

I also found that the uploader could deadlock because the workers could all exit without the dispatcher being aware; this was much simpler to diagnose and fix.