### PR TITLE
s3/s3manager: Add download manager

### DIFF
--- a/service/s3/s3manager/download.go
+++ b/service/s3/s3manager/download.go
@@ -1,0 +1,223 @@
+package s3manager
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/awslabs/aws-sdk-go/aws/awsutil"
+	"github.com/awslabs/aws-sdk-go/service/s3"
+)
+
+// The default range of bytes to get at a time when using Download().
+var DefaultDownloadPartSize int64 = 1024 * 1024 * 5
+
+// The default number of goroutines to spin up when using Download().
+var DefaultDownloadConcurrency = 5
+
+// The default set of options used when opts is nil in Download().
+var DefaultDownloadOptions = &DownloadOptions{
+	PartSize:    DefaultDownloadPartSize,
+	Concurrency: DefaultDownloadConcurrency,
+}
+
+// DownloadOptions keeps tracks of extra options to pass to an Download() call.
+type DownloadOptions struct {
+	// The buffer size (in bytes) to use when buffering data into chunks and
+	// sending them as parts to S3. The minimum allowed part size is 5MB, and
+	// if this value is set to zero, the DefaultPartSize value will be used.
+	PartSize int64
+
+	// The number of goroutines to spin up in parallel when sending parts.
+	// If this is set to zero, the DefaultConcurrency value will be used.
+	Concurrency int
+
+	// An S3 client to use when performing downloads. Leave this as nil to use
+	// a default client.
+	S3 *s3.S3
+}
+
+func NewDownloader(opts *DownloadOptions) *Downloader {
+	if opts == nil {
+		opts = DefaultDownloadOptions
+	}
+	return &Downloader{opts: *opts}
+}
+
+type Downloader struct {
+	opts DownloadOptions
+}
+
+func (d *Downloader) Download(w io.WriterAt, input *s3.GetObjectInput) error {
+	impl := downloadimpl{w: w, in: input, opts: &d.opts}
+	return impl.download()
+}
+
+type downloadimpl struct {
+	opts *DownloadOptions
+	in   *s3.GetObjectInput
+	w    io.WriterAt
+
+	wg sync.WaitGroup
+	m  sync.Mutex
+
+	pos        int64
+	totalBytes int64
+	err        error
+}
+
+func (d *downloadimpl) init() {
+	d.totalBytes = -1
+
+	if d.opts.Concurrency == 0 {
+		d.opts.Concurrency = DefaultDownloadConcurrency
+	}
+
+	if d.opts.PartSize == 0 {
+		d.opts.PartSize = DefaultDownloadPartSize
+	}
+
+	if d.opts.S3 == nil {
+		d.opts.S3 = s3.New(nil)
+	}
+}
+
+func (d *downloadimpl) download() error {
+	d.init()
+
+	// Spin up workers
+	ch := make(chan dlchunk, d.opts.Concurrency)
+	d.wg.Add(d.opts.Concurrency)
+	for i := 0; i < cap(ch); i++ {
+		go d.downloadPart(ch)
+	}
+
+	// Assign work
+	for d.geterr() == nil {
+		if d.pos != 0 {
+			total := d.getTotalBytes()
+			if total < 0 {
+				time.Sleep(10 * time.Millisecond)
+				continue
+			} else if d.pos >= total {
+				break
+			}
+		}
+
+		ch <- dlchunk{
+			dlchunkcounter: &dlchunkcounter{},
+			w:              d.w,
+			start:          d.pos,
+			size:           d.opts.PartSize,
+		}
+		d.pos += d.opts.PartSize
+	}
+
+	// Wait for completion
+	close(ch)
+	d.wg.Wait()
+
+	// Return error
+	return d.err
+}
+
+func (d *downloadimpl) downloadPart(ch chan dlchunk) {
+	defer d.wg.Done()
+
+	for {
+		chunk, ok := <-ch
+
+		if !ok {
+			break
+		}
+
+		if d.geterr() == nil {
+			in := &s3.GetObjectInput{}
+			awsutil.Copy(in, d.in)
+			rng := fmt.Sprintf("bytes=%d-%d",
+				chunk.start, chunk.start+chunk.size-1)
+			in.Range = &rng
+
+			resp, err := d.opts.S3.GetObject(in)
+			if err != nil {
+				d.seterr(err)
+			} else {
+				d.setTotalBytes(resp)
+
+				_, err := io.Copy(chunk, resp.Body)
+				resp.Body.Close()
+
+				if err != nil {
+					d.seterr(err)
+				}
+
+			}
+		}
+	}
+}
+
+func (d *downloadimpl) getTotalBytes() int64 {
+	d.m.Lock()
+	defer d.m.Unlock()
+
+	return d.totalBytes
+}
+
+func (d *downloadimpl) setTotalBytes(resp *s3.GetObjectOutput) {
+	d.m.Lock()
+	defer d.m.Unlock()
+
+	if d.totalBytes >= 0 {
+		return
+	}
+
+	parts := strings.Split(*resp.ContentRange, "/")
+	total, err := strconv.ParseInt(parts[len(parts)-1], 10, 64)
+	if err != nil {
+		d.err = err
+		return
+	}
+
+	d.totalBytes = total
+}
+
+// geterr is a thread-safe getter for the error object
+func (d *downloadimpl) geterr() error {
+	d.m.Lock()
+	defer d.m.Unlock()
+
+	return d.err
+}
+
+// seterr is a thread-safe setter for the error object
+func (d *downloadimpl) seterr(e error) {
+	d.m.Lock()
+	defer d.m.Unlock()
+
+	d.err = e
+}
+
+type dlchunk struct {
+	*dlchunkcounter
+	w     io.WriterAt
+	start int64
+	size  int64
+}
+
+type dlchunkcounter struct {
+	cur int64
+}
+
+func (c dlchunk) Write(p []byte) (n int, err error) {
+	if c.cur >= c.size {
+		return 0, io.EOF
+	}
+
+	n, err = c.w.WriteAt(p, c.start+c.cur)
+	c.cur += int64(n)
+
+	return
+}

--- a/service/s3/s3manager/download_test.go
+++ b/service/s3/s3manager/download_test.go
@@ -1,0 +1,165 @@
+package s3manager_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"regexp"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/internal/test/unit"
+	"github.com/awslabs/aws-sdk-go/service/s3"
+	"github.com/awslabs/aws-sdk-go/service/s3/s3manager"
+	"github.com/stretchr/testify/assert"
+)
+
+var _ = unit.Imported
+
+func dlLoggingSvc(data []byte) (*s3.S3, *[]string, *[]string) {
+	var m sync.Mutex
+	names := []string{}
+	ranges := []string{}
+
+	svc := s3.New(nil)
+	svc.Handlers.Send.Clear()
+	svc.Handlers.Send.PushBack(func(r *aws.Request) {
+		m.Lock()
+		defer m.Unlock()
+
+		names = append(names, r.Operation.Name)
+		ranges = append(ranges, *r.Params.(*s3.GetObjectInput).Range)
+
+		rerng := regexp.MustCompile(`bytes=(\d+)-(\d+)`)
+		rng := rerng.FindStringSubmatch(r.HTTPRequest.Header.Get("Range"))
+		start, _ := strconv.ParseInt(rng[1], 10, 64)
+		fin, _ := strconv.ParseInt(rng[2], 10, 64)
+		fin++
+
+		if fin > int64(len(data)) {
+			fin = int64(len(data))
+		}
+
+		r.HTTPResponse = &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader(data[start:fin])),
+			Header:     http.Header{},
+		}
+		r.HTTPResponse.Header.Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d",
+			start, fin, len(data)))
+	})
+
+	return svc, &names, &ranges
+}
+
+type dlwriter struct {
+	buf []byte
+}
+
+func newDLWriter(size int) *dlwriter {
+	return &dlwriter{buf: make([]byte, size)}
+}
+
+func (d dlwriter) WriteAt(p []byte, pos int64) (n int, err error) {
+	if pos > int64(len(d.buf)) {
+		return 0, io.EOF
+	}
+
+	written := 0
+	for i, b := range p {
+		if i >= len(d.buf) {
+			break
+		}
+		d.buf[pos+int64(i)] = b
+		written++
+	}
+	return written, nil
+}
+
+func TestDownloadOrder(t *testing.T) {
+	s, names, ranges := dlLoggingSvc(buf12MB)
+
+	opts := &s3manager.DownloadOptions{S3: s, Concurrency: 1}
+	d := s3manager.NewDownloader(opts)
+	w := newDLWriter(len(buf12MB))
+	n, err := d.Download(w, &s3.GetObjectInput{
+		Bucket: aws.String("bucket"),
+		Key:    aws.String("key"),
+	})
+
+	assert.Nil(t, err)
+	assert.Equal(t, int64(len(buf12MB)), n)
+	assert.Equal(t, []string{"GetObject", "GetObject", "GetObject"}, *names)
+	assert.Equal(t, []string{"bytes=0-5242879", "bytes=5242880-10485759", "bytes=10485760-15728639"}, *ranges)
+
+	count := 0
+	for _, b := range w.buf {
+		count += int(b)
+	}
+	assert.Equal(t, 0, count)
+}
+
+func TestDownloadZero(t *testing.T) {
+	s, names, ranges := dlLoggingSvc([]byte{})
+
+	opts := &s3manager.DownloadOptions{S3: s}
+	d := s3manager.NewDownloader(opts)
+	w := newDLWriter(0)
+	n, err := d.Download(w, &s3.GetObjectInput{
+		Bucket: aws.String("bucket"),
+		Key:    aws.String("key"),
+	})
+
+	assert.Nil(t, err)
+	assert.Equal(t, int64(0), n)
+	assert.Equal(t, []string{"GetObject"}, *names)
+	assert.Equal(t, []string{"bytes=0-5242879"}, *ranges)
+}
+
+func TestDownloadSetPartSize(t *testing.T) {
+	s, names, ranges := dlLoggingSvc([]byte{1, 2, 3})
+
+	opts := &s3manager.DownloadOptions{S3: s, PartSize: 1, Concurrency: 1}
+	d := s3manager.NewDownloader(opts)
+	w := newDLWriter(3)
+	n, err := d.Download(w, &s3.GetObjectInput{
+		Bucket: aws.String("bucket"),
+		Key:    aws.String("key"),
+	})
+
+	assert.Nil(t, err)
+	assert.Equal(t, int64(3), n)
+	assert.Equal(t, []string{"GetObject", "GetObject", "GetObject"}, *names)
+	assert.Equal(t, []string{"bytes=0-0", "bytes=1-1", "bytes=2-2"}, *ranges)
+	assert.Equal(t, []byte{1, 2, 3}, w.buf)
+}
+
+func TestDownloadError(t *testing.T) {
+	s, names, _ := dlLoggingSvc([]byte{1, 2, 3})
+	opts := &s3manager.DownloadOptions{S3: s, PartSize: 1, Concurrency: 1}
+
+	num := 0
+	s.Handlers.Send.PushBack(func(r *aws.Request) {
+		num++
+		if num > 1 {
+			r.HTTPResponse.StatusCode = 400
+			r.HTTPResponse.Body = ioutil.NopCloser(bytes.NewReader([]byte{}))
+		}
+	})
+
+	d := s3manager.NewDownloader(opts)
+	w := newDLWriter(3)
+	n, err := d.Download(w, &s3.GetObjectInput{
+		Bucket: aws.String("bucket"),
+		Key:    aws.String("key"),
+	})
+
+	assert.NotNil(t, err)
+	assert.Equal(t, int64(1), n)
+	assert.Equal(t, []string{"GetObject", "GetObject"}, *names)
+	assert.Equal(t, []byte{1, 0, 0}, w.buf)
+}


### PR DESCRIPTION
The download manager implementation performs concurrent ranged GET operations against an object in an S3 bucket and writes the data locally using parallel writes. Concurrency can be managed using the "Concurrency" option.

Sample usage:

```go
// Open a file, err omitted for simplicity
fd, _ := os.Create("my-image.png")

// Pass in &s3manager.DownloadOptions{} to manipulate
// Concurrency or ranged PartSize.
mgr := s3manager.NewDownloader(nil)

// Perform the download to the file from a bucket/key
params := &s3.GetObjectInput{Bucket: aws.String("bucket"), Key: "image.png"})
n, err := mgr.Download(fd, params)
if err != nil {
    panic(err)
}
fmt.Println("Wrote %d bytes to my-image.png")
```

This implementation does not yet support arbitrary io.Writer objects. A io.WriterAt object must be provided. Support for io.Writer is planned.