### PR TITLE
aws: ExpiredToken and RequestExpired error code should refresh credentials

### DIFF
--- a/aws/handler_functions.go
+++ b/aws/handler_functions.go
@@ -111,10 +111,12 @@ func AfterRetryHandler(r *Request) {
 		// need to be expired locally so that the next request to
 		// get credentials will trigger a credentials refresh.
 		if r.Error != nil {
-			if err, ok := r.Error.(awserr.Error); ok && err.Code() == "ExpiredTokenException" {
-				r.Config.Credentials.Expire()
-				// The credentials will need to be resigned with new credentials
-				r.signed = false
+			if err, ok := r.Error.(awserr.Error); ok {
+				if isCodeExpiredCreds(err.Code()) {
+					r.Config.Credentials.Expire()
+					// The credentials will need to be resigned with new credentials
+					r.signed = false
+				}
 			}
 		}
 


### PR DESCRIPTION
Only ExpiredTokenException error code was being used to determine if the credentials
need to be refreshed, but there are actually three different error codes which
imply expired credentials.

- ExpiredTokenException
- ExpiredToken
- RequestExpired

All expired credentials conditions should now be handled and the SDK will
attempt to refresh when the error occurs.

Fixes #249