### PR TITLE
s3manager: Slight modification to Upload API [Breaking Change]

### DIFF
--- a/internal/test/integration/s3/s3manager/integration_test.go
+++ b/internal/test/integration/s3/s3manager/integration_test.go
@@ -83,13 +83,13 @@ func validate(t *testing.T, key string, md5value string) {
 }
 
 func TestUploadConcurrently(t *testing.T) {
-	svc := s3.New(nil)
 	key := "12mb-1"
-	out, err := s3manager.Upload(svc, &s3manager.UploadInput{
+	mgr := s3manager.NewUploader(nil)
+	out, err := mgr.Upload(&s3manager.UploadInput{
 		Bucket: bucketName,
 		Key:    &key,
 		Body:   bytes.NewReader(integBuf12MB),
-	}, nil)
+	})
 
 	assert.NoError(t, err)
 	assert.NotEqual(t, "", out.UploadID)
@@ -113,12 +113,14 @@ func TestUploadFailCleanup(t *testing.T) {
 	})
 
 	key := "12mb-leave"
-	_, err := s3manager.Upload(svc, &s3manager.UploadInput{
+	mgr := s3manager.NewUploader(&s3manager.UploadOptions{
+		S3:                svc,
+		LeavePartsOnError: false,
+	})
+	_, err := mgr.Upload(&s3manager.UploadInput{
 		Bucket: bucketName,
 		Key:    &key,
 		Body:   bytes.NewReader(integBuf12MB),
-	}, &s3manager.UploadOptions{
-		LeavePartsOnError: false,
 	})
 	assert.Error(t, err)
 	uploadID := ""

--- a/service/s3/s3manager/upload.go
+++ b/service/s3/s3manager/upload.go
@@ -220,13 +220,13 @@ func NewUploader(opts *UploadOptions) *Uploader {
 	if opts == nil {
 		opts = DefaultUploadOptions
 	}
-	return &Uploader{opts: *opts}
+	return &Uploader{opts: opts}
 }
 
 // The Uploader structure that calls Upload(). It is safe to call Upload()
 // on this structure across concurrent goroutines.
 type Uploader struct {
-	opts UploadOptions
+	opts *UploadOptions
 }
 
 // Upload uploads an object to S3, intelligently buffering large files into
@@ -234,15 +234,17 @@ type Uploader struct {
 // can configure the buffer size and concurrency through the opts parameter.
 //
 // If opts is set to nil, DefaultUploadOptions will be used.
+//
+// It is safe to call this method across concurrent goroutines.
 func (u *Uploader) Upload(input *UploadInput) (*UploadOutput, error) {
-	i := uploader{in: input, opts: &u.opts}
+	i := uploader{in: input, opts: *u.opts}
 	return i.upload()
 }
 
 // internal structure to manage an upload to S3.
 type uploader struct {
 	in   *UploadInput
-	opts *UploadOptions
+	opts UploadOptions
 
 	readerPos int64 // current reader position
 	totalSize int64 // set to -1 if the size is not known


### PR DESCRIPTION
In order to more consistently support the upcoming download manager,
move the s3manager.Upload() function into an s3manager.Uploader
structure. The new API is:

	u := s3manager.NewUploader(opts) // opts can be nil
	resp, err := u.Upload(&s3manager.UploadInput{...})

This changes from:

	s := s3.New(nil)
	resp, err := s3manager.Upload(s, &s3manager.UploadInput{...}, nil)

In the new API, the client is (optionally) passed through the
UploadOptions.S3 member. If S3 is nil, a default client will be used.

Note that the DefaultConcurrency and DefaultPartSize constants are
also renamed in order to be properly namespaced.